### PR TITLE
Base image cache

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -55,7 +55,9 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,protoc-gen-gogoctrd,runc} /usr/lib/golang/pkg/tool/*/* && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
+# Copy shared makefile so that downstream projects can use it
+COPY Makefile.inc ${SHIPYARD_DIR}
+
 # Copy CI deployment scripts into image to share with all submariner-io/* projects
 WORKDIR $SCRIPTS_DIR
 COPY scripts/shared/ .
-COPY Makefile.inc ${SHIPYARD_DIR}

--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -16,33 +16,14 @@ SUFFIX=""
 
 TAG=${TAG:-${VERSION}${SUFFIX}}
 REPO=${REPO:-quay.io/submariner}
+local_image=${REPO}/shipyard-dapper-base:${TAG}
+latest_image=${REPO}/shipyard-dapper-base:latest
 
-DAPPER_BASE_IMAGE=${REPO}/shipyard-dapper-base:${TAG}
+# Always pull latest image from the repo, so that it's layers may be reused.
+docker pull ${latest_image}
+docker tag ${latest_image} ${local_image}
 
-# always compare with upstream master, which is the source for the published dapper image
-UPSTREAM_REMOTE=$(git remote -v | grep submariner-io/shipyard | awk '{ print $1 }' | head -n 1)
-CHANGED_FILES_LOCAL=$(git diff --name-only remotes/$UPSTREAM_REMOTE/master)
-
-# Detect when we are on a merged patch
-LAST_COMMIT_LOCAL=$(git rev-parse HEAD)
-LAST_COMMIT_MASTER=$(git rev-parse remotes/$UPSTREAM_REMOTE/master)
-
-
-
-if [[ "${CHANGED_FILES_PR[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "package/Dockerfile.dapper-base" ]] ||
-   [[ "${CHANGED_FILES_PR[@]}" =~ "scripts/shared/" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "scripts/shared/" ]] ||
-   [[ "${CHANGED_FILES_PR[@]}" =~ "Makefile.inc" ]] ||
-   [[ "${CHANGED_FILES_LOCAL[@]}" =~ "Makefile.inc" ]] ||
-   [[ "${LAST_COMMIT_LOCAL}" == "${LAST_COMMIT_MASTER}" ]]; then
-      echo "Dockerfile.dapper-base was modified, rebuilding dapper image"
-      docker build -t ${DAPPER_BASE_IMAGE} -f package/Dockerfile.dapper-base .
-      docker tag ${DAPPER_BASE_IMAGE} ${REPO}/shipyard-dapper-base:latest
-else
-      docker pull ${REPO}/shipyard-dapper-base:latest || :
-      # make sure the tag is also available for release, even if no changes happened
-      docker tag ${REPO}/shipyard-dapper-base:latest ${DAPPER_BASE_IMAGE}
-fi
-
+# Rebuild the image to update any changed layers and tag it back so it will be used.
+docker build -t ${local_image} -f package/Dockerfile.dapper-base .
+docker tag ${local_image} ${latest_image}
 


### PR DESCRIPTION
Use the docker cache to save time when rebuilding the base image. Docker already knows what changed and so we can save a lot of dev & CI time by using the cached layers.