### PR TITLE
Fix find arg construction in find_functions

### DIFF
--- a/scripts/shared/lib/find_functions
+++ b/scripts/shared/lib/find_functions
@@ -6,11 +6,11 @@ function find_go_pkg_dirs() {
     excluded_pkg_dirs=${EXCLUDE_PKG_DIRS:-vendor .git .trash-cache bin}
 
     for excldir in $excluded_pkg_dirs; do
-        find_exclude="-path ./$excldir -prune -o $find_exclude"
+        find_exclude=(-path "./$excldir" -prune -o "${find_exclude[@]}")
     done
 
 
-    package_dirs="$(find . "$find_exclude" -path './*/*.go' -print | \
+    package_dirs="$(find . "${find_exclude[@]}" -path './*/*.go' -print | \
                       cut -f2 -d/ | \
                       sort -u)"
 


### PR DESCRIPTION
Quoting find_exclude results in find treating the entire string as a
single predicate, which fails. Build find_exclude as an array
instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>