### PR TITLE
Add timeouts to helm installs

### DIFF
--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -10,7 +10,7 @@ readonly SUBMARINER_PSK=$(LC_CTYPE=C tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w
 ### Functions ###
 
 function install_helm() {
-    if kubectl -n kube-system rollout status deploy/tiller-deploy > /dev/null 2>&1; then
+    if kubectl -n kube-system rollout status deploy/tiller-deploy --timeout=3s > /dev/null 2>&1; then
         echo "Helm already installed, skipping helm installation..."
         return
     fi
@@ -19,7 +19,7 @@ function install_helm() {
     kubectl -n kube-system create serviceaccount tiller
     kubectl create clusterrolebinding tiller --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
     helm --kube-context "${cluster}" init --service-account tiller
-    kubectl -n kube-system rollout status deploy/tiller-deploy
+    kubectl -n kube-system rollout status deploy/tiller-deploy --timeout=30s
 }
 
 function deploytool_prereqs() {


### PR DESCRIPTION
Seems CI is getting stuck on these sometimes, adding sensible timeouts
so that worst case the CI would fail (but at leaset wont wait for the
job itself to time out)