### PR TITLE
Display the nodeName for the e2e pods

### DIFF
--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -141,10 +141,12 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		framework.Logf("Will send traffic from IP: %v", sourceIP)
 	}
 
-	By(fmt.Sprintf("Waiting for the connector pod %q to exit, returning what connector sent", connectorPod.Pod.Name))
+	By(fmt.Sprintf("Waiting for the connector pod %q on node %q to exit, returning what connector sent",
+		connectorPod.Pod.Name, connectorPod.Pod.Spec.NodeName))
 	connectorPod.AwaitFinish()
 
-	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
+	By(fmt.Sprintf("Waiting for the listener pod %q on node %q to exit, returning what listener sent",
+		listenerPod.Pod.Name, listenerPod.Pod.Spec.NodeName))
 	listenerPod.AwaitFinish()
 
 	framework.Logf("Connector pod has IP: %s", connectorPod.Pod.Status.PodIP)


### PR DESCRIPTION
In some situations, its helpful to know the nodeName on
which the e2e pods are scheduled.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>