### PR TITLE
Fix MD lint violations

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,2 @@
+line-length:
+  line_length: 140

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shipyard
 
-The Shipyard project provides tooling for creating K8s clusters with [kind](K8s in Docker) and provides a Go framework for creating E2E tests. 
+The Shipyard project provides tooling for creating K8s clusters with [kind](K8s in Docker) and provides a Go framework for creating E2E
+tests.
 
 [![Build Status](https://travis-ci.com/submariner-io/shipyard.svg?branch=master)](https://travis-ci.com/submariner-io/shipyard)
 [![Go Report Card](https://goreportcard.com/badge/github.com/submariner-io/shipyard)](https://goreportcard.com/report/github.com/submariner-io/shipyard)
@@ -11,6 +12,7 @@ The Shipyard project provides tooling for creating K8s clusters with [kind](K8s 
 - [docker]
 
 ## Usage
+
 To use Shipyard for your project, it's easiest to use Dapper and Make.
 To use Dapper, you'll need a specific Dockerfile that Dapper consumes to create a consistent environment based upon Shipyard's base image.
 To use Make, you'll need some commands to enable Dapper and also include the targets which ship in the base image.
@@ -37,7 +39,9 @@ You can also refer to the project's own [Dockerfile.dapper](Dockerfile.dapper) a
 
 ### Makefile
 
-The Makefile should include targets to run everything in Dapper. They're defined in [Makefile.dapper](Makefile.dapper) and can be copied as-is and included. To use Shipyard's target, simply include the [Makefile.inc](Makefile.inc) file in your own Makefile.
+The Makefile should include targets to run everything in Dapper.
+They're defined in [Makefile.dapper](Makefile.dapper) and can be copied as-is and included.
+To use Shipyard's target, simply include the [Makefile.inc](Makefile.inc) file in your own Makefile.
 
 The simplest Makefile would look like this:
 


### PR DESCRIPTION
Configure custom maximum line length of 140 chars to match Go linting.

Per discussions on Automation call and PR, preemptively wrap at the end
of sentences that are shorter than 140c but can not fully fit the next
sentence. This will make diffs better, as changes are typically
sentence-based, compared to re-wrapping a block of 140c lines. We don't
know of a good way to enforce this in automation, but we would like to.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>