### PR TITLE
Make sure the child Make gets the parent flags

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -11,7 +11,7 @@
 	@mv .dapper.tmp .dapper
 
 %: .dapper
-	./.dapper -m bind $(MAKE) $@
+	./.dapper -m bind $(MAKE) $@ $(MAKEFLAGS)
 
 shell: .dapper
 	./.dapper -m bind -s


### PR DESCRIPTION
Because we’re invoking Make through Dapper, the usual
environment-based flag handling doesn’t work.

Signed-off-by: Stephen Kitt <skitt@redhat.com>