### PR TITLE
Avoid touching the base layers

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -46,7 +46,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     curl -Lo /usr/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /usr/bin/kind && \
     curl -Lo /go/bin/subctl "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}" && chmod a+x /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    find /usr/bin /go/bin /usr/lib/golang /usr/libexec -type f -executable -size +1M ! -name subctl ! -name hyperkube | xargs upx && \
+    find /usr/bin /go/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name subctl ! -name hyperkube | xargs upx && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 # Copy kubecfg to always run on the shell


### PR DESCRIPTION
When compressing with UPX, avoid touching files which are part of the
underlying layer; this works by comparing files’ ctime to /proc’s,
using /proc as a witness to the time at which the container build
process started (which post-dates the base image’s contents).

Based on an idea by Miguel Angelo Ajo Pelayo and an initial
implementation by Mike Kolesnik.

Signed-off-by: Stephen Kitt <skitt@redhat.com>