### PR TITLE
Bump golangci-lint version from 1.26.0 to 1.28.0

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -40,7 +40,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube | xargs upx ${UPX_LEVEL} && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
-ENV LINT_VERSION=v1.26.0 \
+ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v2.16.9 \
     KIND_VERSION=v0.7.0 \
     SUBCTL_VERSION=v0.4.0


### PR DESCRIPTION
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>