### PR TITLE
Increase go test timeout

### DIFF
--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -51,7 +51,7 @@ function generate_context_flags() {
 function test_with_e2e_tests {
     cd ${DAPPER_SOURCE}/test/e2e
 
-    go test -v -args -ginkgo.v -ginkgo.randomizeAllSpecs \
+    go test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs \
         -submariner-namespace $SUBM_NS $(generate_context_flags) \
         -ginkgo.reportPassed \
         -ginkgo.focus "\[${focus}\]" \


### PR DESCRIPTION
go test has a default 10-minute timeout, which is insufficient to
complete the test suite when some tests fail. When the timeout is
reached, go test panics, which means the overall test results aren’t
presented even partially.

This patch increases the timeout to 30 minutes.

Signed-off-by: Stephen Kitt <skitt@redhat.com>