### PR TITLE
Fix iteration counts when deploying

### DIFF
--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -93,7 +93,7 @@ function verify_gw_status() {
     fi
 
     if ! subctl show connections | grep "connected"; then
-       echo "iter: $i. Clusters not yet connected. sleeping for $sleep_duration secs"
+       echo "iter: $iteration. Clusters not yet connected. sleeping for $sleep_duration secs"
        sleep $sleep_duration
     else
        return 0

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -27,16 +27,17 @@ function kubectl() {
 # 1st argument is the amount of times to retry the command.
 # 2nd argument is the command to execute.
 # 3rd argument and so forth get passed to the command.
+# The current iteration is made available in the iteration variable.
 function with_retries() {
-    local retries
-    retries=$(eval echo "{1..$1}")
+    local retries=$1
     local cmnd=$2
 
-    for _ in ${retries}; do
+    iteration=1; while ((iteration <= retries)); do
         ( $cmnd "${@:3}"; ) &
         if wait $!; then
             return 0
         fi
+        ((iteration++))
     done
 
     echo "Max attempts reached, failed to run '${*:2}'!"


### PR DESCRIPTION
verify_gw_status currently repeats

    iter: 3. Clusters not yet connected. ...

while it waits for a connection, without updating the iteration
count. This patch makes with_retries export its iteration count, and
changes verify_gw_status to use that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>