### PR TITLE
Use nginx-unprivileged container images

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: nginx:alpine
+          image: nginxinc/nginx-unprivileged:stable-alpine
           ports:
-            - containerPort: 80
+            - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -30,6 +30,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80
+      targetPort: 8080
   selector:
     app: nginx-demo

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -65,7 +65,7 @@ func (f *Framework) NewNetShootDeployment(cluster ClusterIndex) *corev1.PodList 
 
 func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 	var replicaCount int32 = 1
-	var port int32 = 80
+	var port int32 = 8080
 	nginxDeployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nginx-demo",
@@ -87,7 +87,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "nginx:alpine",
+							Image:           "nginxinc/nginx-unprivileged:stable-alpine",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -67,7 +67,7 @@ func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
 					Protocol: corev1.ProtocolTCP,
 					TargetPort: intstr.IntOrString{
 						Type:   intstr.Int,
-						IntVal: 80,
+						IntVal: 8080,
 					},
 				},
 			},


### PR DESCRIPTION
To support root-less deployment, use an unprivileged container image.
It exposes nginx on 8080 instead of 80.