### PR TITLE
Use submariner-operator namespace even with helm deployments

### DIFF
--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -6,7 +6,6 @@
 
 readonly SUBMARINER_BROKER_NS=submariner-k8s-broker
 readonly SUBMARINER_PSK=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 64 | head -n 1)
-readonly SUBM_NS=submariner
 
 ### Functions ###
 
@@ -45,7 +44,7 @@ function setup_broker() {
 function helm_install_subm() {
     local crd_create=$1
 
-    if kubectl wait --for=condition=Ready pods -l app=submariner-engine -n $SUBM_NS --timeout=60s > /dev/null 2>&1; then
+    if kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=60s > /dev/null 2>&1; then
         echo "Submariner already installed, skipping installation..."
         return
     fi
@@ -53,7 +52,7 @@ function helm_install_subm() {
     echo "Installing Submariner..."
     helm --kube-context "${cluster}" install submariner-latest/submariner \
         --name submariner \
-        --namespace submariner \
+        --namespace "${SUBM_NS}" \
         --set ipsec.psk="${SUBMARINER_PSK}" \
         --set broker.server="${submariner_broker_url}" \
         --set broker.token="${submariner_broker_token}" \

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -10,7 +10,6 @@ readonly SUBM_COLORCODES=blue
 readonly SUBM_ENGINE_IMAGE_REPO=localhost:5000
 readonly SUBM_ENGINE_IMAGE_TAG=local
 # shellcheck disable=SC2034 # this variable is used elsewhere
-readonly SUBM_NS=submariner-operator
 
 ### Functions ###
 

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -10,6 +10,7 @@ readonly RESOURCES_DIR=${SCRIPTS_DIR}/resources
 # shellcheck disable=SC2034 # this variable is used elsewhere
 readonly OUTPUT_DIR=${DAPPER_OUTPUT}
 readonly KUBECONFIGS_DIR=${DAPPER_OUTPUT}/kubeconfigs
+export SUBM_NS=submariner-operator
 
 ### Functions ###
 


### PR DESCRIPTION
Currently, when Submariner is deployed via Helm, its installed
in submariner namespace, whereas when its deployed via Operator,
its installed in submariner-operator. It would be helpful to use
the same namespace irrespective of the type of deployment so that
our docs/test-plans can refer to the common namespace.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>