### PR TITLE
Return bool result on RunE2ETests

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -44,7 +44,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	// Run only Ginkgo on node 1
 })
 
-func RunE2ETests(t *testing.T) {
+func RunE2ETests(t *testing.T) bool {
 	framework.ValidateFlags(framework.TestContext)
 
 	gomega.RegisterFailHandler(ginkgo.Fail)
@@ -61,7 +61,7 @@ func RunE2ETests(t *testing.T) {
 		// Create the directory if it doesn't already exists
 		if err := os.MkdirAll(reportDir, 0755); err != nil {
 			t.Fatalf("Failed creating jUnit report directory: %v", err)
-			return
+			return false
 		}
 	}
 	// Configure a junit reporter to write to the directory
@@ -70,5 +70,5 @@ func RunE2ETests(t *testing.T) {
 		config.GinkgoConfig.ParallelNode)
 	junitPath := filepath.Join(reportDir, junitFile)
 	reporterList = append(reporterList, reporters.NewJUnitReporter(junitPath))
-	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Submariner E2E suite", reporterList)
+	return ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "Submariner E2E suite", reporterList)
 }


### PR DESCRIPTION
This will allow subctl verify connectivity to return an exit error when
tests don't pass.