### PR TITLE
Refactor creation of rest Configs and k8s clientsets

### DIFF
--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -15,17 +15,19 @@ import (
 )
 
 var _ = Describe("[example] Basic example to demonstrate how to write tests using the framework", func() {
-	f := framework.NewDefaultFramework("basic-example")
+	f := framework.NewFramework("basic-example")
+
 	It("Should be able to list existing nodes on the cluster", func() {
-		testListingNodes(f)
+		testListingNodes()
 	})
+
 	It("Should be able to create a pod using the provided client", func() {
 		testCreatingAPod(f)
 	})
 })
 
-func testListingNodes(f *framework.Framework) {
-	for _, cs := range f.ClusterClients {
+func testListingNodes() {
+	for _, cs := range framework.KubeClients {
 		testListingNodesFromCluster(cs)
 	}
 }
@@ -71,7 +73,7 @@ var (
 )
 
 func testCreatingAPod(f *framework.Framework) {
-	for _, cs := range f.ClusterClients {
+	for _, cs := range framework.KubeClients {
 		testCreatingAPodInCluster(cs, f)
 	}
 }

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -11,7 +11,7 @@ import (
 
 func (f *Framework) FindDeployment(cluster ClusterIndex, appName string, namespace string) *appsv1.Deployment {
 	deployments := AwaitUntil("list deployments", func() (interface{}, error) {
-		return f.ClusterClients[cluster].AppsV1().Deployments(namespace).List(metav1.ListOptions{
+		return KubeClients[cluster].AppsV1().Deployments(namespace).List(metav1.ListOptions{
 			LabelSelector: "app=" + appName,
 		})
 	}, NoopCheckResult).(*appsv1.DeploymentList)
@@ -107,7 +107,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 }
 
 func create(f *Framework, cluster ClusterIndex, deployment *appsv1.Deployment) *corev1.PodList {
-	pc := f.ClusterClients[cluster].AppsV1().Deployments(f.Namespace)
+	pc := KubeClients[cluster].AppsV1().Deployments(f.Namespace)
 	appName := deployment.Spec.Template.ObjectMeta.Labels["app"]
 
 	_ = AwaitUntil("create deployment", func() (interface{}, error) {

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -40,7 +40,7 @@ func (f *Framework) ExecWithOptions(options ExecOptions, index ClusterIndex) (st
 	Expect(err).To(Succeed(), fmt.Sprintf("ExecWithOptions %#v", options))
 
 	const tty = false
-	req := f.ClusterClients[index].CoreV1().RESTClient().Post().
+	req := KubeClients[index].CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(options.PodName).
 		Namespace(options.Namespace).

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -83,7 +83,7 @@ func (f *Framework) NewNetworkPod(config *NetworkPodConfig) *NetworkPod {
 }
 
 func (np *NetworkPod) AwaitReady() {
-	pods := np.framework.ClusterClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
+	pods := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
 	np.Pod = AwaitUntil("await pod ready", func() (interface{}, error) {
 		return pods.Get(np.Pod.Name, metav1.GetOptions{})
@@ -101,7 +101,7 @@ func (np *NetworkPod) AwaitReady() {
 }
 
 func (np *NetworkPod) AwaitFinish() {
-	pods := np.framework.ClusterClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
+	pods := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
 	_, np.TerminationErrorMsg, np.TerminationError = AwaitResultOrError(fmt.Sprintf("await pod %q finished", np.Pod.Name), func() (interface{}, error) {
 		return pods.Get(np.Pod.Name, metav1.GetOptions{})
@@ -168,7 +168,7 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 		},
 	}
 
-	pc := np.framework.ClusterClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
+	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
 	np.Pod, err = pc.Create(&tcpCheckListenerPod)
 	Expect(err).NotTo(HaveOccurred())
@@ -211,7 +211,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 		},
 	}
 
-	pc := np.framework.ClusterClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
+	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
 	np.Pod, err = pc.Create(&tcpCheckConnectorPod)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -14,7 +14,7 @@ import (
 func (f *Framework) FindNodesByGatewayLabel(cluster ClusterIndex, isGateway bool) []*v1.Node {
 	nodes := AwaitUntil("list nodes", func() (interface{}, error) {
 		// Ignore the control plane node labeled as master as it doesn't allow scheduling of pods
-		return f.ClusterClients[cluster].CoreV1().Nodes().List(metav1.ListOptions{
+		return KubeClients[cluster].CoreV1().Nodes().List(metav1.ListOptions{
 			LabelSelector: "!node-role.kubernetes.io/master",
 		})
 	}, NoopCheckResult).(*v1.NodeList)
@@ -40,7 +40,7 @@ func (f *Framework) SetGatewayLabelOnNode(cluster ClusterIndex, nodeName string,
 	// Escape the '/' char in the label name with the special sequence "~1" so it isn't treated as part of the path
 	PatchString("/metadata/labels/"+strings.Replace(GatewayLabel, "/", "~1", -1), strconv.FormatBool(isGateway),
 		func(pt types.PatchType, payload []byte) error {
-			_, err := f.ClusterClients[cluster].CoreV1().Nodes().Patch(nodeName, pt, payload)
+			_, err := KubeClients[cluster].CoreV1().Nodes().Patch(nodeName, pt, payload)
 			return err
 		})
 }

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -11,7 +11,7 @@ import (
 // expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
 func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, namespace string, expectedCount int) *v1.PodList {
 	return AwaitUntil("find pods for app "+appName, func() (interface{}, error) {
-		return f.ClusterClients[cluster].CoreV1().Pods(namespace).List(metav1.ListOptions{
+		return KubeClients[cluster].CoreV1().Pods(namespace).List(metav1.ListOptions{
 			LabelSelector: "app=" + appName,
 		})
 	}, func(result interface{}) (bool, string, error) {
@@ -39,6 +39,6 @@ func (f *Framework) AwaitSubmarinerEnginePod(cluster ClusterIndex) *v1.Pod {
 // DeletePod deletes the pod for the given name and namespace.
 func (f *Framework) DeletePod(cluster ClusterIndex, podName string, namespace string) {
 	AwaitUntil("delete pod", func() (interface{}, error) {
-		return nil, f.ClusterClients[cluster].CoreV1().Pods(namespace).Delete(podName, &metav1.DeleteOptions{})
+		return nil, KubeClients[cluster].CoreV1().Pods(namespace).Delete(podName, &metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -31,7 +31,7 @@ func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, 
 		},
 	}
 
-	services := f.ClusterClients[cluster].CoreV1().Services(f.Namespace)
+	services := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
 	return AwaitUntil("create service", func() (interface{}, error) {
 		service, err := services.Create(&tcpService)
@@ -75,7 +75,7 @@ func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
 		},
 	}
 
-	sc := f.ClusterClients[cluster].CoreV1().Services(f.Namespace)
+	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 	service := AwaitUntil("create service", func() (interface{}, error) {
 		return sc.Create(&nginxService)
 
@@ -86,6 +86,6 @@ func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
 func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
 	ginkgo.By(fmt.Sprintf("Deleting service %q on %q", serviceName, TestContext.ClusterIDs[cluster]))
 	AwaitUntil("delete service", func() (interface{}, error) {
-		return nil, f.ClusterClients[cluster].CoreV1().Services(f.Namespace).Delete(serviceName, &metav1.DeleteOptions{})
+		return nil, KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(serviceName, &metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
 )
 
@@ -24,7 +23,6 @@ type TestContextType struct {
 	ConnectionAttempts  uint
 	OperationTimeout    uint
 	GlobalnetEnabled    bool
-	ClusterClients      []*kubeclientset.Clientset
 	ClientQPS           float32
 	ClientBurst         int
 	GroupVersion        *schema.GroupVersion


### PR DESCRIPTION
Added a static RestConfigs field to simplify creation of other clientset types for Framework users. This is built during BeforeSuite.
    
Removed the TestContext.ClusterClients field and the redundant Framework.ClusterClients field i lieu of a static KubeClients field. This shortens the referenced name in usage sites.
    
Added a BeforeSuite hook for users to perform their own static initialization (eg create submariner clientsets, perform globalnet check etc)

References: #30
