### PR TITLE
.dapper should be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+.dapper
 .idea
 /bin
 output


### PR DESCRIPTION
This is a binary we fetch, it shouldn't be in the repo