### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -44,7 +44,7 @@ gitlint:
 
 golangci-lint: vendor/modules.txt
 	golangci-lint linters
-	golangci-lint run --timeout 5m
+	golangci-lint run --timeout 10m
 
 markdownlint:
 	markdownlint markdownlint -c .markdownlint.yml -i vendor .

--- a/scripts/shared/validate.sh
+++ b/scripts/shared/validate.sh
@@ -9,6 +9,6 @@ PACKAGES="$(find_go_pkg_dirs) *.go"
 # Show which golangci-lint linters are enabled/disabled
 golangci-lint linters
 
-golangci-lint run --timeout 5m $@
+golangci-lint run --timeout 10m $@
 
 markdownlint -c .markdownlint.yml -i vendor .


### PR DESCRIPTION
I'm increasingly running into golangci-lint timeouts; increasing it to
10 minute would avoid these.

Signed-off-by: Stephen Kitt <skitt@redhat.com>