### PR TITLE
Remove run_sequential function

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -89,19 +89,6 @@ function run_subm_clusters() {
     run_parallel "${subm_clusters[*]}" "$@"
 }
 
-# Run cluster commands sequentially.
-# 1st argument is the numbers of the clusters to run for, supports "1 2 3" or "{1..3}" for range
-# 2nd argument is the command to execute, which will have the $cluster variable set.
-# 3rd argument and so forth get passed to the command.
-function run_sequential() {
-    local clusters cmnd
-    clusters=$(eval echo "$1")
-    cmnd=$2
-    for i in ${clusters}; do
-        with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /"
-    done
-}
-
 function registry_running() {
     docker ps --filter name="^/?$KIND_REGISTRY$" | grep $KIND_REGISTRY
     return $?


### PR DESCRIPTION
This was useful for globalnet workaround, but since we've added support
to deploy in parallel with globalnet this isn't used anymore, so
removing it.