### PR TITLE
Use `git describe` to get a coherent version

### DIFF
--- a/scripts/shared/lib/version
+++ b/scripts/shared/lib/version
@@ -2,16 +2,6 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
-if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-    dirty="-dirty"
-fi
-
-git_tag=$(git tag -l --contains HEAD | head -n 1)
 readonly DEV_VERSION="dev"
-
-# shellcheck disable=SC2034 # VERSION is used in other scripts which source this one
-if [[ -z "$dirty" && -n "$git_tag" ]]; then
-    readonly VERSION=$git_tag
-else
-    readonly VERSION="$DEV_VERSION"
-fi
+# shellcheck disable=SC2034 # VERSION defined here is used elsewhere
+readonly VERSION=$(git describe --tags --dirty="-${DEV_VERSION}" --exclude="devel" --exclude="latest")

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -24,7 +24,7 @@ source ${SCRIPTS_DIR}/lib/version
 
 function release_image() {
     local image=$1
-    local images=("${image}:${commit_hash:0:7}" "${image}:${release_tag#v}")
+    local images=("${image}:${VERSION#v}" "${image}:${release_tag#v}")
 
     for target_image in "${images[@]}"; do
         docker tag ${image}:${DEV_VERSION} ${target_image}


### PR DESCRIPTION
Instead of the tag, or a `dev` value which dont give much information,
use `git describe` to generate a version that gives more information
such as the last tag, how far away is the commit from that tag, and also
a short commit hash and a dirty mark in case the working tree is dirty.

This can then be used to generate binaries with this version which
would be very useful in debugging.

As part of this change, the version is applied to released image tags to
get better information on the image.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>