### PR TITLE
Increase consuming project validations 10m->15m

### DIFF
--- a/.github/workflows/validate-consuming.yaml
+++ b/.github/workflows/validate-consuming.yaml
@@ -5,7 +5,7 @@ on:
 name: Validations (Consuming Projects)
 jobs:
   validate:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     if: |
       ( github.event.action == 'labeled' && github.event.label.name == 'validate-projects' )


### PR DESCRIPTION
Increase the timeout for consuming project validations from 10m to 15m,
as it seems both the submariner and submariner-operator jobs timeout
before 10m. The admiral and lighthouse jobs complete in about 9m.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>