### PR TITLE
Align DEV_VERSION with expected tags

### DIFF
--- a/.github/workflows/e2e-consuming.yaml
+++ b/.github/workflows/e2e-consuming.yaml
@@ -40,7 +40,7 @@ jobs:
           repository: submariner-io/${{ matrix.project }}
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
-        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
+        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:devel/' Dockerfile.dapper
 
       - name: Run E2E deployment and tests
         run: make e2e using=${{ matrix.deploytool }}

--- a/scripts/shared/lib/version
+++ b/scripts/shared/lib/version
@@ -2,6 +2,6 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
-readonly DEV_VERSION="dev"
+readonly DEV_VERSION="devel"
 # shellcheck disable=SC2034 # VERSION defined here is used elsewhere
 readonly VERSION=$(git describe --tags --dirty="-${DEV_VERSION}" --exclude="devel" --exclude="latest")


### PR DESCRIPTION
The “latest” image is now “devel”, but we locally build “latest” and
“dev”, which complicates consuming local images. This changes
DEV_VERSION to “devel” so that we build “devel” images instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>