### PR TITLE
Fix KUBECONFIG var export help at end of deploys

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -132,7 +132,7 @@ function print_clusters_message() {
     cat << EOM
 Your virtual cluster(s) are deployed and working properly and can be accessed with:
 
-export KUBECONFIG=\$(find \$(git rev-parse --show-toplevel)/output/kubeconfigs/ -type f | -printf %p:)
+export KUBECONFIG=\$(find \$(git rev-parse --show-toplevel)/output/kubeconfigs/ -type f -printf %p:)
 
 $ kubectl config use-context cluster1 # or cluster2, cluster3..
 


### PR DESCRIPTION
Remove stray pipe in the KUBECONFIG env var export help message printed
at the end of deployments.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>