### PR TITLE
Fix build_image.sh

### DIFF
--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -45,6 +45,6 @@ fi
 
 # Rebuild the image to update any changed layers and tag it back so it will be used.
 buildargs_flag='--build-arg BUILDKIT_INLINE_CACHE=1'
-[[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} ${buildargs}"
+[[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} --build-arg ${buildargs}"
 DOCKER_BUILDKIT=1 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} ${buildargs_flag} .
 docker tag ${local_image} ${cache_image}


### PR DESCRIPTION
When additional buildargs is specified, need to include "--build-arg"
when constructing buildargs_flag.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>