### PR TITLE
Allow multiple kubeconfigs

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -55,11 +55,11 @@ func init() {
 }
 
 func ValidateFlags(t *TestContextType) {
-	if len(t.KubeConfig) == 0 {
+	if len(t.KubeConfig) == 0 && len(t.KubeConfigs) == 0 {
 		klog.Fatalf("kubeconfig parameter or KUBECONFIG environment variable is required")
 	}
 
-	if len(t.KubeContexts) < 2 {
+	if len(t.KubeContexts) < 2 && len(t.KubeConfigs) < 2 {
 		klog.Fatalf("several kubernetes contexts are necessary east, west, etc..")
 	}
 }


### PR DESCRIPTION
TestContextType allows callers to fill in KubeConfigs instead of the
KubeConfig + KubeContexts pair, and this is used by the operator.
However the flag verification doesn’t account for this; this patch
fixes that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>