### PR TITLE
Use nginx image from quay.io

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: nginxinc/nginx-unprivileged:stable-alpine
+          image: quay.io/bitnami/nginx:latest
           ports:
             - containerPort: 8080
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -87,7 +87,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "nginxinc/nginx-unprivileged:stable-alpine",
+							Image:           "quay.io/bitnami/nginx:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
Due to dockerhub api limits, we run into sporadic failures
when running e2e as it fails to load nginx image.
Use `quay.io/bitnami/nginx:latest` instead to avoid such issues.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>