### PR TITLE
More robust cluster creation & retries

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -78,7 +78,7 @@ function create_kind_cluster() {
 }
 
 function deploy_weave_cni(){
-    if kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=60s > /dev/null 2>&1; then
+    if kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=3s > /dev/null 2>&1; then
         echo "Weave already deployed."
         return
     fi
@@ -91,9 +91,9 @@ function deploy_weave_cni(){
     echo "Applying weave network..."
     kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=v$version&env.IPALLOC_RANGE=${cluster_CIDRs[${cluster}]}"
     echo "Waiting for weave-net pods to be ready..."
-    kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=300s
+    kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout=60s
     echo "Waiting for core-dns deployment to be ready..."
-    kubectl -n kube-system rollout status deploy/coredns --timeout=300s
+    kubectl -n kube-system rollout status deploy/coredns --timeout=60s
 }
 
 function run_local_registry() {

--- a/scripts/shared/lib/cluster_settings
+++ b/scripts/shared/lib/cluster_settings
@@ -19,3 +19,11 @@ declare -gA cluster_subm
 cluster_subm['cluster1']="true"
 cluster_subm['cluster2']="true"
 cluster_subm['cluster3']="true"
+
+# Map of cluster names to values specifying which CNI to install.
+# Empty (or not set) value means default CNI.
+# Currently only "weave" is supported.
+declare -gA cluster_cni
+
+cluster_cni['cluster2']="weave"
+cluster_cni['cluster3']="weave"

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -33,7 +33,8 @@ function with_retries() {
     local cmnd=$2
 
     for _ in ${retries}; do
-        if $cmnd "${@:3}"; then
+        ( $cmnd "${@:3}"; ) &
+        if wait $!; then
             return 0
         fi
     done

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -39,7 +39,7 @@ function with_retries() {
         fi
     done
 
-    echo "Max attempts reached, failed to run ${cmnd}!"
+    echo "Max attempts reached, failed to run '${*:2}'!"
     exit 1
 }
 
@@ -65,7 +65,7 @@ function run_parallel() {
     for i in ${clusters}; do
         (
            set -o pipefail
-           with_context "cluster${i}" "$cmnd" "${@:3}" | sed "s/^/[cluster${i}] /"
+           with_context "cluster${i}" "$cmnd" "${@:3}" |& sed "/\[cluster${i}]/!s/^/[cluster${i}] /"
         ) &
         pids["${i}"]=$!
     done


### PR DESCRIPTION
These commits fix the retries mechanism (it didn't really adhere `set -e` because of how that mechanism works), and move the CNI creation logic into the cluster creation function so that in case it fails (sometimes weave deploy is flaky), the script will destroy the cluster and re create it.

This should hopefully alleviate some of the failures in https://github.com/submariner-io/submariner/issues/532