### PR TITLE
Tag latest stable image as `latest`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,5 +36,5 @@ jobs:
           RELEASE_ARGS: shipyard-dapper-base nettest
           IMAGES_ARGS: --nocache
         run: |
-          [[ $GITHUB_REF =~ "/tags/" ]] && RELEASE_ARGS+=" --tag ${GITHUB_REF##*/}"
+          [[ $GITHUB_REF =~ "/tags/" ]] && RELEASE_ARGS+=" --tag \"${GITHUB_REF##*/} latest\""
           make dapper-image nettest release


### PR DESCRIPTION
As https://github.com/submariner-io/shipyard/pull/235 defines that
`devel` is now used to tag latest development images, tag the latest
stable released image with `latest`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>