### PR TITLE
Monitor all configured applications

### DIFF
--- a/scripts/shared/resources/prometheus/prometheus.yaml
+++ b/scripts/shared/resources/prometheus/prometheus.yaml
@@ -9,6 +9,4 @@ spec:
   replicas: 1
   serviceAccountName: prometheus
   serviceMonitorNamespaceSelector: {}
-  serviceMonitorSelector:
-    matchLabels:
-      name: submariner-operator
+  serviceMonitorSelector: {}


### PR DESCRIPTION
This patch changes the Prometheus operator configuration to track all
ServiceMonitors; this is similar to the OpenShift "user workload
monitoring", and avoids having to change the descriptor when adding
new metrics in Submariner projects.

Signed-off-by: Stephen Kitt <skitt@redhat.com>