### PR TITLE
Add throughput pods into network_pods for benchmark tests

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -265,6 +265,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 	var err error
 	np.Pod, err = pc.Create(&nettestPod)
 	Expect(err).NotTo(HaveOccurred())
+	np.AwaitReady()
 }
 
 // create a test pod inside the current test namespace on the specified cluster.


### PR DESCRIPTION
Add throughput pods to used by benchmark tests, as part of https://github.com/submariner-io/submariner-operator/pull/637
Related to issue https://github.com/submariner-io/submariner-operator/issues/494

Signed-off-by: Maayan Friedman <maafried@redhat.com>