### PR TITLE
Log sourceIP (aka globalIp) only for globalnet jobs

### DIFF
--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -134,14 +134,12 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		Networking:         p.Networking,
 	})
 
-	sourceIP := connectorPod.Pod.Status.PodIP
 	if p.ToEndpointType == GlobalIP {
 		// Wait for the globalIP annotation on the connectorPod.
 		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
-		sourceIP = connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
+		sourceIP := connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
+		framework.Logf("Will send traffic from IP: %v", sourceIP)
 	}
-
-	framework.Logf("Will send traffic from IP: %v", sourceIP)
 
 	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
 	listenerPod.AwaitFinish()


### PR DESCRIPTION
In the non-globalnet CI jobs, an empty message as shown below
is getting logged. This is because, we are trying to retrieve
the podIP immediately after the Pod is scheduled. Since we are
capturing the connector pod IP in subsequent logs, this PR
modifies the existing log to be displayed only when Globalnet
is used.

"Will send traffic from IP: "

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>