### PR TITLE
Export kubeconfigs on dapper image

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -54,6 +54,9 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     find /usr/bin /go/bin /usr/lib/golang -type f -executable -size +5M ! -name subctl ! -name hyperkube | xargs upx && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
+# Copy kubecfg to always run on the shell
+COPY scripts/shared/lib/kubecfg /etc/profile.d/kubecfg.sh
+
 # Copy shared makefile so that downstream projects can use it
 COPY Makefile.inc ${SHIPYARD_DIR}/
 

--- a/scripts/shared/lib/kubecfg
+++ b/scripts/shared/lib/kubecfg
@@ -1,1 +1,3 @@
-export KUBECONFIG=$(find ${DAPPER_OUTPUT:-output}/kubeconfigs -type f | tr '\n' ':')
+#!/usr/bin/env bash
+export KUBECONFIG
+KUBECONFIG=$(find "${DAPPER_OUTPUT:-output}"/kubeconfigs -type f | tr '\n' ':')

--- a/scripts/shared/lib/kubecfg
+++ b/scripts/shared/lib/kubecfg
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 export KUBECONFIG
-KUBECONFIG=$(find "${DAPPER_OUTPUT:-output}"/kubeconfigs -type f | tr '\n' ':')
+KUBECONFIG=$(find "${DAPPER_OUTPUT:-output}"/kubeconfigs -type f -printf %p:)

--- a/scripts/shared/lib/kubecfg
+++ b/scripts/shared/lib/kubecfg
@@ -1,0 +1,1 @@
+export KUBECONFIG=$(find ${DAPPER_OUTPUT:-output}/kubeconfigs -type f | tr '\n' ':')

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -126,5 +126,5 @@ function declare_cidrs() {
 }
 
 function declare_kubeconfig() {
-    source ${SCRIPTS_DIR}/lib/kubecfg
+    source "${SCRIPTS_DIR}"/lib/kubecfg
 }

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -126,6 +126,5 @@ function declare_cidrs() {
 }
 
 function declare_kubeconfig() {
-    export KUBECONFIG
-    KUBECONFIG=$(echo "${KUBECONFIGS_DIR}"/kind-config-cluster{1..3} | sed 's/ /:/g')
+    source ${SCRIPTS_DIR}/lib/kubecfg
 }


### PR DESCRIPTION
Always export it so that when connecting with an interactive shell you'll
already have it primed with the correct kubeconfigs.