### PR TITLE
Add buildx for multiarch support

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -49,6 +49,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v2.16.9 \
     KIND_VERSION=v0.7.0 \
+    BUILDX_VERSION=v0.4.2 \
     SUBCTL_VERSION=devel
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
@@ -58,7 +59,11 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     curl -L "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}.tar.xz" | tar xJf - && mv subctl-${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH} /go/bin/subctl && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    find /go/bin -type f -executable -newercc /proc | xargs -r upx ${UPX_LEVEL}
+    mkdir -p ~/.docker/cli-plugins && \
+    curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \
+    chmod 755 ~/.docker/cli-plugins/docker-buildx && \
+    find /go/bin ~/.docker/cli-plugins -type f -executable -newercc /proc | xargs -r strip && \
+    find /go/bin ~/.docker/cli-plugins -type f -executable -newercc /proc | xargs -r upx ${UPX_LEVEL}
 
 # Copy kubecfg to always run on the shell
 COPY scripts/shared/lib/kubecfg /etc/profile.d/kubecfg.sh


### PR DESCRIPTION
This will greatly simplify building multiarch manifests.

To reduce binary sizes further, this also strips binaries before
compressing them. This results in only 8MiB extra for buildx.

Signed-off-by: Stephen Kitt <skitt@redhat.com>