### PR TITLE
Refactor use of EXCLUDE_PKG_DIRS in find_functions

### DIFF
--- a/scripts/shared/lib/find_functions
+++ b/scripts/shared/lib/find_functions
@@ -3,7 +3,7 @@ function find_go_pkg_dirs() {
     local base excluded_pkg_dirs find_exclude package_dirs
 
     base=${2:-.}
-    excluded_pkg_dirs=${EXCLUDE_PKG_DIRS:-vendor .git .trash-cache bin}
+    excluded_pkg_dirs="${EXCLUDE_PKG_DIRS} vendor .git .trash-cache bin"
 
     for excldir in $excluded_pkg_dirs; do
         find_exclude=(-path "./$excldir" -prune -o "${find_exclude[@]}")

--- a/scripts/validate
+++ b/scripts/validate
@@ -4,7 +4,6 @@ set -e
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/find_functions
 
-EXCLUDE_PKG_DIRS=".git .trash-cache vendor bin"
 PACKAGES="$(find_go_pkg_dirs --no-trailing-dots "*.go")"
 
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then


### PR DESCRIPTION
Make it additive instead of replace the default so test scripts need
only specify EXCLUDE_PKG_DIRS=test.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>