### PR TITLE
Split base image into two parts

### DIFF
--- a/package/Dockerfile.base-deps
+++ b/package/Dockerfile.base-deps
@@ -1,0 +1,55 @@
+FROM fedora:31
+
+ENV DAPPER_HOST_ARCH=amd64
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
+    LINT_VERSION=v1.18.0 \
+    HELM_VERSION=v2.14.1 \
+    KIND_VERSION=v0.6.1 \
+    KUBEFED_VERSION=0.1.0-rc3 \
+    SUBCTL_VERSION=v0.2.0
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor \
+    GOPROXY=https://proxy.golang.org
+
+# Requirements:
+# Component      | Usage
+# -----------------------------------------------------------
+# gcc            | ginkgo
+# git            | find the workspace root
+# curl           | download other tools
+# moby-engine    | Dapper (Docker)
+# golang         | build
+# kubectl        | e2e tests (in kubernetes-client)
+# golangci-lint  | code linting
+# helm           | e2e tests
+# kubefedctl     | e2e tests
+# kind           | e2e tests
+# ginkgo         | tests
+# goimports      | code formatting
+# make           | OLM installation
+# findutils      | validate (find go packages)
+# shflags        | shell script flags
+# subctl *       | Submariner's deploy tool (operator)
+# upx            | binary compression
+# jq             | JSON processing (GitHub API)
+# diffutils      | required for goimports
+# ShellCheck     | shell script linting
+RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
+    dnf -y install --nodocs --setopt=install_weak_deps=False \
+                   gcc git-core curl moby-engine make golang kubernetes-client \
+                   findutils upx jq golang-x-tools-goimports ShellCheck shflags && \
+    dnf -y remove libsemanage && \
+    rpm -e --nodeps selinux-policy-targeted && \
+    dnf -y clean all && \
+    curl -L https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
+    curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
+    mv linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && rm -rf linux-${ARCH} && \
+    curl -L "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" | tar -xzf - && \
+    mv kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
+    curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
+    curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
+    GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
+    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
+    upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,protoc-gen-gogoctrd,runc} /usr/lib/golang/pkg/tool/*/* && \
+    ln -f /usr/bin/kubectl /usr/bin/hyperkube

--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -1,59 +1,6 @@
-FROM fedora:31
+FROM quay.io/submariner/shipyard-dapper-base-deps
 
-ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard/
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
-    LINT_VERSION=v1.18.0 \
-    HELM_VERSION=v2.14.1 \
-    KIND_VERSION=v0.6.1 \
-    KUBEFED_VERSION=0.1.0-rc3 \
-    SUBCTL_VERSION=v0.2.0 \
-    SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
-
-ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
-    GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor \
-    GOPROXY=https://proxy.golang.org
-
-# Requirements:
-# Component      | Usage
-# -----------------------------------------------------------
-# gcc            | ginkgo
-# git            | find the workspace root
-# curl           | download other tools
-# moby-engine    | Dapper (Docker)
-# golang         | build
-# kubectl        | e2e tests (in kubernetes-client)
-# golangci-lint  | code linting
-# helm           | e2e tests
-# kubefedctl     | e2e tests
-# kind           | e2e tests
-# ginkgo         | tests
-# goimports      | code formatting
-# make           | OLM installation
-# findutils      | validate (find go packages)
-# shflags        | shell script flags
-# subctl *       | Submariner's deploy tool (operator)
-# upx            | binary compression
-# jq             | JSON processing (GitHub API)
-# diffutils      | required for goimports
-# ShellCheck     | shell script linting
-RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
-    dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq golang-x-tools-goimports ShellCheck shflags && \
-    dnf -y remove libsemanage && \
-    rpm -e --nodeps selinux-policy-targeted && \
-    dnf -y clean all && \
-    curl -L https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
-    curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
-    mv linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && rm -rf linux-${ARCH} && \
-    curl -L "https://github.com/kubernetes-sigs/kubefed/releases/download/v${KUBEFED_VERSION}/kubefedctl-${KUBEFED_VERSION}-linux-${ARCH}.tgz" | tar -xzf - && \
-    mv kubefedctl /usr/bin/ && chmod a+x /usr/bin/kubefedctl && \
-    curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
-    curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
-    GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
-    upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,protoc-gen-gogoctrd,runc} /usr/lib/golang/pkg/tool/*/* && \
-    ln -f /usr/bin/kubectl /usr/bin/hyperkube
+ENV SHIPYARD_DIR=/opt/shipyard/ SCRIPTS_DIR=/opt/shipyard/scripts
 
 # Copy CI deployment scripts into image to share with all submariner-io/* projects
 WORKDIR $SCRIPTS_DIR

