### PR TITLE
Add CI to find periodic flaky E2E failures

### DIFF
--- a/.github/workflows/flake_finder.yml
+++ b/.github/workflows/flake_finder.yml
@@ -1,29 +1,24 @@
 ---
-name: Consuming Projects
+name: Flake Finder
 
 on:
-  pull_request:
-    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   e2e:
-    name: E2E
+    name: E2E Consuming Projects
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: |
-      ( github.event.action == 'labeled' && github.event.label.name == 'e2e-projects' )
-      || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'e2e-projects') )
     strategy:
       fail-fast: false
       matrix:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
-        # TODO: Revert before merge, just for testing
         globalnet: ['', 'globalnet']
         lighthouse: ['', 'lighthouse']
         cable_driver: ['', 'wireguard', 'libreswan']
         exclude:
-          # TODO: Revert before merge, just for testing
           # No need to specify using=lighthouse in Lighthouse repo
           - project: lighthouse
             lighthouse: lighthouse
@@ -58,7 +53,6 @@ jobs:
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
 
       - name: Run E2E deployment and tests
-        # TODO: Revert before merge, just for testing
         run: make e2e using="${{ matrix.deploytool }} ${{ matrix.globalnet }} ${{ matrix.lighthouse }} ${{ matrix.cable_driver }}"
 
       - name: Post mortem
@@ -67,32 +61,3 @@ jobs:
           df -h
           free -h
           make post-mortem
-
-  lint-consuming:
-    name: Lint
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    if: |
-      ( github.event.action == 'labeled' && github.event.label.name == 'lint-projects' )
-      || ( github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'lint-projects') )
-    strategy:
-      fail-fast: false
-      matrix:
-        project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
-    steps:
-      - name: Check out the Shipyard repository
-        uses: actions/checkout@v2
-
-      - name: Build the latest Shipyard image
-        run: make images
-
-      - name: Check out the ${{ matrix.project }} repository
-        uses: actions/checkout@v2
-        with:
-          repository: submariner-io/${{ matrix.project }}
-
-      - name: Make sure ${{ matrix.project }} is using the built Shipyard image
-        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
-
-      - name: Run all linters
-        run: make lint


### PR DESCRIPTION
Run E2E for consuming projects periodically to find flaky failures.

Because this runs against code that has already passed CI to be merged
to the main branch, any failures are likely to be sporadic flakes. By
having a single GHA workflow to find these failures, we can more easily
spot them and track data about them.

The frequency of this job should be turned up or down depending on how
actively we're hunting for flaky failures.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>