### PR TITLE
Fix multi-stage builds, simplify the nettest image

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -12,8 +12,10 @@ force_image_rebuild = $(if $(shell docker images | grep '\<$(1)\W*latest\>'),,FO
 FORCE_IMAGE: ;
 
 # Dockerfile dependencies are the file and any file copied into it
-# We have to run it through a variable in order to expand any * that might be in the COPY command
-docker_deps = $(shell files="$(1) $$(grep COPY $(1) | sed 's/COPY \(.*\) .*/\1/' )" && find $${files[*]})
+# We have to run it through a variable in order to expand any * that might be
+# in the COPY command; find is used to handle directories as dependencies
+# Files copied from another image are ignored
+docker_deps = $(shell files=($(1) $$(awk '/COPY/ { if (substr($$2, 1, 7) != "--from=") { for (i = 2; i < NF; i++) { print $$i } } }' $(1))) && find $${files[*]} -type f)
 
 # Patterned recipe to use to build any image from any Dockerfile
 # An empty file is used for make to figure out if dependencies changed or not
@@ -21,5 +23,3 @@ docker_deps = $(shell files="$(1) $$(grep COPY $(1) | sed 's/COPY \(.*\) .*/\1/'
 package/.image.%: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_image_rebuild,$$*)
 	$(SCRIPTS_DIR)/build_image.sh -i $(lastword $(subst ., ,$@)) -f $< $(IMAGES_ARGS)
 	touch $@
-
-

--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -2,6 +2,17 @@ FROM alpine
 
 WORKDIR /app
 
+RUN apk add --update --no-cache gcc libc-dev make curl
+
+RUN curl -L https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz | tar xzf -
+RUN cd netperf-netperf-2.7.0 && ./configure \
+    && make && make install
+
+
+FROM alpine
+
+WORKDIR /app
+
 RUN apk add --no-cache \
 	bash \
 	bind-tools \
@@ -10,12 +21,6 @@ RUN apk add --no-cache \
 	iperf3 \
 	tcpdump
 
-RUN apk add --update --no-cache g++ make curl
-
-RUN curl -LO https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz \
-    && tar -xzf netperf-2.7.0.tar.gz \
-    && mv netperf-netperf-2.7.0/ netperf-2.7.0
-RUN cd netperf-2.7.0 && ./configure \
-    && make && make install
+COPY --from=0 /usr/local/bin/net* /usr/local/bin/
 
 CMD ["/bin/bash","-l"]


### PR DESCRIPTION
When calculating the dependencies for images, the --from option to
COPY breaks our call to find. Such dependencies need to be ignored
altogether, so we skip COPY when it is followed by --from=.

To avoid bloating the nettest image with the remnants of the netperf
build (even after clean up), use a multi-stage build: the first builds
netperf, the second copies the binaries to the target image. This
results in a 24MiB image.

This builds on top of #296.