### PR TITLE
Use standard "images" target vs "dapper-image"

### DIFF
--- a/.github/workflows/e2e-consuming.yml
+++ b/.github/workflows/e2e-consuming.yml
@@ -35,7 +35,7 @@ jobs:
           free -h
 
       - name: Build the latest Shipyard image
-        run: make dapper-image
+        run: make images
 
       - name: Checkout the ${{ matrix.project }} repository
         uses: actions/checkout@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build new images
         env:
           IMAGES_ARGS: --nocache ${{ env.UPX_FLAG }}
-        run: make dapper-image nettest
+        run: make images nettest
 
       - name: Release the images
         env:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Test the compile.sh script
         run: |
-          make dapper-image .dapper
+          make images .dapper
           ./.dapper -m bind test/scripts/compile/test.sh
   deploy:
     timeout-minutes: 30

--- a/.github/workflows/validate-consuming.yml
+++ b/.github/workflows/validate-consuming.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Build the latest Shipyard image
-        run: make dapper-image
+        run: make images
 
       - name: Checkout the ${{ matrix.project }} repository
         uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
-clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test validate: dapper-image
+clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test validate: images
 
-dapper-image: export SCRIPTS_DIR=./scripts/shared
+images: export SCRIPTS_DIR=./scripts/shared
 
-dapper-image: package/.image.shipyard-dapper-base
+images: package/.image.shipyard-dapper-base
 
 .DEFAULT_GOAL := validate
 # Shipyard-specific ends

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -12,7 +12,7 @@
 
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
-$(filter-out .dapper dapper-image shell,$(MAKECMDGOALS)): .dapper
+$(filter-out .dapper images shell,$(MAKECMDGOALS)): .dapper
 	+./.dapper -m bind make $@ $(MAKEFLAGS)
 
 shell: .dapper


### PR DESCRIPTION
As a part of simplifying our building/testing experience, all projects
are moving to using a standard `make images` command to build whatever
container images they are responsible for.

This also reduces the need for Shipyard-specific docs.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>