### PR TITLE
Tweak gitlint rules

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,3 +1,9 @@
 [general]
-# Allow commit messages with only a title
-ignore=body-is-missing
+# body-is-missing: Allow commit messages with only a title
+# body-min-length: Allow short body lines, like "Relates-to: #issue"
+ignore=body-is-missing,body-min-length
+
+[ignore-by-body]
+# Dependabot doesn't follow our conventions, unfortunately
+regex=^Signed-off-by: dependabot-preview\[bot\](.*)
+ignore=all


### PR DESCRIPTION
Allow short body lines, for example GH's "Relates-to"/"Closes".

Ignore commits from Dependabot, as it doesn't follow our conventions.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>