### PR TITLE
Add discrete Go and MD linting make targets

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        command: ['shellcheck', 'validate']
+        command: ['shellcheck', 'markdownlint', 'golangci-lint']
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
-clusters deploy e2e gitlint nettest post-mortem unit-test validate: dapper-image
+clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test validate: dapper-image
 
 dapper-image: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -42,6 +42,13 @@ e2e:
 gitlint:
 	gitlint --commits origin/master..HEAD
 
+golangci-lint: vendor/modules.txt
+	golangci-lint linters
+	golangci-lint run --timeout 5m
+
+markdownlint:
+	markdownlint markdownlint -c .markdownlint.yml -i vendor .
+
 yamllint:
 	yamllint .
 


### PR DESCRIPTION
The current "validate" target does these two tasks. The goal is to add
them as individual targets, consume the new targets in other repos, and
then remove/refactor the "validate" target.

Move Shipyard to using the two new targets in CI, vs validate.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>