### PR TITLE
Add --timeout flag to scripts

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -15,7 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - run: make clusters
+      - env:
+          CLUSTERS_ARGS: --timeout 1m
+        run: make clusters
 
       - name: Post Mortem
         if: failure()
@@ -45,8 +47,8 @@ jobs:
 
       - name: Run the deploy script
         env:
-          CLUSTERS_ARGS: ${{ matrix.globalnet }}
-          DEPLOY_ARGS: ${{ matrix.globalnet }} --deploytool ${{ matrix.deploytool }}
+          CLUSTERS_ARGS: ${{ matrix.globalnet }} --timeout 1m
+          DEPLOY_ARGS: ${{ matrix.globalnet }} --deploytool ${{ matrix.deploytool }} --timeout 2m
         run: make deploy
 
       - name: Post Mortem

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ jobs:
   include:
   - env: CMD="make validate"
   - env: CMD="make deploy"
-         CLUSTERS_ARGS="--globalnet"
-         DEPLOY_ARGS="${CLUSTERS_ARGS} --deploytool helm"
+         CLUSTERS_ARGS="--globalnet --timeout 1m"
+         DEPLOY_ARGS="--globalnet --deploytool helm --timeout 2m"
   - env: CMD="make deploy"
+         CLUSTERS_ARGS="--timeout 1m"
+         DEPLOY_ARGS="--timeout 2m"
          RELEASE=true
 
 services:

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -8,6 +8,7 @@ DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm)
 DEFINE_string 'deploytool_broker_args' '' 'Any extra arguments to pass to the deploytool when deploying the broker'
 DEFINE_string 'deploytool_submariner_args' '' 'Any extra arguments to pass to the deploytool when deploying submariner'
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"
+DEFINE_string 'timeout' '5m' "Timeout flag to pass to kubectl when waiting (e.g. 30s)"
 
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -17,8 +18,9 @@ deploytool="${FLAGS_deploytool}"
 deploytool_broker_args="${FLAGS_deploytool_broker_args}"
 deploytool_submariner_args="${FLAGS_deploytool_submariner_args}"
 cluster_settings="${FLAGS_cluster_settings}"
+timeout="${FLAGS_timeout}"
 
-echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}"
+echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}, timeout=${timeout}"
 
 set -em
 

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -88,7 +88,7 @@ function prepare_cluster() {
     local namespace=$1
     [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
     for app in submariner-engine submariner-routeagent submariner-globalnet; do
-        if kubectl wait --for=condition=Ready pods -l "app=$app" -n "$namespace" --timeout=60s > /dev/null 2>&1; then
+        if kubectl wait --for=condition=Ready pods -l "app=$app" -n "$namespace" --timeout="${timeout}" > /dev/null 2>&1; then
             echo "Removing $app pods..."
             kubectl delete pods -n "$namespace" -l "app=$app"
         fi
@@ -102,7 +102,7 @@ function deploy_resource() {
     resource_name=$(basename "$resource_file" ".yaml")
     kubectl apply -f "${resource_file}"
     echo "Waiting for ${resource_name} pods to be ready."
-    kubectl rollout status "deploy/${resource_name}" --timeout=120s
+    kubectl rollout status "deploy/${resource_name}" --timeout="${timeout}"
 }
 
 function remove_resource() {


### PR DESCRIPTION
Seems that on CI a small timeout works fine, but on personal laptops a
bigger one is needed (due to constrained bandwidth).

Added a --timemout flag with default of 5m for clusters and deploy
scripts, and used saner value for the CI.