### PR TITLE
Increase e2e operation timeout

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -51,7 +51,7 @@ func init() {
 	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner", "Namespace in which the submariner components are deployed.")
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18, "The timeout in seconds per connection attempt when verifying communication between clusters.")
 	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7, "The number of connection attempts when verifying communication between clusters.")
-	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 120, "The general operation timeout in seconds.")
+	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 190, "The general operation timeout in seconds.")
 }
 
 func ValidateFlags(t *TestContextType) {


### PR DESCRIPTION
In PR: https://github.com/submariner-io/shipyard/pull/229,
the connectorPod behavior is modified to sleep for an
additional RETRY_SLEEP duration between ConnectionAttempts.
When there are any connectivity/datapath issues, the Pod
would take some additional time to finish.
In AwaitFinish/AwaitResultOrError APIs, we wait for
TestContext.OperationTimeout for the Pod to report its status.
Ideally the TestContext.OperationTimeout should account for
this delay.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>