### PR TITLE
Add globalnet flag to e2e tests

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,6 +8,7 @@ include $(SHIPYARD_DIR)/Makefile.images
 ifneq (,$(filter globalnet,$(_using)))
 override CLUSTERS_ARGS += --globalnet
 override DEPLOY_ARGS += --globalnet
+override E2E_ARGS += --globalnet
 endif
 
 ifneq (,$(filter helm,$(_using)))

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -6,10 +6,12 @@ source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments"
 DEFINE_string 'focus' '.*' "Ginkgo focus for the E2E tests"
 DEFINE_boolean 'lazy_deploy' true "Deploy the environment lazily (If false, don't do anything)"
+DEFINE_boolean 'globalnet' false "Indicates if the globalnaet feature is enabled"
 FLAGS_HELP="USAGE: $0 [--cluster_settings /path/to/settings] [--focus focus] [--[no]lazy_deploy] cluster [cluster ...]"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
+[[ "${FLAGS_globalnet}" = "${FLAGS_TRUE}" ]] && globalnet=-globalnet || globalnet=
 focus="${FLAGS_focus}"
 cluster_settings="${FLAGS_cluster_settings}"
 [[ "${FLAGS_lazy_deploy}" = "${FLAGS_TRUE}" ]] && lazy_deploy=true || lazy_deploy=false
@@ -52,7 +54,7 @@ function test_with_e2e_tests {
     cd ${DAPPER_SOURCE}/test/e2e
 
     go test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace\
-        -submariner-namespace $SUBM_NS $(generate_context_flags) \
+        -submariner-namespace $SUBM_NS $(generate_context_flags) ${globalnet} \
         -ginkgo.reportPassed -test.timeout 15m \
         -ginkgo.focus "\[${focus}\]" \
         -ginkgo.reportFile ${DAPPER_OUTPUT}/e2e-junit.xml 2>&1 | \

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -6,7 +6,7 @@ source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments"
 DEFINE_string 'focus' '.*' "Ginkgo focus for the E2E tests"
 DEFINE_boolean 'lazy_deploy' true "Deploy the environment lazily (If false, don't do anything)"
-DEFINE_boolean 'globalnet' false "Indicates if the globalnaet feature is enabled"
+DEFINE_boolean 'globalnet' false "Indicates if the globalnet feature is enabled"
 FLAGS_HELP="USAGE: $0 [--cluster_settings /path/to/settings] [--focus focus] [--[no]lazy_deploy] cluster [cluster ...]"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -52,7 +52,7 @@ func init() {
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18, "The timeout in seconds per connection attempt when verifying communication between clusters.")
 	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7, "The number of connection attempts when verifying communication between clusters.")
 	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 190, "The general operation timeout in seconds.")
-	flag.BoolVar(&TestContext.GlobalnetEnabled, "globalnet", false, "Indicates if the globalnaet feature is enabled.")
+	flag.BoolVar(&TestContext.GlobalnetEnabled, "globalnet", false, "Indicates if the globalnet feature is enabled.")
 }
 
 func ValidateFlags(t *TestContextType) {

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -52,6 +52,7 @@ func init() {
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18, "The timeout in seconds per connection attempt when verifying communication between clusters.")
 	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7, "The number of connection attempts when verifying communication between clusters.")
 	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 190, "The general operation timeout in seconds.")
+	flag.BoolVar(&TestContext.GlobalnetEnabled, "globalnet", false, "Indicates if the globalnaet feature is enabled.")
 }
 
 func ValidateFlags(t *TestContextType) {


### PR DESCRIPTION
Instead of auto-detecting whether globalnet is enabled, pass it as a flag as the front-end scripts have the knowledge.