### PR TITLE
Only query the latest subctl release

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -15,7 +15,7 @@ readonly SUBM_NS=submariner-operator
 ### Functions ###
 
 function get_latest_subctl_tag() {
-    curl https://api.github.com/repos/submariner-io/submariner-operator/releases | jq -r '.[0].tag_name'
+    curl https://api.github.com/repos/submariner-io/submariner-operator/releases/latest | jq -r '.tag_name'
 }
 
 function travis_retry() {


### PR DESCRIPTION
When determining the version of subctl to download, only query the
latest release, instead of querying all releases and extracting the
latest.

Signed-off-by: Stephen Kitt <skitt@redhat.com>