### PR TITLE
Run tests with gingko -trace option

### DIFF
--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -51,7 +51,7 @@ function generate_context_flags() {
 function test_with_e2e_tests {
     cd ${DAPPER_SOURCE}/test/e2e
 
-    go test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs \
+    go test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace\
         -submariner-namespace $SUBM_NS $(generate_context_flags) \
         -ginkgo.reportPassed -test.timeout 15m \
         -ginkgo.focus "\[${focus}\]" \

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -13,4 +13,4 @@ packages="$(find_go_pkg_dirs "$@" | sed -e 's![^ ]*!./&/...!g')"
 
 echo "Running tests in ${packages}"
 [ "${ARCH}" == "amd64" ] && race=-race
-go test -v ${race} -cover ${packages} -ginkgo.reportPassed -ginkgo.reportFile junit.xml
+go test -v ${race} -cover ${packages} -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml


### PR DESCRIPTION
This will print out the full stack trace for each failure and not
just the line number of the failure which most of the time isn't
very useful especially when the failure occurs in nested generic code.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>