### PR TITLE
Use the right image tags for tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,8 @@ deploy:
     on:
       branch: master
       condition: $DEPLOY = true
+  - provider: script
+    script: make dapper-image release image_tag=$TRAVIS_TAG images="shipyard-dapper-base" dapper_image_flags="--nocache"
+    on:
+      tags: true
+      condition: $DEPLOY = true


### PR DESCRIPTION
Add support in .travis.yml to release images under a git tag
event.