### PR TITLE
Fail if a parallel command fails

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -62,7 +62,10 @@ function run_parallel() {
     cmnd=$2
     declare -A pids
     for i in ${clusters}; do
-        ( with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /" ) &
+        (
+           set -o pipefail
+           with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /"
+        ) &
         pids["${i}"]=$!
     done
 


### PR DESCRIPTION
In case a paralle command failed the pipe to sed would "swallow" the
failure. For this, pipefail will allow the command to eventually fail
anyhow.