### PR TITLE
Add using-flag support for OLM deploys

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -16,6 +16,10 @@ ifneq (,$(filter helm,$(_using)))
 override DEPLOY_ARGS += --deploytool helm
 endif
 
+ifneq (,$(filter olm,$(_using)))
+override CLUSTERS_ARGS += --olm true
+endif
+
 # Shipyard provided targets
 
 cleanup:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -17,7 +17,7 @@ override DEPLOY_ARGS += --deploytool helm
 endif
 
 ifneq (,$(filter olm,$(_using)))
-override CLUSTERS_ARGS += --olm true
+override CLUSTERS_ARGS += --olm
 endif
 
 # Shipyard provided targets


### PR DESCRIPTION
Support shortcut `using=olm` for `CLUSTERS_ARGS="--olm true"`.

Relates-to: submariner-io/submariner-operator#373
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>