### PR TITLE
Don't distrosync on image build

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -34,8 +34,7 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # jq             | JSON processing (GitHub API)
 # diffutils      | required for goimports
 # ShellCheck     | shell script linting
-RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
-    dnf -y install --nodocs --setopt=install_weak_deps=False \
+RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq golang-x-tools-goimports ShellCheck shflags && \
     dnf -y remove libsemanage && \


### PR DESCRIPTION
We're getting the updated base image anyhow, and for the base dapper
image (which is not running in production) having the bleeding edge
doesn't really matter.

This should save a bit of time and space on the image building.