### PR TITLE
Stop manually deleting pods

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -51,7 +51,7 @@ import_image quay.io/submariner/submariner-route-agent ${image_tag}
 load_deploytool $deploytool
 deploytool_prereqs
 
-run_subm_clusters prepare_cluster "$SUBM_NS"
+run_subm_clusters prepare_cluster
 
 with_context $broker setup_broker
 install_subm_all_clusters

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -112,14 +112,7 @@ function del_subm_gateway_label() {
 }
 
 function prepare_cluster() {
-    local namespace=$1
     [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
-    for app in submariner-engine submariner-routeagent submariner-globalnet; do
-        if kubectl wait --for=condition=Ready pods -l "app=$app" -n "$namespace" --timeout="${timeout}" > /dev/null 2>&1; then
-            echo "Removing $app pods..."
-            kubectl delete pods -n "$namespace" -l "app=$app"
-        fi
-    done
     add_subm_gateway_label
 }
 


### PR DESCRIPTION
When joining a cluster, subctl deletes any Submariner CR when it
starts, which stops all the Submariner-related pods (apart from the
operator). It is thus not useful to manually delete the pods. What's
more, we want to test the startup behaviour with existing pods in
place, if any; manually deleting them could hide issues.

Signed-off-by: Stephen Kitt <skitt@redhat.com>