### PR TITLE
Make CODEOWNERS additive

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 * @mangelajo @tpantelis @Oats87
-go.mod @skitt
-go.sum @skitt
-/.github/workflows/ 	@mkolesnik
-/scripts/ 		@mkolesnik
-Makefile* 		@mkolesnik
-Dockerfile.dapper 	@mkolesnik
-package/ 		@mkolesnik
+go.mod	     		@mangelajo @tpantelis @Oats87 @skitt
+go.sum			@mangelajo @tpantelis @Oats87 @skitt
+/.github/workflows/ 	@mangelajo @tpantelis @Oats87 @mkolesnik
+/scripts/ 		@mangelajo @tpantelis @Oats87 @mkolesnik
+Makefile* 		@mangelajo @tpantelis @Oats87 @mkolesnik
+Dockerfile.dapper 	@mangelajo @tpantelis @Oats87 @mkolesnik
+package/ 		@mangelajo @tpantelis @Oats87 @mkolesnik


### PR DESCRIPTION
Since CODEOWNERS isn't additive, we need to mention all owners of any
pattern defined in the file, i.e. duplicate the '*' owners on all
lines.

This will avoid code-owner-based review and merging being limited by
having a single person identified as the code owner for a review.

Signed-off-by: Stephen Kitt <skitt@redhat.com>