### PR TITLE
Remove dockerd

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -43,6 +43,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     dnf -y remove libsemanage && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \
+    rm -f /usr/bin/dockerd && \
     find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube | xargs upx ${UPX_LEVEL} && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 


### PR DESCRIPTION
This shaves nearly 60MiB off the Dapper image, and saves compression
time during the image build.

Signed-off-by: Stephen Kitt <skitt@redhat.com>