### PR TITLE
Add logs for lighthouse pods to post_mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -55,6 +55,20 @@ function post_analyze() {
     done
 
     echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+
+    for pod in $(kubectl get pods --selector=app=submariner-lighthouse-agent -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+        echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
+        kubectl -n $namespace logs $pod
+    done
+
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+
+    for pod in $(kubectl get pods --selector=app=submariner-lighthouse-coredns -n $namespace -o jsonpath='{.items[*].metadata.name}'); do
+        echo "+++++++++++++++++++++: Logs for Pod $pod in namespace $namespace :++++++++++++++++++++++"
+        kubectl -n $namespace logs $pod
+    done
+
+    echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
     subctl show all
 
     echo "===================== END Post mortem $cluster ====================="


### PR DESCRIPTION
Logs of lighthouse pods are not captured in post_mortem, which makes it
difficult to troubleshoot lighthouse failures in e2e.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>