### PR TITLE
Build with buildx, add platform support

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -10,28 +10,28 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
     SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
 
 # Requirements:
-# Component      | Usage
-# -----------------------------------------------------------
-# gcc            | needed by `go test -race` (https://github.com/golang/go/issues/27089)
-# git            | find the workspace root
-# curl           | download other tools
-# moby-engine    | Dapper (Docker)
-# golang         | build
-# kubectl        | e2e tests (in kubernetes-client)
-# golangci-lint  | code linting
-# helm           | e2e tests
-# kind           | e2e tests
-# ginkgo         | tests
-# make           | OLM installation
-# findutils      | validate (find go packages)
-# subctl *       | Submariner's deploy tool (operator)
-# upx            | binary compression
-# jq             | JSON processing (GitHub API)
-# ShellCheck     | shell script linting
-# npm            | Required for installing markdownlint
-# markdownlint   | Markdown linting
-# gitlint        | Commit message linting
-# yamllint       | YAML linting
+# Component        | Usage
+# -------------------------------------------------------------
+# curl             | download other tools
+# findutils        | validate (find go packages)
+# gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
+# ginkgo           | tests
+# git              | find the workspace root
+# gitlint          | Commit message linting
+# golang           | build
+# golangci-lint    | code linting
+# helm             | e2e tests
+# jq               | JSON processing (GitHub API)
+# kind             | e2e tests
+# kubectl          | e2e tests (in kubernetes-client)
+# make             | OLM installation
+# markdownlint     | Markdown linting
+# moby-engine      | Dapper (Docker)
+# npm              | Required for installing markdownlint
+# ShellCheck       | shell script linting
+# subctl *         | Submariner's deploy tool (operator)
+# upx              | binary compression
+# yamllint         | YAML linting
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -28,6 +28,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # markdownlint     | Markdown linting
 # moby-engine      | Dapper (Docker)
 # npm              | Required for installing markdownlint
+# qemu-user-static | Emulation (for multiarch builds)
 # ShellCheck       | shell script linting
 # subctl *         | Submariner's deploy tool (operator)
 # upx              | binary compression
@@ -36,7 +37,8 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq ShellCheck npm gitlint yamllint && \
+                   findutils upx jq ShellCheck npm gitlint yamllint \
+                   qemu-user-static && \
     npm install -g markdownlint-cli && \
     rpm -e --nodeps containerd npm && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \


### PR DESCRIPTION
This will allow building images for different architectures. For the
time being only a single architecture can be built at a time, because
multiarch images can only be pushed to a registry.

Signed-off-by: Stephen Kitt <skitt@redhat.com>