### PR TITLE
Fix shflags handling when the package is installed

### DIFF
--- a/scripts/shared/lib/shflags
+++ b/scripts/shared/lib/shflags
@@ -2,16 +2,23 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
-if [ -f /usr/share/shflags/shflags ]; then
-    . /usr/share/shflags/shflags
-elif [ ! -f .shflags ]; then
-    echo "Downloading shflags ${SHFLAGS_VERSION:=1.2.3}"
-    if ! (curl -L "https://github.com/kward/shflags/archive/v${SHFLAGS_VERSION}.tar.gz" | tar -xzf - shflags-${SHFLAGS_VERSION}/shflags &&
-          mv shflags-${SHFLAGS_VERSION}/shflags .shflags); then
-        echo This program needs shflags in /usr/share/shflags/shflags or locally as .shflags. 1>&2
-        echo It was unable to download it; please install it and try again. 1>&2
-        exit 1
+ensure_shflags() {
+    if [ -f /usr/share/shflags/shflags ]; then
+	. /usr/share/shflags/shflags
+	return
     fi
-fi
 
-. ./.shflags
+    if [ ! -f .shflags ]; then
+        echo "Downloading shflags ${SHFLAGS_VERSION:=1.2.3}"
+        if ! (curl -L "https://github.com/kward/shflags/archive/v${SHFLAGS_VERSION}.tar.gz" | tar -xzf - shflags-${SHFLAGS_VERSION}/shflags &&
+              mv shflags-${SHFLAGS_VERSION}/shflags .shflags); then
+            echo "$0 needs shflags in /usr/share/shflags/shflags or locally as .shflags." 1>&2
+            echo "It was unable to download it; please install it and try again." 1>&2
+            exit 1
+        fi
+    fi
+
+    . ./.shflags
+}
+
+ensure_shflags


### PR DESCRIPTION
If shflags is available in /usr/share/shflags/shflags, we mustn’t try
to load .shflags.

Signed-off-by: Stephen Kitt <skitt@redhat.com>