### PR TITLE
Add GHA check for go.mod & go.sum being up to date

### DIFF
--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v**'
+
+name: Tidyness Validation
+jobs:
+  tidy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - run: make tidy
+      - name: Check that go.mod and go.sum files are up to date
+        run: |
+          [ -n "$(git status --porcelain --untracked-files=no)" ] || exit 0
+          git diff
+          echo "##[error] The go.mod and/or go.sum files are out of date, please run 'make tidy' and update your changes"
+          exit 1

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ else
 include Makefile.images
 
 # Shipyard-specific starts
-clusters deploy e2e nettest post-mortem release unit-test validate: dapper-image
+clusters deploy e2e nettest post-mortem release tidy unit-test validate: dapper-image
 
 dapper-image: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -41,6 +41,9 @@ release:
 post-mortem:
 	$(SCRIPTS_DIR)/post_mortem.sh
 
+tidy:
+	go mod tidy && go mod vendor
+
 unit-test: vendor/modules.txt
 	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
 


### PR DESCRIPTION
This check makes sure go.mod and go.sum are up to date for the code.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>