### PR TITLE
Fix connector pod implementation in e2e tests

### DIFF
--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -141,11 +141,11 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		framework.Logf("Will send traffic from IP: %v", sourceIP)
 	}
 
-	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
-	listenerPod.AwaitFinish()
-
 	By(fmt.Sprintf("Waiting for the connector pod %q to exit, returning what connector sent", connectorPod.Pod.Name))
 	connectorPod.AwaitFinish()
+
+	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
+	listenerPod.AwaitFinish()
 
 	framework.Logf("Connector pod has IP: %s", connectorPod.Pod.Status.PodIP)
 


### PR DESCRIPTION
Currently, as part of e2e tests, as soon as Connector pod is
scheduled, it tries to connect to the listener pod with a wait
interval configured in CONN_TIMEOUT (defaults to 18 secs).

However, in some scenarios, if there is any error while accessing
the remote server, the current logic does not wait for 18 secs
before retrying for the next time. So, all the CONN_TRIES seem
to happen one after the other and the test-case is marked as failed.

This is seen with Globalnet jobs where it takes time for the
ingress/egress rules to programmed on the Gateway nodes.

In this PR, we sleep for RETRY_SLEEP duration between retries,
where RETRY_SLEEP is half of ConnectionTimeout interval.

Example:
Waiting for the connector pod "tcp-check-pod5rfhb" to exit, returning what connector sent
INFO: Pod "tcp-check-pod5rfhb" output:
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host
nc: 169.254.2.13 (169.254.2.13:1234): No route to host

Fixes issue: https://github.com/submariner-io/shipyard/issues/231

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>