### PR TITLE
Upgrade golangci-lint to 1.26

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -2,7 +2,7 @@ FROM fedora:31
 
 ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
-    LINT_VERSION=v1.18.0 \
+    LINT_VERSION=v1.26.0 \
     HELM_VERSION=v2.14.1 \
     KIND_VERSION=v0.6.1 \
     SUBCTL_VERSION=v0.3.0-rc2 \
@@ -41,7 +41,7 @@ RUN dnf -y distrosync --nodocs --setopt=install_weak_deps=False && \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \
-    curl -L https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
     mv linux-${ARCH}/helm /usr/bin/ && chmod a+x /usr/bin/helm && rm -rf linux-${ARCH} && \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \

--- a/scripts/validate
+++ b/scripts/validate
@@ -15,5 +15,5 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run
+golangci-lint run --timeout 5m
 


### PR DESCRIPTION
Also switch to the recommended installation procedure (which will
avoid future failures related to expired certificates...), and
increase the timeout (the default, 1 min, is no longer sufficient on
my laptop with this upgrade).

Signed-off-by: Stephen Kitt <skitt@redhat.com>