### PR TITLE
Upgrade to KIND 0.9

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -51,8 +51,9 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.36.0 \
     HELM_VERSION=v3.4.1 \
-    KIND_VERSION=v0.7.0 \
-    BUILDX_VERSION=v0.5.1
+    KIND_VERSION=v0.9.0 \
+    BUILDX_VERSION=v0.5.1 \
+    SUBCTL_VERSION=subctl-devel
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -3,7 +3,7 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'k8s_version' '1.17.0' 'Version of K8s to use'
+DEFINE_string 'k8s_version' '1.17.11' 'Version of K8s to use'
 DEFINE_string 'olm_version' '0.14.1' 'Version of OLM to use'
 DEFINE_boolean 'olm' false 'Deploy OLM'
 DEFINE_boolean 'prometheus' false 'Deploy Prometheus'


### PR DESCRIPTION
Changes since 0.7.0:
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.0
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.1
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0

The Kubernetes 1.17 image for KIND 0.9 uses 1.17.11, so we upgrade to
that too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>