### PR TITLE
Rm goimports validation, now run by golangci-lint

### DIFF
--- a/.github/workflows/validate-consuming.yaml
+++ b/.github/workflows/validate-consuming.yaml
@@ -5,7 +5,7 @@ on:
 name: Validations (Consuming Projects)
 jobs:
   validate:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: |
       ( github.event.action == 'labeled' && github.event.label.name == 'validate-projects' )

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -22,19 +22,17 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # helm           | e2e tests
 # kind           | e2e tests
 # ginkgo         | tests
-# goimports      | code formatting
 # make           | OLM installation
 # findutils      | validate (find go packages)
 # subctl *       | Submariner's deploy tool (operator)
 # upx            | binary compression
 # jq             | JSON processing (GitHub API)
-# diffutils      | required for goimports
 # ShellCheck     | shell script linting
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq golang-x-tools-goimports ShellCheck && \
+                   findutils upx jq ShellCheck && \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \

--- a/scripts/shared/validate.sh
+++ b/scripts/shared/validate.sh
@@ -6,16 +6,6 @@ source ${SCRIPTS_DIR}/lib/find_functions
 
 PACKAGES="$(find_go_pkg_dirs) *.go"
 
-# TODO: Use goimports via golangci-lint, enable it via per-repo config files
-if [[ $(goimports -l ${PACKAGES} | wc -l) -gt 0 ]]; then
-    echo "Incorrect formatting"
-    echo "These are the files with formatting errors:"
-    goimports -l ${PACKAGES}
-    echo "These are the formatting errors:"
-    goimports -d ${PACKAGES}
-    exit 1
-fi
-
 # Show which golangci-lint linters are enabled/disabled
 golangci-lint linters
 


### PR DESCRIPTION
Remove our custom goimports validations, as goimports is now run as part
of our golangci-lint linting in all repositories.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>