### PR TITLE
Increase go test timeout to 15 mins

### DIFF
--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -53,7 +53,7 @@ function test_with_e2e_tests {
 
     go test -v -args -ginkgo.v -ginkgo.randomizeAllSpecs \
         -submariner-namespace $SUBM_NS $(generate_context_flags) \
-        -ginkgo.reportPassed \
+        -ginkgo.reportPassed -test.timeout 15m \
         -ginkgo.focus "\[${focus}\]" \
         -ginkgo.reportFile ${DAPPER_OUTPUT}/e2e-junit.xml 2>&1 | \
         tee ${DAPPER_OUTPUT}/e2e-tests.log


### PR DESCRIPTION
Currently, we are not configuring any timeout while running the e2e
tests, so the default timeout of 10 minutes is used. However, it
was seen that since we are now running more number of tests, at times,
the tests are unable to complete its execution in 10 mins and because
of this the test is abruptly stopped with PANIC. This PR explicitly
configures the timeout to 15 mins to give sufficient time for tests
to run.

Fixes Issue: https://github.com/submariner-io/submariner/issues/593
Partially fixes: https://github.com/submariner-io/submariner/issues/544

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>