### PR TITLE
Drop the gitlint.sh script

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -40,7 +40,7 @@ e2e:
 	$(SCRIPTS_DIR)/e2e.sh $(E2E_ARGS)
 
 gitlint:
-	$(SCRIPTS_DIR)/gitlint.sh
+	gitlint --commits origin/master..HEAD
 
 yamllint:
 	yamllint .

--- a/scripts/shared/gitlint.sh
+++ b/scripts/shared/gitlint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-gitlint --commits origin/master..HEAD


### PR DESCRIPTION
This can be done entirely in Makefile.inc.

Signed-off-by: Stephen Kitt <skitt@redhat.com>