### PR TITLE
Make the number of clusters configurable

### DIFF
--- a/scripts/shared/cleanup.sh
+++ b/scripts/shared/cleanup.sh
@@ -8,9 +8,7 @@ source ${SCRIPTS_DIR}/lib/utils
 ### Functions ###
 
 function delete_cluster() {
-    if kind get clusters | grep -q ${cluster}; then
-        kind delete cluster --name=${cluster};
-    fi
+    kind delete cluster --name=${cluster};
 }
 
 function stop_local_registry {
@@ -23,7 +21,9 @@ function stop_local_registry {
 
 ### Main ###
 
-run_all_clusters delete_cluster
+clusters=($(kind get clusters))
+run_parallel "${clusters[*]}" delete_cluster
+
 stop_local_registry
 docker system prune --volumes -f
 

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -25,6 +25,13 @@ source ${SCRIPTS_DIR}/lib/utils
 source "${SCRIPTS_DIR}/lib/cluster_settings"
 [[ -z "${cluster_settings}" ]] || source ${cluster_settings}
 
+cat << EOM
+Cluster settings::
+  clusters - ${clusters[*]@Q}
+  nodes per cluster - $(typeset -p cluster_nodes | cut -f 2- -d=)
+  install submariner - $(typeset -p cluster_subm | cut -f 2- -d=)
+EOM
+
 ### Functions ###
 
 function render_template() {
@@ -123,3 +130,4 @@ with_retries 3 run_all_clusters create_kind_cluster
 declare_kubeconfig
 run_subm_clusters deploy_weave_cni
 
+print_clusters_message

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -52,5 +52,9 @@ install_subm_all_clusters
 
 deploytool_postreqs
 
-with_context cluster2 connectivity_tests
+if [ "${#clusters[@]}" -gt 2 ]; then
+    with_context "${clusters[1]}" connectivity_tests
+else
+    echo "Not executing connectivity tests - requires at least 3 clusters"
+fi
 

--- a/scripts/shared/lib/cluster_settings
+++ b/scripts/shared/lib/cluster_settings
@@ -3,6 +3,9 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
+# Array of all cluster names that we create and deploy on.
+declare -ga clusters=(cluster{1..3})
+
 # Map of cluster names to a space separated string, representing a list of nodes to deploy.
 # Possible node types are 'control-plane' and 'worker'.
 # e.g. cluster_nodes['multi-master']="control-plane control-plane worker worker worker"

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -52,7 +52,7 @@ function test_connection() {
     local source_pod=$1
     local target_address=$2
 
-    echo "Attempting connectivity between clusters - $source_pod (cluster2) --> $target_address (service on cluster3)"
+    echo "Attempting connectivity between clusters - $source_pod (${clusters[1]}) --> $target_address (service on ${clusters[2]})"
     if ! kubectl exec "${source_pod}" -- curl --output /dev/null -m 30 --silent --head --fail "${target_address}"; then
         return 1
     fi
@@ -62,16 +62,16 @@ function test_connection() {
 
 function connectivity_tests() {
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
-    with_context cluster3 deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
+    with_context "${clusters[2]}" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 
     local netshoot_pod nginx_svc_ip
     netshoot_pod=$(kubectl get pods -l app=netshoot | awk 'FNR == 2 {print $1}')
-    nginx_svc_ip=$(with_context cluster3 get_svc_ip nginx-demo)
+    nginx_svc_ip=$(with_context "${clusters[2]}" get_svc_ip nginx-demo)
 
     with_retries 5 test_connection "$netshoot_pod" "$nginx_svc_ip"
 
     remove_resource "${RESOURCES_DIR}/netshoot.yaml"
-    with_context cluster3 remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"
+    with_context "${clusters[2]}" remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 }
 
 function add_subm_gateway_label() {

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -53,52 +53,48 @@ function with_context() {
 }
 
 # Run cluster commands in parallel.
-# 1st argument is the numbers of the clusters to run for, supports "1 2 3" or "{1..3}" for range
+# 1st argument is the cluster names for which to run.
 # 2nd argument is the command to execute, which will have the $cluster variable set.
 # 3rd argument and so forth get passed to the command.
 function run_parallel() {
-    local clusters cmnd
-    clusters=$(eval echo "$1")
-    cmnd=$2
+    local cmnd=$2
     declare -A pids
-    for i in ${clusters}; do
+    for cluster in $(eval echo "$1"); do
         (
            set -o pipefail
-           with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /"
+           $cmnd "${@:3}" | sed "s/^/[${cluster}] /"
         ) &
-        pids["${i}"]=$!
+        pids["${cluster}"]=$!
     done
 
-    for i in "${!pids[@]}"; do
-        wait ${pids[$i]}
+    for pid in "${pids[@]}"; do
+        wait $pid
     done
 }
 
 # Run the given command (with any arguments) in parallel on all the clusters.
 function run_all_clusters() {
-    run_parallel "{1..3}" "$@"
+    run_parallel "${clusters[*]}" "$@"
 }
 
 # Run the given command (with any arguments) in parallel on the clusters that install submariner.
 function run_subm_clusters() {
     declare -a subm_clusters
-    for i in {1..3}; do
-        [[ "${cluster_subm[cluster$i]}" != "true" ]] || subm_clusters+=( "$i" )
+    for cluster in "${clusters[@]}"; do
+        [[ "${cluster_subm[${cluster}]}" != "true" ]] || subm_clusters+=( "${cluster}" )
     done
 
     run_parallel "${subm_clusters[*]}" "$@"
 }
 
 # Run cluster commands sequentially.
-# 1st argument is the numbers of the clusters to run for, supports "1 2 3" or "{1..3}" for range
+# 1st argument is the numbers of the clusters names for which to run.
 # 2nd argument is the command to execute, which will have the $cluster variable set.
 # 3rd argument and so forth get passed to the command.
 function run_sequential() {
-    local clusters cmnd
-    clusters=$(eval echo "$1")
-    cmnd=$2
-    for i in ${clusters}; do
-        with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /"
+    local cmnd=$2
+    for cluster in $(eval echo "$1"); do
+        $cmnd "${@:3}" | sed "s/^/[${cluster}] /" 
     done
 }
 
@@ -108,8 +104,8 @@ function registry_running() {
 }
 
 function add_cluster_cidrs() {
-    local idx="cluster${1}"
     local val=$1
+    local idx=$2
     [[ $globalnet != "true" ]] || val="0"
     cluster_CIDRs[$idx]="10.24${val}.0.0/16"
     service_CIDRs[$idx]="100.9${val}.0.0/16"
@@ -120,11 +116,25 @@ function declare_cidrs() {
     # shellcheck disable=SC2034 # these variables are used elsewhere
     declare -gA cluster_CIDRs service_CIDRs global_CIDRs
 
-    for i in {1..3}; do
-        add_cluster_cidrs $i
+    i=1
+    for cluster in "${clusters[@]}"; do
+        add_cluster_cidrs "$i" "$cluster"
+        i=$(("$i"+1))
     done
 }
 
 function declare_kubeconfig() {
     source "${SCRIPTS_DIR}"/lib/kubecfg
+}
+
+function print_clusters_message() {
+    cat << EOM
+Your virtual cluster(s) are deployed and working properly and can be accessed with:
+
+export KUBECONFIG=\$(find \$(git rev-parse --show-toplevel)/output/kubeconfigs/ -type f | -printf %p:)
+
+$ kubectl config use-context cluster1 # or cluster2, cluster3..
+
+To clean everthing up, just run: make cleanup
+EOM
 }


### PR DESCRIPTION
Not all project E2E tests need 3 clusters so make it configurable.

A new indexed "clusters" array was added to the cluster_settings file
to hold the cluster names.