### PR TITLE
Release by default to 'devel' image tag

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,5 +1,3 @@
-release_tag ?= latest
-repo ?= quay.io/submariner
 , := ,
 _using = $(subst $(,), ,$(using))
 
@@ -36,7 +34,7 @@ e2e:
 	$(SCRIPTS_DIR)/e2e.sh $(E2E_ARGS)
 
 release:
-	$(SCRIPTS_DIR)/release.sh --tag $(release_tag) --repo $(repo) $(release_images) $(RELEASE_ARGS)
+	$(SCRIPTS_DIR)/release.sh $(RELEASE_ARGS)
 
 post-mortem:
 	$(SCRIPTS_DIR)/post_mortem.sh

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -3,8 +3,8 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'tag' 'latest' "Additional tag to use for the image (prefix 'v' will be stripped)"
-DEFINE_string 'repo' '' "Quay.io repo to deploy to"
+DEFINE_string 'tag' 'devel' "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
+DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to deploy to"
 FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -24,9 +24,9 @@ source ${SCRIPTS_DIR}/lib/version
 
 function release_image() {
     local image=$1
-    local images=("${image}:${VERSION#v}" "${image}:${release_tag#v}")
 
-    for target_image in "${images[@]}"; do
+    for target_tag in $VERSION $release_tag; do
+        local target_image="${image}:${target_tag#v}"
         docker tag ${image}:${DEV_VERSION} ${target_image}
         docker push ${target_image}
     done


### PR DESCRIPTION
Since `latest` is commonly used to point to the latest *stable* release
of an image, we better use `devel` to point to the latest image unless
we specify the `latest` tag explicitly when releasing.

Also changed the release script to be able to accept multiple tags.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>