### PR TITLE
Download shflags if necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
 .dapper
 .idea
+.shflags
 /bin
 output
 dist

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -8,7 +8,7 @@ SUFFIX=""
 
 ## Process command line flags ##
 
-source /usr/share/shflags/shflags
+source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' "${VERSION}${SUFFIX}" "Tag to set for the local image"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to use for the image"
 DEFINE_string 'image' '' "Image name to build" 'i'

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -2,7 +2,7 @@
 
 ## Process command line flags ##
 
-source /usr/share/shflags/shflags
+source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'k8s_version' '' 'Version of K8s to use'
 DEFINE_string 'globalnet' 'false' "Deploy with operlapping CIDRs (set to 'true' to enable)"
 DEFINE_string 'registry_inmemory' 'true' "Run local registry in memory to speed up the image loading."

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -2,7 +2,7 @@
 
 ## Process command line flags ##
 
-source /usr/share/shflags/shflags
+source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments"
 DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm)'
 DEFINE_string 'globalnet' 'false' "Deploy with operlapping CIDRs (set to 'true' to enable)"

--- a/scripts/shared/lib/shflags
+++ b/scripts/shared/lib/shflags
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+# shellcheck source=scripts/shared/lib/source_only
+. "${BASH_SOURCE%/*}"/source_only
+
+if [ -f /usr/share/shflags/shflags ]; then
+    . /usr/share/shflags/shflags
+elif [ ! -f .shflags ]; then
+    echo "Downloading shflags ${SHFLAGS_VERSION:=1.2.3}"
+    if ! (curl -L "https://github.com/kward/shflags/archive/v${SHFLAGS_VERSION}.tar.gz" | tar -xzf - shflags-${SHFLAGS_VERSION}/shflags &&
+          mv shflags-${SHFLAGS_VERSION}/shflags .shflags); then
+        echo This program needs shflags in /usr/share/shflags/shflags or locally as .shflags. 1>&2
+        echo It was unable to download it; please install it and try again. 1>&2
+        exit 1
+    fi
+fi
+
+. ./.shflags

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -2,7 +2,7 @@
 
 ## Process command line flags ##
 
-source /usr/share/shflags/shflags
+source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' '' "Additional tag to use for the image (prefix 'v' will be stripped)"
 DEFINE_string 'repo' '' "Quay.io repo to deploy to"
 FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"


### PR DESCRIPTION
This adds a new shared script which takes care of providing shflags,
using either the installed version, or a previously-downloaded
version, or by downloading it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>