### PR TITLE
Allow local yamllint

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -7,11 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: YAML Linting
     steps:
-      - name: Check out code
-        uses: actions/checkout@v1
-
-      - name: Run yamllint
-        uses: ibiqlik/action-yamllint@v1
+      - uses: actions/checkout@master
         with:
-          file_or_dir: .
-          config_file: .yamllint.yml
+          fetch-depth: 0
+      - run: make dapper-image yamllint

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -11,5 +11,6 @@ rules:
 ignore: |
   /vendor
   /prometheus
+  /scripts/shared/resources/cluster*-config.yaml
 
 strict: true

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -42,6 +42,9 @@ e2e:
 gitlint:
 	$(SCRIPTS_DIR)/gitlint.sh
 
+yamllint:
+	yamllint .
+
 release:
 	$(SCRIPTS_DIR)/release.sh $(RELEASE_ARGS)
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -32,11 +32,12 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # markdownlint   | Markdown linting
 # pip            | Required for installing gitlint
 # gitlint        | Commit message linting
+# yamllint       | YAML linting
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq ShellCheck npm python3-pip && \
+                   findutils upx jq ShellCheck npm python3-pip yamllint && \
     npm install -g markdownlint-cli && \
     pip install gitlint && \
     dnf -y remove libsemanage && \


### PR DESCRIPTION
This installs yamllint in the Shipyard Dapper base image, provides a
yamllint Make target, and uses it in the GHA.

Signed-off-by: Stephen Kitt <skitt@redhat.com>