### PR TITLE
Ship subctl in base dapper image

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -6,6 +6,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
     HELM_VERSION=v2.14.1 \
     KIND_VERSION=v0.6.1 \
     KUBEFED_VERSION=0.1.0-rc3 \
+    SUBCTL_VERSION=v0.2.0 \
     SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
@@ -30,6 +31,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # make           | OLM installation
 # findutils      | validate (find go packages)
 # shflags        | shell script flags
+# subctl *       | Submariner's deploy tool (operator)
 # upx            | binary compression
 # jq             | JSON processing (GitHub API)
 # diffutils      | required for goimports
@@ -47,6 +49,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     curl -L "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" | tar -xzf - && \
     mv kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
+    curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-amd64" && chmod a+x /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
     upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,protoc-gen-gogoctrd,runc} /usr/lib/golang/pkg/tool/*/* && \

--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -49,7 +49,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     curl -L "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" | tar -xzf - && \
     mv kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
-    curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-amd64" && chmod a+x /go/bin/subctl && \
+    curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
     upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,protoc-gen-gogoctrd,runc} /usr/lib/golang/pkg/tool/*/* && \

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -14,22 +14,8 @@ readonly SUBM_NS=submariner-operator
 
 ### Functions ###
 
-function get_latest_subctl_tag() {
-    curl https://api.github.com/repos/submariner-io/submariner-operator/releases/latest | jq -r '.tag_name'
-}
-
-function travis_retry() {
-    # We don't pretend to support commands with multiple words
-    $1 || (sleep 2 && $1) || (sleep 10 && $1)
-}
-
 function deploytool_prereqs() {
-    test -x /go/bin/subctl && return
-    local version
-    version=$(travis_retry get_latest_subctl_tag || echo v0.1.0)
-    curl -L "https://github.com/submariner-io/submariner-operator/releases/download/${version}/subctl-${version}-linux-amd64" \
-         -o /go/bin/subctl
-    chmod a+x /go/bin/subctl
+    test -x /go/bin/subctl
 }
 
 function setup_broker() {


### PR DESCRIPTION
Since subctl download is quite finicky, and we're getting the latest
*released* version anyhow, it makes more sense to always ship it in the
base image.