### PR TITLE
Remove most e2e framework dependencies on ginkgo

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,12 +1,15 @@
 package e2e
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	"github.com/onsi/gomega"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 )
 
@@ -46,8 +49,24 @@ func init() {
 }
 
 func RunE2ETests(t *testing.T) bool {
-	framework.ValidateFlags(framework.TestContext)
+	framework.SetStatusFunction(func(text string) {
+		ginkgo.By(text)
+	})
 
+	framework.SetFailFunction(func(text string) {
+		ginkgo.Fail(text)
+	})
+
+	framework.SetUserAgentFunction(func() string {
+		testDesc := ginkgo.CurrentGinkgoTestDescription()
+		prefix := "ginkgo"
+		if len(testDesc.ComponentTexts) > 0 {
+			prefix = strings.Join(testDesc.ComponentTexts, " ")
+		}
+		return fmt.Sprintf("%v -- %v", rest.DefaultKubernetesUserAgent(), prefix)
+	})
+
+	framework.ValidateFlags(framework.TestContext)
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// If the ginkgo default for slow test was not modified, bump it to 45 seconds

--- a/test/e2e/framework/ginkgo_framework.go
+++ b/test/e2e/framework/ginkgo_framework.go
@@ -1,0 +1,13 @@
+package framework
+
+import "github.com/onsi/ginkgo"
+
+// NewFramework creates a test framework, under ginkgo
+func NewFramework(baseName string) *Framework {
+	f := NewBareFramework(baseName)
+
+	ginkgo.BeforeEach(f.BeforeEach)
+	ginkgo.AfterEach(f.AfterEach)
+
+	return f
+}

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -3,7 +3,6 @@ package framework
 import (
 	"fmt"
 
-	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -86,7 +85,7 @@ func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
 }
 
 func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
-	ginkgo.By(fmt.Sprintf("Deleting service %q on %q", serviceName, TestContext.ClusterIDs[cluster]))
+	By(fmt.Sprintf("Deleting service %q on %q", serviceName, TestContext.ClusterIDs[cluster]))
 	AwaitUntil("delete service", func() (interface{}, error) {
 		return nil, KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(serviceName, &metav1.DeleteOptions{})
 	}, NoopCheckResult)


### PR DESCRIPTION
This will enable the usage of the Framework object
outside of ginkgo. For example from subctl, when we
need a multi-cluster client for benchmarking, etc..

There is still work that needs to be done in the
logging module, although it's safe now, because
GinkgoWriter defaults to stdout unless you change
the reporters.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>