--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -17,6 +17,9 @@ SUFFIX=""
 TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-quay.io/submariner}
 
+BASE_DEPS_IMAGE_NAME=shipyard-dapper-base-deps
+BASE_DEPS_IMAGE_DOCKERFILE=package/Dockerfile.base-deps
+BASE_DEPS_IMAGE=${REPO}/${BASE_DEPS_IMAGE_NAME}:${TAG}
 DAPPER_BASE_IMAGE=${REPO}/shipyard-dapper-base:${TAG}
 
 # always compare with upstream master, which is the source for the published dapper image
@@ -27,22 +30,26 @@ CHANGED_FILES_LOCAL=$(git diff --name-only remotes/$UPSTREAM_REMOTE/master)
 LAST_COMMIT_LOCAL=$(git rev-parse HEAD)
 LAST_COMMIT_MASTER=$(git rev-parse remotes/$UPSTREAM_REMOTE/master)
 
+function rebuild_image_if_changed() {
+    local image_name=$1
+    local image_file=$2
+    shift 2
+    local changed_files=("${image_file}" "${@}")
+    local latest_image="${REPO}/${image_name}:latest"
+    local local_image="${REPO}/${image_name}:${TAG}"
 
+    for check_file in "${changed_files}"; do
+        if [[ "${CHANGED_FILES_PR[@]}" =~ "${changed_file}" ]] ||
+           [[ "${CHANGED_FILES_LOCAL[@]}" =~ "${changed_file}" ]] ||
+           [[ "${LAST_COMMIT_LOCAL}" = "${LAST_COMMIT_MASTER}" ]]; then
+            echo "${image_file} was modified, rebuilding image"
+            docker build -t ${local_image} -f ${image_file} .
+            docker tag ${local_image} ${latest_image}
+            return
+        fi
+    done
+}
 
-if [[ "${CHANGED_FILES_PR[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
-   [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/shared/" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "scripts/shared/" ]] ||
-   [[ "${CHANGED_FILES_PR[@]}" =~ "Makefile.inc" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "Makefile.inc" ]] ||
-   [[ "${LAST_COMMIT_LOCAL}" == "${LAST_COMMIT_MASTER}" ]]; then
-      echo "Dockerfile.dapper-base was modified, rebuilding dapper image"
-      docker build -t ${DAPPER_BASE_IMAGE} -f package/Dockerfile.dapper-base .
-      docker tag ${DAPPER_BASE_IMAGE} ${REPO}/shipyard-dapper-base:latest
-else
-      docker pull ${REPO}/shipyard-dapper-base:latest || :
-      # make sure the tag is also available for release, even if no changes happened
-      docker tag ${REPO}/shipyard-dapper-base:latest ${DAPPER_BASE_IMAGE}
-fi
-
+rebuild_image_if_changed shipyard-dapper-base-deps package/Dockerfile.base-deps
+rebuild_image_if_changed shipyard-dapper-base package/Dockerfile.dapper-base package/Dockerfile.base-deps scripts/shared/ Makefile.inc
 

--- a/scripts/release
+++ b/scripts/release
@@ -8,6 +8,8 @@ DOCKER_TAG=${1:-latest}
 REPO=${REPO:-quay.io/submariner}
 
 echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+docker tag ${REPO}/shipyard-dapper-base-deps:${VERSION} ${REPO}/shipyard-dapper-base-deps:${DOCKER_TAG#"v"}
+docker tag ${REPO}/shipyard-dapper-base-deps:${VERSION} ${REPO}/shipyard-dapper-base-deps:"${TRAVIS_COMMIT:0:7}"
 docker tag ${REPO}/shipyard-dapper-base:${VERSION} ${REPO}/shipyard-dapper-base:${DOCKER_TAG#"v"}
 docker tag ${REPO}/shipyard-dapper-base:${VERSION} ${REPO}/shipyard-dapper-base:"${TRAVIS_COMMIT:0:7}"
 for i in $(docker images --format "{{.Repository}}:{{.Tag}}" | grep -E "${REPO}/.*:(${DOCKER_TAG#v}|${TRAVIS_COMMIT:0:7})"); do docker push $i; done


### PR DESCRIPTION
Since most of the time we're just changing the scripts and no the entire
base image, it's a shame to have to rebuild it.
Instead, split the base image into a `shipyard-dapper-base-deps` image
which contains the OS and all the downloaded & installed tools.

Each image would be rebuilt only when necessary.