### PR TITLE
Revert "Remove GCC and related packages"

### DIFF
--- a/package/Dockerfile.dapper-base
+++ b/package/Dockerfile.dapper-base
@@ -10,11 +10,12 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go GO111MODULE=on PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash GOFLAGS=-mod=vendor \
-    GOPROXY=https://proxy.golang.org CGO_ENABLED=0
+    GOPROXY=https://proxy.golang.org
 
 # Requirements:
 # Component      | Usage
 # -----------------------------------------------------------
+# gcc            | needed by `go test -race` (https://github.com/golang/go/issues/27089)
 # git            | find the workspace root
 # curl           | download other tools
 # moby-engine    | Dapper (Docker)
@@ -34,11 +35,10 @@ ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARC
 # diffutils      | required for goimports
 # ShellCheck     | shell script linting
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   git-core curl moby-engine make golang kubernetes-client \
+                   gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq golang-x-tools-goimports ShellCheck shflags && \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
-    rpm -e --nodeps gcc cpp binutils binutils-gold && \
     dnf -y clean all && \
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     curl "https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \


### PR DESCRIPTION
This reverts commit 8b3aae107c0249099fd14e7aa66cc234f80838a7.

This is due to GCC being required by `go test -race`.
See also https://github.com/golang/go/issues/27089