### PR TITLE
Use BuildKit to build the images

### DIFF
--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -44,8 +44,7 @@ if [[ "$cache" = true ]]; then
 fi
 
 # Rebuild the image to update any changed layers and tag it back so it will be used.
-buildargs_flag=''
-[[ -z "${buildargs}" ]] || buildargs_flag="--build-arg ${buildargs}"
-docker build -t ${local_image} ${cache_flag} -f ${dockerfile} ${buildargs_flag} .
+buildargs_flag='--build-arg BUILDKIT_INLINE_CACHE=1'
+[[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} ${buildargs}"
+DOCKER_BUILDKIT=1 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} ${buildargs_flag} .
 docker tag ${local_image} ${cache_image}
-


### PR DESCRIPTION
This greatly improves caching in my experience. See
https://docs.docker.com/engine/reference/builder/#buildkit and
https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources
for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>