### PR TITLE
Add E2E job to test consuming projects

### DIFF
--- a/.github/workflows/e2e-consuming.yaml
+++ b/.github/workflows/e2e-consuming.yaml
@@ -1,12 +1,15 @@
 on:
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
 
 name: E2E Tests (Consuming Projects)
 jobs:
   e2e:
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'test-projects')
+    if: |
+      ( github.event.action == 'labeled' && github.event.label.name == 'test-projects' )
+      || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'test-projects') )
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-consuming.yaml
+++ b/.github/workflows/e2e-consuming.yaml
@@ -1,0 +1,48 @@
+on:
+  pull_request:
+
+name: E2E Tests (Consuming Projects)
+jobs:
+  e2e:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'test-projects')
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ['submariner', 'submariner-operator', 'lighthouse']
+        deploytool: ['operator', 'helm']
+        exclude:
+          - project: submariner-operator
+            deploytool: helm
+    steps:
+      - name: Checkout the Shipyard repository
+        uses: actions/checkout@master
+
+      - name: Reclaim free space!
+        run: |
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          df -h
+          free -h
+
+      - name: Built the latest Shipyard image
+        run: make dapper-image
+
+      - name: Checkout the ${{ matrix.project }} repository
+        uses: actions/checkout@master
+        with:
+          repository: submariner-io/${{ matrix.project }}
+
+      - name: Make sure ${{ matrix.project }} is using the built Shipyard image
+        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
+
+      - name: Run E2E deployment and tests
+        run: make e2e using=${{ matrix.deploytool }}
+
+      - name: Post Mortem
+        if: failure()
+        run: |
+          df -h
+          free -h
+          make post-mortem


### PR DESCRIPTION
This job will run if the PR is labeled with `test-projects` and will
make sure to check out the consuming projects and run them with the
latest Shipyard image that includes the PR contents.

Resolves #211 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>