### PR TITLE
Use more precise arguments in unit test

### DIFF
--- a/scripts/shared/lib/find_functions
+++ b/scripts/shared/lib/find_functions
@@ -1,11 +1,21 @@
 # shellcheck shell=bash
-function find_go_pkg_dirs() {
-    local find_exclude excluded_dirs="${*} vendor .git .trash-cache bin"
+function _find_pkg_dirs() {
+    local find_exclude
+    excluded_dirs+=" vendor .git .trash-cache bin"
 
     for dir in $excluded_dirs; do
         find_exclude+=" -path ./$dir -prune -o"
     done
 
     # shellcheck disable=SC2086
-    find . ${find_exclude} -path './*/*.go' -print | cut -f2 -d/ | sort -u
+    find . ${find_exclude} -path "$1" -printf "%h\n" | sort -u
+}
+
+function find_go_pkg_dirs() {
+    _find_pkg_dirs "./*/*.go"
+}
+
+function find_unit_test_dirs() {
+    local excluded_dirs="${*}"
+    _find_pkg_dirs "./*/*_test.go"
 }

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -7,9 +7,7 @@ source ${SCRIPTS_DIR}/lib/find_functions
 
 echo "Looking for packages to test"
 
-# This can’t be done as simply with parameter substitution
-# shellcheck disable=SC2001
-packages="$(find_go_pkg_dirs "$@" | sed -e 's![^ ]*!./&/...!g')"
+packages="$(find_unit_test_dirs "$@")"
 
 echo "Running tests in ${packages}"
 [ "${ARCH}" == "amd64" ] && race=-race


### PR DESCRIPTION
Intead of blindly sending the top level firectory and letting `go test`
find out the directories (and possibly include ignored ones), act only
on the directories we find to contain unit tests.