### PR TITLE
Move root dapper to shipyard image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/dapper-base
+FROM quay.io/submariner/shipyard-dapper-base
 
 ENV DAPPER_ENV=REPO DAPPER_ENV=TAG \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/shipyard DAPPER_DOCKER_SOCKET=true \


### PR DESCRIPTION
Now that the image is in Quay.io, change the root dapper to use it.