### PR TITLE
Add a Submariner image pruning command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,20 @@ images: package/.image.shipyard-dapper-base
 .DEFAULT_GOAL := lint
 # Shipyard-specific ends
 
+# This removes all Submariner-provided images and all untagged images
+# Use this to ensure you use current images
+prune-images:
+	docker images | grep -E '(admiral|lighthouse|nettest|shipyard|submariner|<none>)' | while read image tag hash _; do \
+	    if [ "$$tag" != "<none>" ]; then \
+	        docker rmi $$image:$$tag; \
+	    else \
+	        docker rmi $$hash; \
+	    fi \
+	done
+
+NON_DAPPER_GOALS += prune-images
+.PHONY: prune-images
+
 include Makefile.dapper
 
 endif

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -12,7 +12,7 @@
 
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
-$(filter-out .dapper images shell,$(MAKECMDGOALS)): .dapper
+$(filter-out .dapper images shell $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
 	+./.dapper -m bind make $@ $(MAKEFLAGS)
 
 shell: .dapper

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -90,3 +90,16 @@ endif
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners
+
+# This removes all Submariner-provided images and all untagged images
+# Use this to ensure you use current images
+# Copied from Makefile to provide this everywhere (until we can share
+# non-Dapper goals across projects)
+prune-images:
+	docker images | grep -E '(admiral|lighthouse|nettest|shipyard|submariner|<none>)' | while read image tag hash _; do \
+	    if [ "$$tag" != "<none>" ]; then \
+	        docker rmi $$image:$$tag; \
+	    else \
+	        docker rmi $$hash; \
+	    fi \
+	done


### PR DESCRIPTION
This defines

        make prune-subm-images

which prunes all Submariner-provided images, ensuring that the next
deployment will pull or build all the images it needs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>