### PR TITLE
Fix double slash in SCRIPTS_DIR file paths

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -1,6 +1,6 @@
 FROM fedora:31
 
-ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard/
+ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
     LINT_VERSION=v1.18.0 \
     HELM_VERSION=v2.14.1 \
@@ -55,7 +55,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 # Copy shared makefile so that downstream projects can use it
-COPY Makefile.inc ${SHIPYARD_DIR}
+COPY Makefile.inc ${SHIPYARD_DIR}/
 
 # Copy CI deployment scripts into image to share with all submariner-io/* projects
 WORKDIR $SCRIPTS_DIR


### PR DESCRIPTION
The SHIPYARD_DIR variable was defined with a trailing slash to make
Docker copy the directory into the base image correctly, but when
SHIPYARD_DIR was used to build SCRIPTS_DIR this resulted in an extra
slash. Move the slash to the Docker command that requires it, keeping
the var trailing-slash-free as per norms elsewhere in the codebase.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>