### PR TITLE
Validate globalIP annotation for Pods when using globalnet

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -44,8 +44,8 @@ func (f *Framework) DeletePod(cluster ClusterIndex, podName string, namespace st
 	}, NoopCheckResult)
 }
 
-// AwaitPodByAnnotation queries the Pod and looks for the presence of annotation.
-func (f *Framework) AwaitPodByAnnotation(cluster ClusterIndex, annotation string, podName string, namespace string) *v1.Pod {
+// AwaitUntilAnnotationOnPod queries the Pod and looks for the presence of annotation.
+func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation string, podName string, namespace string) *v1.Pod {
 	return AwaitUntil("get "+annotation+" annotation for pod "+podName, func() (interface{}, error) {
 		pod, err := KubeClients[cluster].CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -41,4 +42,25 @@ func (f *Framework) DeletePod(cluster ClusterIndex, podName string, namespace st
 	AwaitUntil("delete pod", func() (interface{}, error) {
 		return nil, KubeClients[cluster].CoreV1().Pods(namespace).Delete(podName, &metav1.DeleteOptions{})
 	}, NoopCheckResult)
+}
+
+// AwaitPodByAnnotation queries the Pod and looks for the presence of annotation.
+func (f *Framework) AwaitPodByAnnotation(cluster ClusterIndex, annotation string, podName string, namespace string) *v1.Pod {
+	return AwaitUntil("get "+annotation+" annotation for pod "+podName, func() (interface{}, error) {
+		pod, err := KubeClients[cluster].CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return pod, err
+	}, func(result interface{}) (bool, string, error) {
+		if result == nil {
+			return false, "No Pod found", nil
+		}
+
+		pod := result.(*v1.Pod)
+		if pod.GetAnnotations()[annotation] == "" {
+			return false, fmt.Sprintf("Pod %q does not have annotation %q yet", podName, annotation), nil
+		}
+		return true, "", nil
+	}).(*v1.Pod)
 }

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -92,8 +92,8 @@ func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
 	}, NoopCheckResult)
 }
 
-// AwaitServiceByAnnotation queries the service and looks for the presence of annotation.
-func (f *Framework) AwaitServiceByAnnotation(cluster ClusterIndex, annotation string, svcName string, namespace string) *v1.Service {
+// AwaitUntilAnnotationOnService queries the service and looks for the presence of annotation.
+func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation string, svcName string, namespace string) *v1.Service {
 	return AwaitUntil("get"+annotation+" annotation for service "+svcName, func() (interface{}, error) {
 		service, err := KubeClients[cluster].CoreV1().Services(namespace).Get(svcName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -116,7 +116,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 		if p.ToEndpointType == GlobalIP {
 			// Wait for the globalIP annotation on the service.
-			service = p.Framework.AwaitServiceByAnnotation(p.ToCluster, globalnetGlobalIPAnnotation, service.Name, service.Namespace)
+			service = p.Framework.AwaitUntilAnnotationOnService(p.ToCluster, globalnetGlobalIPAnnotation, service.Name, service.Namespace)
 			remoteIP = service.GetAnnotations()[globalnetGlobalIPAnnotation]
 		}
 	}
@@ -137,7 +137,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	sourceIP := connectorPod.Pod.Status.PodIP
 	if p.ToEndpointType == GlobalIP {
 		// Wait for the globalIP annotation on the connectorPod.
-		connectorPod.Pod = p.Framework.AwaitPodByAnnotation(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
+		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
 		sourceIP = connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
 	}
 

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -134,6 +134,15 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		Networking:         p.Networking,
 	})
 
+	sourceIP := connectorPod.Pod.Status.PodIP
+	if p.ToEndpointType == GlobalIP {
+		// Wait for the globalIP annotation on the connectorPod.
+		connectorPod.Pod = p.Framework.AwaitPodByAnnotation(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
+		sourceIP = connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
+	}
+
+	framework.Logf("Will send traffic from IP: %v", sourceIP)
+
 	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
 	listenerPod.AwaitFinish()
 


### PR DESCRIPTION
In this PR, we validate the globalIP annotation on the connectorPod
as part of e2e tests.

Partially fixes# https://github.com/submariner-io/submariner/issues/544

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>