### PR TITLE
Make Makefile.inc really shareable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,34 @@
-include Makefile.inc
+ifneq (,$(DAPPER_HOST_ARCH))
+
+# Running in Dapper
+
+include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e /)
 
-$(TARGETS): .dapper dapper-image
-	./.dapper -m bind $@
+# Add any project-specific arguments here
+$(TARGETS):
+	./scripts/$@
 
-# We need the latest image for these targets in shipyard
+.PHONY: $(TARGETS)
+
+# Project-specific targets go here
+
+else
+
+# Not running in Dapper
+
+# Shipyard-specific starts
 clusters: dapper-image
 deploy: dapper-image
 
-.PHONY: $(TARGETS)
+dapper-image:
+	SCRIPTS_DIR=./scripts/shared ./scripts/dapper-image
+# Shipyard-specific ends
+
+include Makefile.dapper
+
+endif
+
+# Disable rebuilding Makefile
+Makefile Makefile.dapper Makefile.inc: ;

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -1,0 +1,19 @@
+# This Makefile contains the rules required to set up our
+# Dapper-based build environment; it can be copied as-is to
+# other projects (and needs to be copied, it can't be shared
+# via the Dapper image since it's needed to retrieve the image)
+
+.dapper:
+	@echo Downloading dapper
+	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
+	@@chmod +x .dapper.tmp
+	@./.dapper.tmp -v
+	@mv .dapper.tmp .dapper
+
+%: .dapper
+	./.dapper -m bind $(MAKE) $@
+
+shell: .dapper
+	./.dapper -m bind -s
+
+.PHONY: shell

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -5,21 +5,11 @@ registry_inmemory ?= true
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
 
-.dapper:
-	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
-	@@chmod +x .dapper.tmp
-	@./.dapper.tmp -v
-	@mv .dapper.tmp .dapper
+cleanup:
+	$(SCRIPTS_DIR)/cleanup.sh
 
-shell: .dapper
-	./.dapper -m bind -s
+clusters:
+	$(SCRIPTS_DIR)/clusters.sh --k8s_version $(k8s_version) --globalnet $(globalnet) --registry_inmemory $(registry_inmemory)
 
-cleanup: .dapper
-	./.dapper -m bind $(SCRIPTS_DIR)/cleanup.sh
-
-clusters: .dapper
-	./.dapper -m bind $(SCRIPTS_DIR)/clusters.sh --k8s_version $(k8s_version) --globalnet $(globalnet) --registry_inmemory $(registry_inmemory)
-
-deploy: .dapper clusters
-	./.dapper -m bind $(SCRIPTS_DIR)/deploy.sh --globalnet $(globalnet) --deploytool $(deploytool)
+deploy: clusters
+	$(SCRIPTS_DIR)/deploy.sh --globalnet $(globalnet) --deploytool $(deploytool)

--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -33,6 +33,8 @@ if [[ "${CHANGED_FILES_PR[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
    [[ "${CHANGED_FILES_LOCAL[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
    [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/shared/" ]] ||
    [[ "${CHANGED_FILES_LOCAL[@]}" =~ "scripts/shared/" ]] ||
+   [[ "${CHANGED_FILES_PR[@]}" =~ "Makefile.inc" ]] ||
+   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "Makefile.inc" ]] ||
    [[ "${LAST_COMMIT_LOCAL}" == "${LAST_COMMIT_MASTER}" ]]; then
       echo "Dockerfile.dapper-base was modified, rebuilding dapper image"
       docker build -t ${DAPPER_BASE_IMAGE} -f package/Dockerfile.dapper-base .


### PR DESCRIPTION
To allow sharing Makefile.inc, we need to rework the Dapper
integration. If we detect a Dapper environment (based on the existence
of a non-empty DAPPER_HOST_ARCH environment variable), we define the
available targets, without caring about Dapper. Otherwise, we define
targets to set Dapper up, and run everything through Dapper.

Downstreams can use this by copying the Makefile template, removing
the Shipyard-specific lines marked by comments, and adding their own
project-specific targets in the “Dapper is running” section.

A nice side-effect of this is that targets with dependencies are
handled entirely within Dapper, saving quite a lot of time in complex
builds.

Signed-off-by: Stephen Kitt <skitt@redhat.com>