### PR TITLE
Allow deploying two clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ifneq (,$(DAPPER_HOST_ARCH))
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings
 CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
-E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) cluster2 cluster3
+E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) cluster1 cluster2
 
 include $(SHIPYARD_DIR)/Makefile.inc
 

--- a/scripts/cluster_settings
+++ b/scripts/cluster_settings
@@ -1,9 +1,10 @@
 . "${SCRIPTS_DIR}"/lib/source_only
 
 # For shipyard we need a very minimal setup to verify the deployment works
-cluster_nodes['cluster1']="control-plane"
+clusters=('cluster1' 'cluster2')
+cluster_nodes['cluster1']="control-plane worker"
 cluster_nodes['cluster2']="control-plane worker"
-cluster_nodes['cluster3']="control-plane worker"
 
-# Don't install submariner where we don't need it
-cluster_subm['cluster1']="false"
+cluster_cni=( ['cluster1']="weave" ['cluster2']="weave" )
+
+cluster_subm=( ['cluster1']="true" ['cluster2']="true" )

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -51,11 +51,10 @@ run_subm_clusters prepare_cluster "$SUBM_NS"
 with_context $broker setup_broker
 install_subm_all_clusters
 
-deploytool_postreqs
-
-if [ "${#clusters[@]}" -gt 2 ]; then
-    with_context "${clusters[1]}" connectivity_tests
+if [ "${#cluster_subm[@]}" -gt 1 ]; then
+    cls=(${!cluster_subm[@]})
+    with_context "${cls[0]}" connectivity_tests "${cls[1]}"
 else
-    echo "Not executing connectivity tests - requires at least 3 clusters"
+    echo "Not executing connectivity tests - requires at least two clusters with submariner installed"
 fi
 

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -52,7 +52,7 @@ function test_connection() {
     local source_pod=$1
     local target_address=$2
 
-    echo "Attempting connectivity between clusters - $source_pod (${clusters[1]}) --> $target_address (service on ${clusters[2]})"
+    echo "Attempting connectivity between clusters - $source_pod --> $target_address"
     if ! kubectl exec "${source_pod}" -- curl --output /dev/null -m 30 --silent --head --fail "${target_address}"; then
         return 1
     fi
@@ -61,17 +61,18 @@ function test_connection() {
 }
 
 function connectivity_tests() {
+    target_cluster="$1"
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
-    with_context "${clusters[2]}" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
+    with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 
     local netshoot_pod nginx_svc_ip
     netshoot_pod=$(kubectl get pods -l app=netshoot | awk 'FNR == 2 {print $1}')
-    nginx_svc_ip=$(with_context "${clusters[2]}" get_svc_ip nginx-demo)
+    nginx_svc_ip=$(with_context "$target_cluster" get_svc_ip nginx-demo)
 
     with_retries 5 test_connection "$netshoot_pod" "$nginx_svc_ip"
 
     remove_resource "${RESOURCES_DIR}/netshoot.yaml"
-    with_context "${clusters[2]}" remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"
+    with_context "$target_cluster" remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 }
 
 function add_subm_gateway_label() {

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -88,8 +88,3 @@ function helm_install_subm() {
 function install_subm_all_clusters() {
     run_subm_clusters helm_install_subm
 }
-
-function deploytool_postreqs() {
-    # This function must exist for parity with Operator deploys, but does nothing for Helm
-    :
-}

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -55,10 +55,3 @@ function subctl_install_subm() {
 function install_subm_all_clusters() {
     run_subm_clusters subctl_install_subm
 }
-
-function deploytool_postreqs() {
-    # FIXME: Make this unnecessary using subctl v0.0.4 --no-label flag
-    # subctl wants a gateway node labeled, or it will ask, but this script is not interactive,
-    # and E2E expects cluster1 to not have the gateway configured at start, so we remove it
-    with_context cluster1 del_subm_gateway_label
-}

--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -2,7 +2,6 @@
 
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
-source ${SCRIPTS_DIR}/lib/cluster_settings
 
 ### Functions ###
 
@@ -23,4 +22,5 @@ function post_analyze() {
 ### Main ###
 
 declare_kubeconfig
+clusters=($(kind get clusters))
 run_sequential "${clusters[*]}" post_analyze

--- a/test/scripts/post_mortem/test.sh
+++ b/test/scripts/post_mortem/test.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-source ${SCRIPTS_DIR}/lib/cluster_settings
 source ${SCRIPTS_DIR}/lib/debug_functions
 source ${SCRIPTS_DIR}/lib/utils
 
@@ -20,7 +19,8 @@ function deploy_deadshoot() {
 }
 
 declare_kubeconfig
-run_all_clusters deploy_deadshoot
+clusters=($(kind get clusters))
+run_parallel "${clusters[*]}" deploy_deadshoot
 
 post_mortem=$(make post-mortem)
 echo "$post_mortem"


### PR DESCRIPTION
Allow deploying only two clusters (with broker running on one of them).
This will benefit projects such as Shipyard, Lighthouse and others that
don't really need a 3 cluster setup.

The default remains 3 clusters, but now its possible to override to only
deploy 2.

Closes #138 