### PR TITLE
Turn the version script into a Makefile snippet

### DIFF
--- a/.github/workflows/e2e-consuming.yaml
+++ b/.github/workflows/e2e-consuming.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout the Shipyard repository
         uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Reclaim free space!
         run: |
@@ -37,6 +39,7 @@ jobs:
       - name: Checkout the ${{ matrix.project }} repository
         uses: actions/checkout@master
         with:
+          fetch-depth: 0
           repository: submariner-io/${{ matrix.project }}
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - run: make e2e
         env:

--- a/.github/workflows/scripts.yaml
+++ b/.github/workflows/scripts.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - env:
           CLUSTERS_ARGS: --timeout 1m
@@ -28,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Test the compile.sh script
         run: |
@@ -43,6 +47,8 @@ jobs:
         deploytool: ['operator', 'helm']
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Run the deploy script
         env:
@@ -61,6 +67,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - run: make e2e
 
@@ -72,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
 
       - name: Test the most_mortem.sh script
         run: |

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -17,4 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - run: make ${{ matrix.command }}

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ else
 # Not running in Dapper
 
 include Makefile.images
+include Makefile.versions
 
 # Shipyard-specific starts
 clusters deploy e2e nettest post-mortem unit-test validate: dapper-image

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,6 +2,7 @@
 _using = $(subst $(,), ,$(using))
 
 include $(SHIPYARD_DIR)/Makefile.images
+include $(SHIPYARD_DIR)/Makefile.versions
 
 # Process extra flags from the `using=a,b,c` optional flag
 

--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,0 +1,7 @@
+# Calculate versions; these can be overridden
+CUTTING_EDGE := devel
+DEV_VERSION := dev
+override CALCULATED_VERSION := $(shell git describe --tags --dirty="-$(DEV_VERSION)" --exclude="$(CUTTING_EDGE)" --exclude="latest")
+VERSION ?= $(CALCULATED_VERSION)
+
+export CUTTING_EDGE DEV_VERSION VERSION

--- a/scripts/shared/lib/version
+++ b/scripts/shared/lib/version
@@ -2,6 +2,8 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
+# The CUTTING_EDGE, DEV_VERSION, and VERSION are set in Makefile.inc;
+# this script is only preserved for backwards compatibility
 readonly DEV_VERSION="dev"
 readonly CUTTING_EDGE="devel"
 # shellcheck disable=SC2034 # VERSION defined here is used elsewhere


### PR DESCRIPTION
... and include it as appropriate from Makefile.inc and Makefile (the latter is necessary for the initial Dapper image build).

This ensures CUTTING_EDGE, DEV_VERSION and VERSION are exported everywhere, with the same value, calculated only once.

Signed-off-by: Stephen Kitt <skitt@redhat.com>