### PR TITLE
Use 'make release' to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
 
 deploy:
   - provider: script
-    script: bash scripts/release
+    script: make release
     on:
       branch: master
       condition: $DEPLOY = true


### PR DESCRIPTION
To be consistent with the rest of the process, use 'make release' for
the release step in travis.