### PR TITLE
Update subctl to v0.7.0-pre0

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -51,7 +51,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v2.16.9 \
     KIND_VERSION=v0.7.0 \
-    SUBCTL_VERSION=v0.6.1
+    SUBCTL_VERSION=v0.7.0-pre0
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \


### PR DESCRIPTION
The operator started accessing config.openshift.io/networks
instead of network.openshift.io/clusternetworks as it's the
common denominator to other network plugins and not only
OpenshiftSDN. Now the submariner-operator requires the 
ClusterRole changes contained in subctl to properly work.

Signed-Off-By: Miguel Angel Ajo Pelayo <majopela@redhat.com>