### PR TITLE
Store cache information in generated images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 language: go
 
 branches:
@@ -14,11 +14,20 @@ jobs:
   - env: CMD="make deploy deploytool=helm"
   - env: CMD="make deploy deploytool=operator" DEPLOY=true
 
-install:
-  - sudo apt-get install moreutils # make ts available
+before_install:
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install moreutils docker-ce
 
 services:
   - docker
+
+#addons:
+#  apt:
+#    packages:
+#      - docker-ce
+#      - moreutils
 
 script:
   - set -o pipefail;

--- a/scripts/dapper-image
+++ b/scripts/dapper-image
@@ -19,11 +19,15 @@ REPO=${REPO:-quay.io/submariner}
 local_image=${REPO}/shipyard-dapper-base:${TAG}
 latest_image=${REPO}/shipyard-dapper-base:latest
 
+# Enable BuildKit
+DOCKER_BUILDKIT=1
+export DOCKER_BUILDKIT
+
 # Always pull latest image from the repo, so that it's layers may be reused.
 docker pull ${latest_image}
 docker tag ${latest_image} ${local_image}
 
 # Rebuild the image to update any changed layers and tag it back so it will be used.
-docker build -t ${local_image} --cache-from ${latest_image} -f package/Dockerfile.dapper-base .
+docker build -t ${local_image} --cache-from ${latest_image} -f package/Dockerfile.dapper-base --build-arg BUILDKIT_INLINE_CACHE=1 .
 docker tag ${local_image} ${latest_image}
 


### PR DESCRIPTION
To use --cache-from most effectively, we should store cache metadata
in the container images we build. This requires enabling BuildKit (in
Docker 18.09 or later) and requesting it store the metadata.

See
https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>