### PR TITLE
Validate the tests we ship

### DIFF
--- a/scripts/shared/lib/find_functions
+++ b/scripts/shared/lib/find_functions
@@ -2,7 +2,7 @@ function find_go_pkg_dirs() {
     local base excluded_pkg_dirs find_exclude package_dirs
 
     base=${2:-.}
-    excluded_pkg_dirs=${EXCLUDE_PKG_DIRS:-vendor test .git .trash-cache bin}
+    excluded_pkg_dirs=${EXCLUDE_PKG_DIRS:-vendor .git .trash-cache bin}
 
     for excldir in $excluded_pkg_dirs; do
         find_exclude="-path ./$excldir -prune -o $find_exclude"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/submariner-io/shipyard/test/e2e/example"
-	_ "github.com/submariner-io/submariner/test/e2e/framework"
+	_ "github.com/submariner-io/shipyard/test/e2e/framework"
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
Since the point of shipyard is to provide a test framework, we should
validate that framework. Doing so reveals a dependency on submariner
which this patch also removes.

Signed-off-by: Stephen Kitt <skitt@redhat.com>