### PR TITLE
Show which golangci-lint linters are enabled

### DIFF
--- a/scripts/shared/validate.sh
+++ b/scripts/shared/validate.sh
@@ -6,6 +6,7 @@ source ${SCRIPTS_DIR}/lib/find_functions
 
 PACKAGES="$(find_go_pkg_dirs) *.go"
 
+# TODO: Use goimports via golangci-lint, enable it via per-repo config files
 if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     echo "Incorrect formatting"
     echo "These are the files with formatting errors:"
@@ -15,5 +16,7 @@ if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
     exit 1
 fi
 
-golangci-lint run --timeout 5m $@
+# Show which golangci-lint linters are enabled/disabled
+golangci-lint linters
 
+golangci-lint run --timeout 5m $@


### PR DESCRIPTION
Makes it more clear what is actually running. Particularly important as
we move to enable non-default linters via per-repo .golangci.yml files.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>