### PR TITLE
Only compress files that are installed

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -51,7 +51,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
     curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    upx /go/bin/{ginkgo,golangci-lint} /usr/bin/{containerd*,ctr,docker*,goimports,helm,kind,kube*,runc} /usr/lib/golang/pkg/tool/*/* && \
+    find /usr/bin /go/bin /usr/lib/golang -type f -executable -size +5M ! -name subctl ! -name hyperkube | xargs upx && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 # Copy shared makefile so that downstream projects can use it


### PR DESCRIPTION
To avoid failures in the future from changes to the Fedora packages we
use, this patch changes our upx invocation:

* one invocation compresses files we install explicitly
* another lists files from packages we install, and compresses those

In the second phase, missing packages (from changes to dependencies)
will only result in a “package ... is not installed” message on
standard output, which will be filtered by the grep. We ignore errors
because this approach results in asking upx to compress symlinks,
which it complains about (but everything works anyway).

Signed-off-by: Stephen Kitt <skitt@redhat.com>