### PR TITLE
Provide a ServiceExport resource file for other projects to use

### DIFF
--- a/scripts/shared/resources/nginx-demo-export.yaml
+++ b/scripts/shared/resources/nginx-demo-export.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: lighthouse.submariner.io/v2alpha1
+kind: ServiceExport
+metadata:
+  name: nginx-demo


### PR DESCRIPTION
Lighthouse now expects a ServiceExport along with the service
to make the service exported.

Fixes-Issue: #182
Depends-On: https://github.com/submariner-io/shipyard/issues/182