### PR TITLE
Don't pass . to unit test

### DIFF
--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -9,7 +9,7 @@ echo "Looking for packages to test"
 
 # This can’t be done as simply with parameter substitution
 # shellcheck disable=SC2001
-packages=". $(find_go_pkg_dirs "$@" | sed -e 's![^ ]*!./&/...!g')"
+packages="$(find_go_pkg_dirs "$@" | sed -e 's![^ ]*!./&/...!g')"
 
 echo "Running tests in ${packages}"
 [ "${ARCH}" == "amd64" ] && race=-race


### PR DESCRIPTION
Seems that, other than submariner, no project handles it well, but in
submariner itself it has no effect (since there aren't any tests there).

Simply don't pass it.