### PR TITLE
Change deploy job to the image checking one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ git:
 
 jobs:
   include:
-  - env: CMD="make validate" DEPLOY=true
+  - env: CMD="make validate"
   - env: CMD="make deploy deploytool=helm"
-  - env: CMD="make deploy deploytool=operator"
+  - env: CMD="make deploy deploytool=operator" DEPLOY=true
 
 install:
   - sudo apt-get install moreutils # make ts available

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -14,6 +14,7 @@ function import_image() {
         docker tag "${orig_image}:latest" "${versioned_image}"
         docker tag "${versioned_image}" "${local_image}"
     fi
+
     docker push "${local_image}"
 }
 


### PR DESCRIPTION
The validate job doesnt check the image itself so it doesn't rebuild it,
which is fine.
Hence, changing the deploying job to the `deploy` one which does rebuild
the image.