### PR TITLE
Use distinct names for release make target variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,12 @@ after_success:
 
 deploy:
   - provider: script
-    script: make dapper-image release images="shipyard-dapper-base" dapper_image_flags="--nocache"
+    script: make dapper-image dapper_image_flags="--nocache" release release_images="shipyard-dapper-base"
     on:
       branch: master
       condition: $DEPLOY = true
   - provider: script
-    script: make dapper-image release image_tag=$TRAVIS_TAG images="shipyard-dapper-base" dapper_image_flags="--nocache"
+    script: make dapper-image dapper_image_flags="--nocache" release release_images="shipyard-dapper-base" release_tag="$TRAVIS_TAG"
     on:
       tags: true
       condition: $DEPLOY = true

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,7 +2,7 @@ k8s_version ?= 1.14.6
 globalnet ?= false
 deploytool ?= operator
 registry_inmemory ?= true
-image_tag ?= latest
+release_tag ?= latest
 repo ?= quay.io/submariner
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
@@ -17,7 +17,7 @@ deploy: clusters
 	$(SCRIPTS_DIR)/deploy.sh --globalnet $(globalnet) --deploytool $(deploytool) $(DEPLOY_ARGS)
 
 release:
-	$(SCRIPTS_DIR)/release.sh --tag $(image_tag) --repo $(repo) $(images)
+	$(SCRIPTS_DIR)/release.sh --tag $(release_tag) --repo $(repo) $(release_images)
 
 ifeq (go.mod,$(wildcard go.mod))
 # If go.mod exists (as determined above), assume we're vendoring


### PR DESCRIPTION
To make sure we don't have any naming conflicts in the consuming
projects, rename the makefile variables to have "release_" prefix.

Also reordered the make command to make (no pun intended) more sense
logically, it should still work the same.