### PR TITLE
Output engine logs, and Gateway status on postmortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -31,6 +31,17 @@ function post_analyze() {
         echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
         kubectl -n $namespace logs $pod
     done
+
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+
+    for pod in $(kubectl get pods --selector=app=submariner-engine -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+        echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
+        kubectl -n $namespace logs $pod
+    done
+
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+    kubectl get Gateway -A -o yaml
+
     echo "===================== END Post mortem $cluster ====================="
 }
 


### PR DESCRIPTION
Sometimes we experience failed jobs [1] and the existing logs
don't show any clue of what happened. This commit includes
the submariner engine logs as well as the Gateway status
which will contain the list of the active connections.

[1] https://github.com/submariner-io/submariner/runs/741639885#step:5:1391