### PR TITLE
Undeploy test resources once connectivity test succeeds

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -38,8 +38,5 @@ install_subm_all_clusters
 
 deploytool_postreqs
 
-with_context cluster2 deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
-with_context cluster3 deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
-
 with_context cluster2 connectivity_tests
 

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -61,11 +61,17 @@ function test_connection() {
 }
 
 function connectivity_tests() {
+    deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
+    with_context cluster3 deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
+
     local netshoot_pod nginx_svc_ip
     netshoot_pod=$(kubectl get pods -l app=netshoot | awk 'FNR == 2 {print $1}')
     nginx_svc_ip=$(with_context cluster3 get_svc_ip nginx-demo)
 
     with_retries 5 test_connection "$netshoot_pod" "$nginx_svc_ip"
+
+    remove_resource "${RESOURCES_DIR}/netshoot.yaml"
+    with_context cluster3 remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 }
 
 function add_subm_gateway_label() {
@@ -94,6 +100,11 @@ function deploy_resource() {
     kubectl apply -f "${resource_file}"
     echo "Waiting for ${resource_name} pods to be ready."
     kubectl rollout status "deploy/${resource_name}" --timeout=120s
+}
+
+function remove_resource() {
+    local resource_file=$1
+    kubectl delete -f "$resource_file"
 }
 
 function load_deploytool() {


### PR DESCRIPTION
In case the connectivity test succeeds, undeploy the resources that were
used for testing. This leaves the nodes clean and with more capacity
to dedicate to E2E tests.