### PR TITLE
Test the same cable drivers as consuming projects

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
+        cabledriver: ['libreswan']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -25,9 +26,23 @@ jobs:
           # Operator and Helm are mutually exclusive, don't try to use Helm in Operator repo
           - project: submariner-operator
             deploytool: helm
+        include:
+          # Test the same set of cable driver combinations as the consuming projects do in their CI
+          - project: submariner
+            cabledriver: strongswan
+            deploytool: operator
+          - project: submariner
+            cabledriver: wireguard
+            deploytool: operator
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@v2
+
+      - name: Install WireGuard kernel module (only in WireGuard jobs)
+        if: matrix.cabledriver == 'wireguard'
+        run: |
+          sudo apt install -y linux-headers-$(uname -r) wireguard
+          sudo modprobe wireguard
 
       - name: Reclaim free space!
         run: |
@@ -48,7 +63,7 @@ jobs:
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
 
       - name: Run E2E deployment and tests
-        run: make e2e using="${{ matrix.deploytool }}"
+        run: make e2e using="${{ matrix.deploytool }} ${{ matrix.cabledriver }}"
 
       - name: Post mortem
         if: failure()


### PR DESCRIPTION
In E2E CI for consuming projects, which is non-default and only
triggered if a label is explicitly added, add cable driver to the test
matrix. Only test exactly the combinations that are covered in the CI of
the consuming projects.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>