### PR TITLE
Remove cable_driver flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
          CLUSTERS_ARGS="--globalnet"
          DEPLOY_ARGS="${CLUSTERS_ARGS} --deploytool helm"
   - env: CMD="make deploy"
-         DEPLOY_ARGS="--cable_driver wireguard"
+         DEPLOY_ARGS="--deploytool_submariner_args '--cable-driver wireguard'"
   - env: CMD="make deploy"
          RELEASE=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,7 @@ jobs:
          CLUSTERS_ARGS="--globalnet"
          DEPLOY_ARGS="${CLUSTERS_ARGS} --deploytool helm"
   - env: CMD="make deploy"
-         DEPLOY_ARGS="--deploytool_submariner_args '--cable-driver wireguard'"
-  - env: CMD="make deploy"
          RELEASE=true
-
-install:
-  - sudo add-apt-repository -y ppa:wireguard/wireguard # add WireGuard support
-  - sudo apt-get update
-  - sudo apt-get install linux-headers-`uname -r` wireguard -y
-  - sudo modprobe wireguard
 
 services:
   - docker

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,7 +2,6 @@ k8s_version ?= 1.14.6
 deploytool ?= operator
 release_tag ?= latest
 repo ?= quay.io/submariner
-cable_driver ?= ''
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
 
@@ -13,7 +12,7 @@ clusters:
 	$(SCRIPTS_DIR)/clusters.sh --k8s_version $(k8s_version) $(CLUSTERS_ARGS)
 
 deploy: clusters
-	$(SCRIPTS_DIR)/deploy.sh --deploytool $(deploytool) --cable_driver $(cable_driver) $(DEPLOY_ARGS)
+	$(SCRIPTS_DIR)/deploy.sh --deploytool $(deploytool) $(DEPLOY_ARGS)
 
 release:
 	$(SCRIPTS_DIR)/release.sh --tag $(release_tag) --repo $(repo) $(release_images) $(RELEASE_ARGS)

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -8,7 +8,6 @@ DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm)
 DEFINE_string 'deploytool_broker_args' '' 'Any extra arguments to pass to the deploytool when deploying the broker'
 DEFINE_string 'deploytool_submariner_args' '' 'Any extra arguments to pass to the deploytool when deploying submariner'
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"
-DEFINE_string 'cable_driver' '' "Cable driver implementation"
 
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -18,9 +17,8 @@ deploytool="${FLAGS_deploytool}"
 deploytool_broker_args="${FLAGS_deploytool_broker_args}"
 deploytool_submariner_args="${FLAGS_deploytool_submariner_args}"
 cluster_settings="${FLAGS_cluster_settings}"
-cable_driver="${FLAGS_cable_driver}"
 
-echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}, cable_driver=${cable_driver@Q}"
+echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}"
 
 set -em
 

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -81,7 +81,6 @@ function helm_install_subm() {
         --set globalnet.image.tag="local" \
         --set globalnet.image.pullPolicy="IfNotPresent" \
         --set crd.create="${crd_create}" \
-        --set "submariner.cableDriver=${cable_driver}" \
         ${deploytool_submariner_args}
 }
 

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -48,7 +48,6 @@ function subctl_install_subm() {
                 --colorcodes "${SUBM_COLORCODES}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \
                 --disable-nat \
-                --cable-driver "${cable_driver}" \
                 ${deploytool_submariner_args} \
                 "${OUTPUT_DIR}"/broker-info.subm
 }


### PR DESCRIPTION
This flag is very specific to the deploytool, and so should use the
--deploytool_submariner_args flag when passing it, since we now have
support for these things.