### PR TITLE
Need to fetch the tags in order for the release to work

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Release the images
         env:


### PR DESCRIPTION
Since we're using `git describe`, we need the CI to fetch everything
including the tags (it only fetches the specific commit by default).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>