### PR TITLE
Add cable-driver support to using flag, add tests

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,8 +19,10 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
         exclude:
+          # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
             deploytool: helm
+          # Operator and Helm are mutually exclusive, don't try to use Helm in Operator repo
           - project: submariner-operator
             deploytool: helm
     steps:
@@ -46,7 +48,7 @@ jobs:
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
 
       - name: Run E2E deployment and tests
-        run: make e2e using=${{ matrix.deploytool }}
+        run: make e2e using="${{ matrix.deploytool }}"
 
       - name: Post mortem
         if: failure()

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -6,6 +6,15 @@ include $(SHIPYARD_DIR)/Makefile.versions
 
 # Process extra flags from the `using=a,b,c` optional flag
 
+ifneq (,$(filter libreswan,$(_using)))
+override DEPLOY_ARGS += --cable_driver libreswan
+else ifneq (,$(filter strongswan,$(_using)))
+override DEPLOY_ARGS += --cable_driver strongswan
+else ifneq (,$(filter wireguard,$(_using)))
+# Wireguard requires kernel module install on the host
+override DEPLOY_ARGS += --cable_driver wireguard
+endif
+
 ifneq (,$(filter globalnet,$(_using)))
 override CLUSTERS_ARGS += --globalnet
 override DEPLOY_ARGS += --globalnet

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -10,6 +10,7 @@ DEFINE_string 'deploytool_submariner_args' '' 'Any extra arguments to pass to th
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"
 DEFINE_string 'timeout' '5m' "Timeout flag to pass to kubectl when waiting (e.g. 30s)"
 DEFINE_string 'image_tag' 'local' "Tag to use for the images"
+DEFINE_string 'cable_driver' 'libreswan' "Tunneling method for connections between clusters (libreswan, strongswan, wireguard requires kernel module on host)"
 
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -21,8 +22,9 @@ deploytool_submariner_args="${FLAGS_deploytool_submariner_args}"
 cluster_settings="${FLAGS_cluster_settings}"
 timeout="${FLAGS_timeout}"
 image_tag="${FLAGS_image_tag}"
+cable_driver="${FLAGS_cable_driver}"
 
-echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}, timeout=${timeout}, image_tag=${image_tag}"
+echo "Running with: globalnet=${globalnet@Q}, deploytool=${deploytool@Q}, deploytool_broker_args=${deploytool_broker_args@Q}, deploytool_submariner_args=${deploytool_submariner_args@Q}, cluster_settings=${cluster_settings@Q}, timeout=${timeout}, image_tag=${image_tag}, cable_driver=${cable_driver}"
 
 set -em
 

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -53,6 +53,7 @@ function helm_install_subm() {
         --set broker.token="${submariner_broker_token}" \
         --set broker.namespace="${SUBMARINER_BROKER_NS}" \
         --set broker.ca="${submariner_broker_ca}" \
+        --set submariner.cableDriver="${cable_driver}" \
         --set submariner.clusterId="${cluster}" \
         --set submariner.clusterCidr="${cluster_CIDRs[$cluster]}" \
         --set submariner.serviceCidr="${service_CIDRs[$cluster]}" \

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -52,6 +52,7 @@ function subctl_install_subm() {
                 --colorcodes "${SUBM_COLORCODES}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \
                 --disable-nat \
+                --cable-driver "${cable_driver}" \
                 ${deploytool_submariner_args} \
                 "${OUTPUT_DIR}"/broker-info.subm
 }


### PR DESCRIPTION
Adds support for setting the cable driver via using= flag.

make e2e using=libreswan

Relates-to: #364
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>