### PR TITLE
Fix release job, avoid deprecated set-env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
         run: |
           tags="${GITHUB_REF##*/}"
           { echo $tags | grep -q -v -; } && tags+=" latest"
-          echo "::set-env name=RELEASE_TAGS::--tag \"$tags\""
-          echo "::set-env name=UPX_FLAG::--buildargs \"UPX_LEVEL=-9\""
+          echo "RELEASE_TAGS=--tag \"$tags\"" >> $GITHUB_ENV
+          echo "UPX_FLAG=--buildargs \"UPX_LEVEL=-9\"" >> $GITHUB_ENV
 
       - name: Build new images
         env:


### PR DESCRIPTION
The process for setting environment variables in GitHub Actions has
changed due to a security issue.

See:

https://github.blog/changelog/2020-10-01-github-actions-deprecating-
set-env-and-add-path-commands/

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>