### PR TITLE
Fix globalnet E2E

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -95,7 +95,7 @@ function add_cluster_cidrs() {
     [[ $globalnet != "true" ]] || val="0"
     cluster_CIDRs[$idx]="10.24${val}.0.0/16"
     service_CIDRs[$idx]="100.9${val}.0.0/16"
-    [[ $globalnet != "true" ]] || global_CIDRs[$idx]="169.254.${1}.0/24"
+    [[ $globalnet != "true" ]] || global_CIDRs[$idx]="169.254.$((val-2)).0/24"
 }
 
 function declare_cidrs() {


### PR DESCRIPTION
Globalnet E2E not working coz it expects clusterX to get
global-cidr 169.254.X.0/24 This is incorrect as first data
cluster (cluster2) will get 169.254.0.0/24, broker cluster
isn't allocated any global cidr.

Fixes #82