### PR TITLE
Rebuild dapper base image if a shared script changed

### DIFF
--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -31,6 +31,8 @@ LAST_COMMIT_MASTER=$(git rev-parse remotes/$UPSTREAM_REMOTE/master)
 
 if [[ "${CHANGED_FILES_PR[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
    [[ "${CHANGED_FILES_LOCAL[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
+   [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/shared/" ]] ||
+   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "scripts/shared/" ]] ||
    [[ "${LAST_COMMIT_LOCAL}" == "${LAST_COMMIT_MASTER}" ]]; then
       echo "Dockerfile.dapper-base was modified, rebuilding dapper image"
       docker build -t ${DAPPER_BASE_IMAGE} -f package/Dockerfile.dapper-base .


### PR DESCRIPTION
Since we're copying this directory into the base dapper image, we should
rebuild the image should any of the files inside it change.