### PR TITLE
Saner UPX

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@master
 
       - run: make e2e
+        env:
+          IMAGES_ARGS: --nocache
 
       - name: Post Mortem
         if: failure()
@@ -29,16 +31,22 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Tagged release detection
+        if: contains(github.ref, '/tags/')
+        run: |
+          tags="${GITHUB_REF##*/}"
+          { echo $tags | grep -q -v -; } && tags+=" latest"
+          echo "::set-env name=RELEASE_TAGS::--tag \"$tags\""
+          echo "::set-env name=UPX_FLAG::--buildargs \"UPX_LEVEL=-9\""
+
+      - name: Build new images
+        env:
+          IMAGES_ARGS: --nocache ${{ env.UPX_FLAG }}
+        run: make dapper-image nettest
+
       - name: Release the images
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          RELEASE_ARGS: shipyard-dapper-base nettest
-          IMAGES_ARGS: --nocache --buildargs 'UPX_LEVEL=-9'
-        run: |
-          if [[ $GITHUB_REF =~ "/tags/" ]]; then
-              tags="${GITHUB_REF##*/}"
-              { echo $tags | grep -q -v -; } && tags+=" latest"
-              RELEASE_ARGS+=" --tag \"$tags\""
-          fi
-          make dapper-image nettest release
+          RELEASE_ARGS: shipyard-dapper-base nettest ${{ env.RELEASE_TAGS }}
+        run: make release

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ else
 include Makefile.images
 
 # Shipyard-specific starts
-clusters deploy e2e nettest post-mortem release unit-test validate: dapper-image
+clusters deploy e2e nettest post-mortem unit-test validate: dapper-image
 
 dapper-image: export SCRIPTS_DIR=./scripts/shared
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,7 +1,8 @@
 FROM fedora:32
 
-# Unless specified otherwise, compress the fastest to save time
-ARG UPX_LEVEL=-1
+# Unless specified otherwise, compress to a medium level which gives (from experemintation) a
+# good balance between compression time and resulting image size.
+ARG UPX_LEVEL=-5
 ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/local/go/bin:$PATH \
     GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${DAPPER_HOST_ARCH} \


### PR DESCRIPTION
Turns out we inadvertently ruined the image caching since we're using upx -1 for CI but -9 for release, which causes docker cache misses.

This PR fixes that by only UPXing to a higher level on a tagged release, and also changes the default UPX level to -5 which seems to be a sweet spot between build time and space saved.