### PR TITLE
Use the latest development subctl

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -51,7 +51,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v2.16.9 \
     KIND_VERSION=v0.7.0 \
-    SUBCTL_VERSION=v0.7.0-pre1
+    SUBCTL_VERSION=devel
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \


### PR DESCRIPTION
... until we're closer to releasing 0.7, to avoid problems caused by
mis-matches between devel images and older subctl.

Signed-off-by: Stephen Kitt <skitt@redhat.com>