### PR TITLE
Use simple `dev` version for locally built image

### DIFF
--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -2,14 +2,10 @@
 
 source ${SCRIPTS_DIR}/lib/version
 
-ARCH=${ARCH:-"amd64"}
-SUFFIX=""
-[ "${ARCH}" != "amd64" ] && SUFFIX="_${ARCH}"
-
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'tag' "${VERSION}${SUFFIX}" "Tag to set for the local image"
+DEFINE_string 'tag' "${DEV_VERSION}" "Tag to set for the local image"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to use for the image"
 DEFINE_string 'image' '' "Image name to build" 'i'
 DEFINE_string 'dockerfile' '' "Dockerfile to build from" 'f'

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -6,7 +6,7 @@
 
 function import_image() {
     local orig_image=$1
-    local versioned_image="$1:$VERSION"
+    local versioned_image="$1:${DEV_VERSION}"
     local local_image="localhost:5000/${orig_image##*/}:local"
     if ! docker tag "${versioned_image}" "${local_image}"; then
         # The project doesn't build this image, pull it

--- a/scripts/shared/lib/version
+++ b/scripts/shared/lib/version
@@ -7,10 +7,11 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 git_tag=$(git tag -l --contains HEAD | head -n 1)
+readonly DEV_VERSION="dev"
 
 # shellcheck disable=SC2034 # VERSION is used in other scripts which source this one
 if [[ -z "$dirty" && -n "$git_tag" ]]; then
     readonly VERSION=$git_tag
 else
-    readonly VERSION="dev"
+    readonly VERSION="$DEV_VERSION"
 fi

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -27,7 +27,7 @@ function release_image() {
     local images=("${image}:${commit_hash:0:7}" "${image}:${release_tag#v}")
 
     for target_image in "${images[@]}"; do
-        docker tag ${image}:${VERSION} ${target_image}
+        docker tag ${image}:${DEV_VERSION} ${target_image}
         docker push ${target_image}
     done
 }


### PR DESCRIPTION
The scripts trying to deduce a version can cause confusing failures due
to undeterministic behavior.

Instead, to build and release an image use a simple $DEV_VERSION
constant which is set to an arbitrary & simple value.