### PR TITLE
Added cluster funcs that abstract details

### DIFF
--- a/scripts/shared/cleanup.sh
+++ b/scripts/shared/cleanup.sh
@@ -23,7 +23,7 @@ function stop_local_registry {
 
 ### Main ###
 
-run_parallel "{1..3}" delete_cluster
+run_all_clusters delete_cluster
 stop_local_registry
 docker system prune --volumes -f
 

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -83,6 +83,11 @@ function deploy_weave_cni(){
         return
     fi
 
+    if [[ "${cluster}" = "cluster1" ]]; then
+       echo "Not deploying weave on broker cluster"
+       return
+    fi
+
     echo "Applying weave network..."
     kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=v$version&env.IPALLOC_RANGE=${cluster_CIDRs[${cluster}]}"
     echo "Waiting for weave-net pods to be ready..."
@@ -114,7 +119,7 @@ mkdir -p ${KUBECONFIGS_DIR}
 
 run_local_registry
 declare_cidrs
-with_retries 3 run_parallel "{1..3}" create_kind_cluster
+with_retries 3 run_all_clusters create_kind_cluster
 declare_kubeconfig
-run_parallel "2 3" deploy_weave_cni
+run_subm_clusters deploy_weave_cni
 

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -45,7 +45,7 @@ import_image quay.io/submariner/submariner-route-agent
 load_deploytool $deploytool
 deploytool_prereqs
 
-run_parallel "{1..3}" prepare_cluster "$SUBM_NS"
+run_subm_clusters prepare_cluster "$SUBM_NS"
 
 with_context cluster1 setup_broker
 install_subm_all_clusters

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -25,7 +25,7 @@ function install_helm() {
 function deploytool_prereqs() {
     helm init --client-only
     helm repo add submariner-latest https://submariner-io.github.io/submariner-charts/charts
-    run_parallel "{1..3}" install_helm
+    run_all_clusters install_helm
 }
 
 function setup_broker() {
@@ -47,12 +47,8 @@ function setup_broker() {
 }
 
 function helm_install_subm() {
-    local crd_create=$1
-
-    if [[ ${cluster_subm[$cluster]} != "true" ]]; then
-        echo "Skipping installation as requested in cluster settings"
-        return
-    fi
+    local crd_create=false
+    [[ "${cluster}" = "cluster1" ]] || crd_create=true
 
     if kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=60s > /dev/null 2>&1; then
         echo "Submariner already installed, skipping installation..."
@@ -91,9 +87,7 @@ function helm_install_subm() {
 
 
 function install_subm_all_clusters() {
-    with_context cluster1 helm_install_subm false
-
-    run_parallel "2 3" helm_install_subm true
+    run_subm_clusters helm_install_subm
 }
 
 function deploytool_postreqs() {

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -54,7 +54,7 @@ function subctl_install_subm() {
 }
 
 function install_subm_all_clusters() {
-    run_parallel "{1..3}" subctl_install_subm
+    run_subm_clusters subctl_install_subm
 }
 
 function deploytool_postreqs() {

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -74,6 +74,21 @@ function run_parallel() {
     done
 }
 
+# Run the given command (with any arguments) in parallel on all the clusters.
+function run_all_clusters() {
+    run_parallel "{1..3}" "$@"
+}
+
+# Run the given command (with any arguments) in parallel on the clusters that install submariner.
+function run_subm_clusters() {
+    declare -a subm_clusters
+    for i in {1..3}; do
+        [[ "${cluster_subm[cluster$i]}" != "true" ]] || subm_clusters+=( "$i" )
+    done
+
+    run_parallel "${subm_clusters[*]}" "$@"
+}
+
 # Run cluster commands sequentially.
 # 1st argument is the numbers of the clusters to run for, supports "1 2 3" or "{1..3}" for range
 # 2nd argument is the command to execute, which will have the $cluster variable set.


### PR DESCRIPTION
Instead of calling run_parallel it's now possible to call
run_all_clusters or run_subm_clusters to execute on all the clusters or
just the ones that have subm installed, respectively.

Secret knowledge about specific deployment constraints is now part of
the called functions themselves (e.g. deploy_weave_cni).