### PR TITLE
Use GITHUB_SHA if available

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,5 +34,5 @@ jobs:
           RELEASE_ARGS: shipyard-dapper-base nettest
           dapper_image_flags: --nocache
         run: |
-          [[ $GITHUB_REF =~ "/tags/" ]] && RELEASE_ARGS+="--tag ${GITHUB_REF##*/}"
+          [[ $GITHUB_REF =~ "/tags/" ]] && RELEASE_ARGS+=" --tag ${GITHUB_REF##*/}"
           make dapper-image nettest release

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -3,7 +3,7 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'tag' '' "Additional tag to use for the image (prefix 'v' will be stripped)"
+DEFINE_string 'tag' 'latest' "Additional tag to use for the image (prefix 'v' will be stripped)"
 DEFINE_string 'repo' '' "Quay.io repo to deploy to"
 FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"
 FLAGS "$@" || exit $?
@@ -24,13 +24,15 @@ source ${SCRIPTS_DIR}/lib/version
 
 function release_image() {
     local image=$1
-    local images=("${image}:${TRAVIS_COMMIT:0:7}" "${image}:${release_tag#v}")
+    local images=("${image}:${commit_hash:0:7}" "${image}:${release_tag#v}")
 
     for target_image in "${images[@]}"; do
         docker tag ${image}:${VERSION} ${target_image}
         docker push ${target_image}
     done
 }
+
+commit_hash=${GITHUB_SHA:-${TRAVIS_COMMIT}}
 
 echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
 for image in "$@"; do


### PR DESCRIPTION
To support GitHub Actions release, need to use the SHA from there.

Also added space for tag in case it's needed (otherwise it'll fail)