### PR TITLE
Add make flag `using=` to pass options

### DIFF
--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -39,16 +39,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        globalnet: ['', '--globalnet']
+        globalnet: ['', 'globalnet']
         deploytool: ['operator', 'helm']
     steps:
       - uses: actions/checkout@master
 
       - name: Run the deploy script
         env:
-          CLUSTERS_ARGS: ${{ matrix.globalnet }} --timeout 1m
-          DEPLOY_ARGS: ${{ matrix.globalnet }} --deploytool ${{ matrix.deploytool }} --timeout 2m
-        run: make deploy
+          CLUSTERS_ARGS: --timeout 1m
+          DEPLOY_ARGS: --timeout 2m
+        run: make deploy using="${{ matrix.globalnet }} ${{ matrix.deploytool }}"
 
       - name: Post Mortem
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ ifneq (,$(DAPPER_HOST_ARCH))
 # Running in Dapper
 
 CLUSTER_SETTINGS_FLAG = --cluster_settings $(DAPPER_SOURCE)/scripts/cluster_settings
-CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
-DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
-E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) cluster1 cluster2
+override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
+override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
+override E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) cluster1 cluster2
 
 include $(SHIPYARD_DIR)/Makefile.inc
 

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -10,10 +10,6 @@
 	@./.dapper.tmp -v
 	@mv .dapper.tmp .dapper
 
-# Prevent passing variable definitions through MAKEFLAGS
-# (rely on the environment instead)
-MAKEOVERRIDES =
-
 %: .dapper
 	+./.dapper -m bind make $@ $(MAKEFLAGS)
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,7 +1,22 @@
 release_tag ?= latest
 repo ?= quay.io/submariner
+, := ,
+_using = $(subst $(,), ,$(using))
 
 SCRIPTS_DIR ?= /opt/shipyard/scripts
+
+# Process extra flags from the `using=a,b,c` optional flag
+
+ifneq (,$(filter globalnet,$(_using)))
+override CLUSTERS_ARGS += --globalnet
+override DEPLOY_ARGS += --globalnet
+endif
+
+ifneq (,$(filter helm,$(_using)))
+override DEPLOY_ARGS += --deploytool helm
+endif
+
+# Shipyard provided targets
 
 cleanup:
 	$(SCRIPTS_DIR)/cleanup.sh


### PR DESCRIPTION
Added a flag that can be sent to make to specify additional options
more easily, e.g.
`using=globalnet,helm`

This also exposes a more friendly `$(_using)` make variable that can be
used by other projects as well.