### PR TITLE
Remove anti deploy check from release

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM quay.io/submariner/shipyard-dapper-base
 
-ENV DAPPER_ENV=REPO DAPPER_ENV=TAG \
+ENV DAPPER_ENV="REPO TAG QUAY_USERNAME QUAY_PASSWORD TRAVIS_COMMIT" \
     DAPPER_SOURCE=/go/src/github.com/submariner-io/shipyard DAPPER_DOCKER_SOCKET=true
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 

--- a/scripts/release
+++ b/scripts/release
@@ -1,21 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-DEPLOY="${DEPLOY:-false}"
-
-
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/version
-
-
-# This flag is passed from travis, so only the right jobs will deploy the
-# container images to quay
-
-if [ "$DEPLOY" != "true" ] ; then
-    echo "We don't need to deploy from this job, if you're trying to deploy manually set DEPLOY=true"
-    exit 0
-fi
-
 
 DOCKER_TAG=${1:-latest}
 REPO=${REPO:-quay.io/submariner}


### PR DESCRIPTION
This check is already done in travis, no need for it.
Also added QUAY vars to DAPPER_ENV so theyre passed down to the dapper
container.