### PR TITLE
Update subctl version in base image to v0.6.0-rc0

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -48,7 +48,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v2.16.9 \
     KIND_VERSION=v0.7.0 \
-    SUBCTL_VERSION=v0.5.0
+    SUBCTL_VERSION=v0.6.0-rc0
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -15,6 +15,7 @@ readonly SUBM_ENGINE_IMAGE_TAG=local
 
 function deploytool_prereqs() {
     test -x /go/bin/subctl
+    /go/bin/subctl version
     import_image quay.io/submariner/submariner-operator
 }
 


### PR DESCRIPTION
Also adds subctl version output to deploy pre-reqs

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>