### PR TITLE
Allow up to 255 clusters by widening the usable IPs

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -108,8 +108,8 @@ function add_cluster_cidrs() {
     local val=$1
     local idx=$2
     [[ $globalnet != "true" ]] || val="0"
-    cluster_CIDRs[$idx]="10.24${val}.0.0/16"
-    service_CIDRs[$idx]="100.9${val}.0.0/16"
+    cluster_CIDRs[$idx]="10.${val}.0.0/16"
+    service_CIDRs[$idx]="100.${val}.0.0/16"
     [[ $globalnet != "true" ]] || global_CIDRs[$idx]="169.254.${1}.0/24"
 }
 


### PR DESCRIPTION
For scalability testing reasons we need to deploy more than 10
clusters, this change makes it possible.

Related-Issue: https://github.com/submariner-io/submariner/issues/861

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
Co-Authored-by: Mike Kolesnik <mkolesni@redhat.com>