### PR TITLE
Stop building images for yamllint

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -10,4 +10,4 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - run: make dapper-image yamllint
+      - run: make yamllint


### PR DESCRIPTION
Now that yamllint is in the published base image, the GHA doesn't need
to build its own image.

Signed-off-by: Stephen Kitt <skitt@redhat.com>