### PR TITLE
Add commit message validations

### DIFF
--- a/.github/workflows/gitlint.yaml
+++ b/.github/workflows/gitlint.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v**'
+
+name: Commit Message Validations
+jobs:
+  gitlint:
+    name: Gitlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - run: make gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,3 @@
+[general]
+# Allow commit messages with only a title
+ignore=body-is-missing

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
-clusters deploy e2e nettest post-mortem unit-test validate: dapper-image
+clusters deploy e2e gitlint nettest post-mortem unit-test validate: dapper-image
 
 dapper-image: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -39,6 +39,9 @@ deploy: clusters
 e2e:
 	$(SCRIPTS_DIR)/e2e.sh $(E2E_ARGS)
 
+gitlint:
+	$(SCRIPTS_DIR)/gitlint.sh
+
 release:
 	$(SCRIPTS_DIR)/release.sh $(RELEASE_ARGS)
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -30,12 +30,15 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # ShellCheck     | shell script linting
 # npm            | Required for installing markdownlint
 # markdownlint   | Markdown linting
+# pip            | Required for installing gitlint
+# gitlint        | Commit message linting
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq ShellCheck npm && \
+                   findutils upx jq ShellCheck npm python3-pip && \
     npm install -g markdownlint-cli && \
+    pip install gitlint && \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \

--- a/scripts/shared/gitlint.sh
+++ b/scripts/shared/gitlint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+gitlint --commits origin/master..HEAD


### PR DESCRIPTION
Run gitlint to validate the format of commit messages. Add corresponding
make target. Tests commits between master and HEAD.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>