### PR TITLE
validate needs dapper-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,7 @@ else
 # Not running in Dapper
 
 # Shipyard-specific starts
-clusters: dapper-image
-deploy: dapper-image
+clusters deploy validate: dapper-image
 
 dapper-image:
 	SCRIPTS_DIR=./scripts/shared ./scripts/dapper-image


### PR DESCRIPTION
Otherwise we try to validate with an out-dated base image.

Signed-off-by: Stephen Kitt <skitt@redhat.com>