### PR TITLE
Add ability to specify nodes dynamically

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -6,18 +6,21 @@ source /usr/share/shflags/shflags
 DEFINE_string 'k8s_version' '' 'Version of K8s to use'
 DEFINE_string 'globalnet' 'false' "Deploy with operlapping CIDRs (set to 'true' to enable)"
 DEFINE_string 'registry_inmemory' 'true' "Run local registry in memory to speed up the image loading."
+DEFINE_string 'cluster_settings' "${SCRIPTS_DIR}/lib/cluster_settings" "Settings file to customize cluster deployments"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
 version="${FLAGS_k8s_version}"
 globalnet="${FLAGS_globalnet}"
 registry_inmemory="${FLAGS_registry_inmemory}"
-echo "Running with: k8s_version=${version}, globalnet=${globalnet}, registry_inmemory=${registry_inmemory}"
+cluster_settings="${FLAGS_cluster_settings}"
+echo "Running with: k8s_version=${version}, globalnet=${globalnet}, registry_inmemory=${registry_inmemory}, cluster_settings=${cluster_settings}"
 
 set -em
 
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
+source ${cluster_settings}
 
 ### Functions ###
 
@@ -33,6 +36,9 @@ function generate_cluster_yaml() {
     if [[ "${cluster}" = "cluster1" ]]; then
         disable_cni="false"
     fi
+
+    local nodes
+    for node in ${cluster_nodes[${cluster}]}; do nodes="${nodes}"$'\n'"- role: $node"; done
 
     render_template ${RESOURCES_DIR}/kind-cluster-config.yaml > ${RESOURCES_DIR}/${cluster}-config.yaml
 }

--- a/scripts/shared/lib/cluster_settings
+++ b/scripts/shared/lib/cluster_settings
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+# shellcheck source=scripts/shared/lib/source_only
+. "${BASH_SOURCE%/*}"/source_only
+
+# Map of cluster names to a space separated string, representing a list of nodes to deploy.
+# Possible node types are 'control-plane' and 'worker'.
+# e.g. cluster_nodes['multi-master']="control-plane control-plane worker worker worker"
+declare -gA cluster_nodes
+
+cluster_nodes['cluster1']="control-plane worker"
+cluster_nodes['cluster2']="control-plane worker"
+# shellcheck disable=SC2034 # this variable is used elsewhere
+cluster_nodes['cluster3']="control-plane worker worker"

--- a/scripts/shared/resources/kind-cluster-config.yaml
+++ b/scripts/shared/resources/kind-cluster-config.yaml
@@ -16,7 +16,4 @@ kubeadmConfigPatches:
     podSubnet: ${pod_cidr}
     serviceSubnet: ${service_cidr}
     dnsDomain: ${dns_domain}
-nodes:
-- role: control-plane
-- role: worker
-- role: worker
+nodes:${nodes}


### PR DESCRIPTION
Added an ability to specify for each cluster the types of nodes it
should have.
Downstream projects (or just devs) can use this to vary the deployment according to their needs.