### PR TITLE
Remove GCC and related packages

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -10,12 +10,11 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor \
-    GOPROXY=https://proxy.golang.org
+    GOPROXY=https://proxy.golang.org CGO_ENABLED=0
 
 # Requirements:
 # Component      | Usage
 # -----------------------------------------------------------
-# gcc            | ginkgo
 # git            | find the workspace root
 # curl           | download other tools
 # moby-engine    | Dapper (Docker)
@@ -35,10 +34,11 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # diffutils      | required for goimports
 # ShellCheck     | shell script linting
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   gcc git-core curl moby-engine make golang kubernetes-client \
+                   git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq golang-x-tools-goimports ShellCheck shflags && \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
+    rpm -e --nodeps gcc cpp binutils binutils-gold && \
     dnf -y clean all && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \


### PR DESCRIPTION
Go can build/test on it's own without GCC.
This frees up around 80MB of the image size.