### PR TITLE
Allow not installing submariner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
 
+CLUSTERS_ARGS = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings
+DEPLOY_ARGS = $(CLUSTERS_ARGS)
+
 include $(SHIPYARD_DIR)/Makefile.inc
 
 TARGETS := $(shell ls -p scripts | grep -v -e /)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -4,12 +4,14 @@ deploytool ?= operator
 registry_inmemory ?= true
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
+CLUSTERS_ARGS ?= ''
+DEPLOY_ARGS ?= ''
 
 cleanup:
 	$(SCRIPTS_DIR)/cleanup.sh
 
 clusters:
-	$(SCRIPTS_DIR)/clusters.sh --k8s_version $(k8s_version) --globalnet $(globalnet) --registry_inmemory $(registry_inmemory)
+	$(SCRIPTS_DIR)/clusters.sh --k8s_version $(k8s_version) --globalnet $(globalnet) --registry_inmemory $(registry_inmemory) $(CLUSTERS_ARGS)
 
 deploy: clusters
-	$(SCRIPTS_DIR)/deploy.sh --globalnet $(globalnet) --deploytool $(deploytool)
+	$(SCRIPTS_DIR)/deploy.sh --globalnet $(globalnet) --deploytool $(deploytool) $(DEPLOY_ARGS)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -4,8 +4,6 @@ deploytool ?= operator
 registry_inmemory ?= true
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
-CLUSTERS_ARGS ?= ''
-DEPLOY_ARGS ?= ''
 
 cleanup:
 	$(SCRIPTS_DIR)/cleanup.sh

--- a/scripts/cluster_settings
+++ b/scripts/cluster_settings
@@ -1,0 +1,9 @@
+. "${SCRIPTS_DIR}"/lib/source_only
+
+# For shipyard we need a very minimal setup to verify the deployment works
+cluster_nodes['cluster1']="control-plane"
+cluster_nodes['cluster2']="control-plane worker"
+cluster_nodes['cluster3']="control-plane worker"
+
+# Don't install submariner where we don't need it
+cluster_subm['cluster1']="false"

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -6,7 +6,7 @@ source /usr/share/shflags/shflags
 DEFINE_string 'k8s_version' '' 'Version of K8s to use'
 DEFINE_string 'globalnet' 'false' "Deploy with operlapping CIDRs (set to 'true' to enable)"
 DEFINE_string 'registry_inmemory' 'true' "Run local registry in memory to speed up the image loading."
-DEFINE_string 'cluster_settings' "${SCRIPTS_DIR}/lib/cluster_settings" "Settings file to customize cluster deployments"
+DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
@@ -20,7 +20,10 @@ set -em
 
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
-source ${cluster_settings}
+
+# Always source the shared cluster settings, to set defaults in case something wasn't set in the provided settings
+source "${SCRIPTS_DIR}/lib/cluster_settings"
+[[ -z "${cluster_settings}" ]] || source ${cluster_settings}
 
 ### Functions ###
 

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -3,6 +3,7 @@
 ## Process command line flags ##
 
 source /usr/share/shflags/shflags
+DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments"
 DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm)'
 DEFINE_string 'globalnet' 'false' "Deploy with operlapping CIDRs (set to 'true' to enable)"
 FLAGS "$@" || exit $?
@@ -10,7 +11,8 @@ eval set -- "${FLAGS_ARGV}"
 
 globalnet="${FLAGS_globalnet}"
 deploytool="${FLAGS_deploytool}"
-echo "Running with: globalnet=${globalnet}, deploytool=${deploytool}"
+cluster_settings="${FLAGS_cluster_settings}"
+echo "Running with: globalnet=${globalnet}, deploytool=${deploytool}, cluster_settings=${cluster_settings}"
 
 set -em
 
@@ -18,6 +20,10 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/version
 source ${SCRIPTS_DIR}/lib/utils
 source ${SCRIPTS_DIR}/lib/deploy_funcs
+
+# Always source the shared cluster settings, to set defaults in case something wasn't set in the provided settings
+source "${SCRIPTS_DIR}/lib/cluster_settings"
+[[ -z "${cluster_settings}" ]] || source ${cluster_settings}
 
 ### Main ###
 

--- a/scripts/shared/lib/cluster_settings
+++ b/scripts/shared/lib/cluster_settings
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
+# shellcheck disable=SC2034 # We declare some shared variables here
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
@@ -9,5 +10,12 @@ declare -gA cluster_nodes
 
 cluster_nodes['cluster1']="control-plane worker"
 cluster_nodes['cluster2']="control-plane worker"
-# shellcheck disable=SC2034 # this variable is used elsewhere
 cluster_nodes['cluster3']="control-plane worker worker"
+
+# Map of cluster names to values specifying if submariner should be installed.
+# Only "true" string means its installed, otherwise it's not.
+declare -gA cluster_subm
+
+cluster_subm['cluster1']="true"
+cluster_subm['cluster2']="true"
+cluster_subm['cluster3']="true"

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -69,15 +69,18 @@ function connectivity_tests() {
 }
 
 function add_subm_gateway_label() {
+    [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
     kubectl label node "${cluster}-worker" "submariner.io/gateway=true" --overwrite
 }
 
 function del_subm_gateway_label() {
+    [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
     kubectl label node "${cluster}-worker" "submariner.io/gateway-" --overwrite
 }
 
 function prepare_cluster() {
     local namespace=$1
+    [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
     for app in submariner-engine submariner-routeagent submariner-globalnet; do
         if kubectl wait --for=condition=Ready pods -l "app=$app" -n "$namespace" --timeout=60s > /dev/null 2>&1; then
             echo "Removing $app pods..."

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -44,6 +44,11 @@ function setup_broker() {
 function helm_install_subm() {
     local crd_create=$1
 
+    if [[ ${cluster_subm[$cluster]} != "true" ]]; then
+        echo "Skipping installation as requested in cluster settings"
+        return
+    fi
+
     if kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=60s > /dev/null 2>&1; then
         echo "Submariner already installed, skipping installation..."
         return

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -28,6 +28,11 @@ function setup_broker() {
 }
 
 function subctl_install_subm() {
+    if [[ ${cluster_subm[$cluster]} != "true" ]]; then
+        echo "Skipping installation as requested in cluster settings"
+        return
+    fi
+
     subctl join --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
                 --clusterid "${cluster}" \
                 --repository "${SUBM_ENGINE_IMAGE_REPO}" \


### PR DESCRIPTION
Some projects (including shipyard) don't need submariner installed on cluster1, hence added an option to specify whether it should be installed or not.

Also added the ability to override default so that shipyard can provide sensible default for downstream projects, while running with a smaller footprint for itself.