### PR TITLE
Dump kubeproxy and globalnet logs in post_mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -7,7 +7,7 @@ source ${SCRIPTS_DIR}/lib/utils
 
 function post_analyze() {
     echo "======================= Post mortem $cluster ======================="
-    kubectl get all -A
+    kubectl get all --all-namespaces
     for pod in $(kubectl get pods -A | tail -n +2 | grep -v Running | sed 's/  */;/g'); do
         ns=$(echo $pod | cut -f1 -d';')
         name=$(echo $pod | cut -f2 -d';')
@@ -15,6 +15,21 @@ function post_analyze() {
         kubectl -n $ns describe pod $name
         kubectl -n $ns logs $name
         echo "===================== END $name - $ns =========================="
+    done
+
+    # TODO (revisit): The following is added to debug intermittent globalnet failures.
+    namespace="kube-system"
+    for pod in $(kubectl get pods --selector=k8s-app=kube-proxy -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+        echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
+        kubectl -n $namespace logs $pod
+    done
+
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+
+    namespace="submariner-operator"
+    for pod in $(kubectl get pods --selector=app=submariner-globalnet -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+        echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
+        kubectl -n $namespace logs $pod
     done
     echo "===================== END Post mortem $cluster ====================="
 }


### PR DESCRIPTION
We are seeing some occasional failures in globalnet jobs and need the
logs of kube-proxy and globalnet pods to understand the reasons for
failure. In a separate PR we can enhance the post-mortem function to
capture the required logs.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>