### PR TITLE
Remove the --no-dataplane deprecated flag call

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -26,7 +26,6 @@ function setup_broker() {
         cd "${OUTPUT_DIR}" && \
         subctl deploy-broker \
                --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
-               --no-dataplane \
                ${gn} \
                ${deploytool_broker_args}
     )


### PR DESCRIPTION
During subctl deploy-broker we pass down the --no-dataplane
flag which was deprecated and it's being removed now. This
commit removes the flag usage.