### PR TITLE
Fix sleep duration in test_connection

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -53,7 +53,7 @@ install_subm_all_clusters
 
 if [ "${#cluster_subm[@]}" -gt 1 ]; then
     cls=(${!cluster_subm[@]})
-    with_context "${cls[0]}" verify_gw_status
+    with_context "${cls[0]}" with_retries 30 verify_gw_status
     with_context "${cls[0]}" connectivity_tests "${cls[1]}"
 else
     echo "Not executing connectivity tests - requires at least two clusters with submariner installed"

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -53,14 +53,16 @@ function test_connection() {
     local target_address=$2
 
     echo "Attempting connectivity between clusters - $source_pod --> $target_address"
+    wait_time=30
     start_time=$(date +%s)
-    if ! kubectl exec "${source_pod}" -- curl --output /dev/null -m 30 --silent --head --fail "${target_address}"; then
+    if ! kubectl exec "${source_pod}" -- curl --output /dev/null -m "${wait_time}" --silent --head --fail "${target_address}"; then
         end_time=$(date +%s)
         execution_time=$(( end_time - start_time))
-        if [ $execution_time -lt 30 ]
+        if [ $execution_time -lt $wait_time ]
         then
-           echo "curl returned too soon. Sleeping for $execution_time secs"
-           sleep $execution_time
+           remaining_time=$(( wait_time - execution_time))
+           echo "curl returned too soon. Sleeping for $remaining_time secs"
+           sleep $remaining_time
         fi
         return 1
     fi
@@ -84,20 +86,18 @@ function connectivity_tests() {
 }
 
 function verify_gw_status() {
-    sleep_duration=5
+    sleep_duration=6
     # helm doesn't use the operator yet, and connection status is based on the operator object
     if subctl show connections 2>&1 | grep "the server could not find the requested resource"; then
         return 0
     fi
 
-    for i in {1..90}; do
-       if ! subctl show connections | grep "connected"; then
-          echo "iter: $i. Clusters not yet connected. sleeping for $sleep_duration secs"
-          sleep $sleep_duration
-       else
-          return 0
-       fi
-    done
+    if ! subctl show connections | grep "connected"; then
+       echo "iter: $i. Clusters not yet connected. sleeping for $sleep_duration secs"
+       sleep $sleep_duration
+    else
+       return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
While validating the connectivity between the clusters if curl
returns too soon, test_connection should wait for the balance
amount of time that we intended to wait.

Along with this change, this PR also modifies the retry interval
for verify_gw_status.

Fixes issue: https://github.com/submariner-io/shipyard/issues/309

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
Co-authored-by: Miguel Angel Ajo Pelayo <miguelangel@ajo.es>