### PR TITLE
Import the cutting edge image if its not built

### DIFF
--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -29,7 +29,6 @@ set -e
 
 local_image=${repo}/${image}:${tag}
 cache_image=${repo}/${image}:${CUTTING_EDGE}
-latest_image=${repo}/${image}:latest
 
 # When using cache pull latest image from the repo, so that it's layers may be reused.
 cache_flag=''
@@ -48,5 +47,5 @@ fi
 buildargs_flag=''
 [[ -z "${buildargs}" ]] || buildargs_flag="--build-arg ${buildargs}"
 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} ${buildargs_flag} .
-docker tag ${local_image} ${latest_image}
+docker tag ${local_image} ${CUTTING_EDGE}
 

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -28,7 +28,7 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 set -e
 
 local_image=${repo}/${image}:${tag}
-cache_image=${repo}/${image}:devel
+cache_image=${repo}/${image}:${CUTTING_EDGE}
 latest_image=${repo}/${image}:latest
 
 # When using cache pull latest image from the repo, so that it's layers may be reused.

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -10,8 +10,8 @@ function import_image() {
     local local_image="localhost:5000/${orig_image##*/}:local"
     if ! docker tag "${versioned_image}" "${local_image}"; then
         # The project doesn't build this image, pull it
-        docker pull "${orig_image}:latest"
-        docker tag "${orig_image}:latest" "${versioned_image}"
+        docker pull "${orig_image}:${CUTTING_EDGE}"
+        docker tag "${orig_image}:${CUTTING_EDGE}" "${versioned_image}"
         docker tag "${versioned_image}" "${local_image}"
     fi
 

--- a/scripts/shared/lib/version
+++ b/scripts/shared/lib/version
@@ -3,5 +3,6 @@
 . "${BASH_SOURCE%/*}"/source_only
 
 readonly DEV_VERSION="dev"
+readonly CUTTING_EDGE="devel"
 # shellcheck disable=SC2034 # VERSION defined here is used elsewhere
-readonly VERSION=$(git describe --tags --dirty="-${DEV_VERSION}" --exclude="devel" --exclude="latest")
+readonly VERSION=$(git describe --tags --dirty="-${DEV_VERSION}" --exclude="${CUTTING_EDGE}" --exclude="latest")

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -3,7 +3,8 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'tag' 'devel' "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
+source ${SCRIPTS_DIR}/lib/version
+DEFINE_string 'tag' "${CUTTING_EDGE}" "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to deploy to"
 FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"
 FLAGS "$@" || exit $?
@@ -20,7 +21,6 @@ fi
 set -e
 
 source ${SCRIPTS_DIR}/lib/debug_functions
-source ${SCRIPTS_DIR}/lib/version
 
 function release_image() {
     local image=$1


### PR DESCRIPTION
Since we moved to tag the cuitting edge images as `devel` we should use
that version.

Also added this as a constant in to stop having it hard coded all over.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>