### PR TITLE
Add a CODEOWNERS generation script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,9 @@
-* @mangelajo @tpantelis @Oats87
-go.mod	     		@mangelajo @tpantelis @Oats87 @skitt
-go.sum			@mangelajo @tpantelis @Oats87 @skitt
-/.github/workflows/ 	@mangelajo @tpantelis @Oats87 @mkolesnik
-/scripts/ 		@mangelajo @tpantelis @Oats87 @mkolesnik
-Makefile* 		@mangelajo @tpantelis @Oats87 @mkolesnik
-Dockerfile.dapper 	@mangelajo @tpantelis @Oats87 @mkolesnik
-package/ 		@mangelajo @tpantelis @Oats87 @mkolesnik
+# Auto-generated, do not edit; see CODEOWNERS.in
+* @mangelajo @Oats87 @tpantelis
+/.github/workflows/ @mangelajo @mkolesnik @Oats87 @tpantelis
+/scripts/ @mangelajo @mkolesnik @Oats87 @tpantelis
+Dockerfile.dapper @mangelajo @mkolesnik @Oats87 @tpantelis
+go.mod @mangelajo @Oats87 @skitt @tpantelis
+go.sum @mangelajo @Oats87 @skitt @tpantelis
+Makefile* @mangelajo @mkolesnik @Oats87 @tpantelis
+package/ @mangelajo @mkolesnik @Oats87 @tpantelis

--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,0 +1,5 @@
+@mangelajo	*
+@Oats87		*
+@tpantelis	*
+@mkolesnik	/.github/workflows/ /scripts/ Makefile* Dockerfile.dapper package/
+@skitt		go.mod go.sum

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -76,3 +76,6 @@ vendor/modules.txt: go.mod
 	go mod download
 	go mod vendor
 endif
+
+CODEOWNERS: CODEOWNERS.in
+	$(SCRIPTS_DIR)/gen-codeowners

--- a/scripts/shared/gen-codeowners
+++ b/scripts/shared/gen-codeowners
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from fnmatch import fnmatch
+
+with open('CODEOWNERS.in', 'r') as ins, open('CODEOWNERS', 'w') as out:
+    paths_by_owner = {}
+    owners_by_path = {}
+    paths = set()
+    for line in ins:
+        comps = line.split()
+        if len(comps) > 1:
+            paths_by_owner[comps[0]] = comps[1:]
+            paths |= set(comps[1:])
+            for path in comps[1:]:
+                owners_by_path.setdefault(path, set()).add(comps[0])
+    print('# Auto-generated, do not edit; see CODEOWNERS.in', file = out)
+    for path in sorted(owners_by_path, key = str.lower):
+        owners = owners_by_path[path]
+        for extra_path in owners_by_path.keys():
+            if extra_path != path and fnmatch(path, extra_path):
+                owners |= owners_by_path[extra_path]
+        print('{0} {1}'.format(path, ' '.join(sorted(owners, key = str.lower))), file = out)


### PR DESCRIPTION
This allows a simpler format to be used, in CODEOWNERS.in:

    @owner paths

The gen-codeowners script reads this and produced an additive
CODEOWNERS file, taking into account common paths.

Signed-off-by: Stephen Kitt <skitt@redhat.com>