### PR TITLE
Use nettest image for netshoot pod

### DIFF
--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -47,7 +47,7 @@ func (f *Framework) NewNetShootDeployment(cluster ClusterIndex) *corev1.PodList 
 					Containers: []corev1.Container{
 						{
 							Name:            "netshoot",
-							Image:           "nicolaka/netshoot",
+							Image:           "quay.io/submariner/nettest",
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"sleep", "600",


### PR DESCRIPTION
Since PR #157 added a slim "netshoot" image, use that for the
framework's testing instead of the full blown one.