### PR TITLE
Use single space vs tab alignment in CODEOWNERS.in

### DIFF
--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,5 +1,5 @@
-@mangelajo	*
-@Oats87		*
-@tpantelis	*
-@mkolesnik	/.github/workflows/ /scripts/ Makefile* Dockerfile.dapper package/
-@skitt		*
+@mangelajo *
+@Oats87 *
+@tpantelis *
+@mkolesnik /.github/workflows/ /scripts/ Makefile* Dockerfile.dapper package/
+@skitt *


### PR DESCRIPTION
Trying to line up rows of files with a number of tabs varying by the
length of the code owner's GitHub username is difficult to maintain and
consistently achieve readable rendering.

Instead, use a single space after each code owner handle.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>