### PR TITLE
Stop go getting goimports

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -51,7 +51,6 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
     curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v golang.org/x/tools/cmd/goimports && \
     upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,runc} /usr/lib/golang/pkg/tool/*/* && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 


### PR DESCRIPTION
We’re installing the packaged goimports, we don’t need to go get it
too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>