### PR TITLE
Add "unit" make target, will replace "unit-test"

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -58,6 +58,10 @@ release:
 post-mortem:
 	$(SCRIPTS_DIR)/post_mortem.sh
 
+unit: vendor/modules.txt
+	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
+
+# TODO: Remove once all consumers are migrated to "unit"
 unit-test: vendor/modules.txt
 	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
 


### PR DESCRIPTION
The current "unit-test" make target is re-mapped to "test" in each
dependent Makefile. Instead, make the target more explicit, and equal
length, and avoid re-mapping by using "unit" everywhere.

Will remove "unit-test" target once "unit" is consumed everywhere.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>