### PR TITLE
Validate globalIp annotation only for regular Pods

### DIFF
--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -135,7 +135,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	})
 
 	sourceIP := connectorPod.Pod.Status.PodIP
-	if p.ToEndpointType == GlobalIP {
+	if p.ToEndpointType == GlobalIP && p.Networking == framework.PodNetworking {
 		// Wait for the globalIP annotation on the connectorPod.
 		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
 		sourceIP = connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]


### PR DESCRIPTION
Globalnet does not annotate Pods that use HostNetworking, so the
validation for the globalIp annotation on the Pods should be done
only for regular pods.

Related to: https://github.com/submariner-io/shipyard/issues/200

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>