### PR TITLE
Initial support for OVN in Kind

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -33,6 +33,10 @@ ifneq (,$(filter prometheus,$(_using)))
 override CLUSTERS_ARGS += --prometheus
 endif
 
+ifneq (,$(filter ovn,$(_using)))
+override CLUSTERS_ARGS += --ovn
+endif
+
 # Shipyard provided targets
 
 cleanup:

--- a/ovn/daemonset.sh
+++ b/ovn/daemonset.sh
@@ -1,0 +1,335 @@
+#!/bin/bash
+#set -x
+
+#Always exit on errors
+set -e
+
+# The script renders j2 templates into yaml files in .${OVN_YAML_DIR}/
+
+# ensure j2 renderer installed
+## pip freeze | grep j2cli || pip install j2cli[yaml] --user
+export PATH=~/.local/bin:$PATH
+
+OVN_IMAGE=""
+OVN_IMAGE_PULL_POLICY=""
+OVN_NET_CIDR=""
+OVN_SVC_DIDR=""
+OVN_K8S_APISERVER=""
+OVN_GATEWAY_MODE=""
+OVN_GATEWAY_OPTS=""
+OVN_DB_REPLICAS=""
+OVN_MTU=""
+OVN_SSL_ENABLE=""
+KIND=""
+OVN_UNPRIVILEGED_MODE=""
+MASTER_LOGLEVEL=""
+NODE_LOGLEVEL=""
+DBCHECKER_LOGLEVEL=""
+OVN_LOGLEVEL_NORTHD=""
+OVN_LOGLEVEL_NB=""
+OVN_LOGLEVEL_SB=""
+OVN_LOGLEVEL_CONTROLLER=""
+OVN_LOGLEVEL_NBCTLD=""
+OVNKUBE_LOGFILE_MAXSIZE=""
+OVNKUBE_LOGFILE_MAXBACKUPS=""
+OVNKUBE_LOGFILE_MAXAGE=""
+OVN_MASTER_COUNT=""
+OVN_REMOTE_PROBE_INTERVAL=""
+OVN_HYBRID_OVERLAY_ENABLE=""
+OVN_DISABLE_SNAT_MULTIPLE_GWS=""
+OVN_MULTICAST_ENABLE=""
+OVN_EGRESSIP_ENABLE=
+OVN_V4_JOIN_SUBNET=""
+OVN_V6_JOIN_SUBNET=""
+
+# Parse parameters given as arguments to this script.
+while [ "$1" != "" ]; do
+  PARAM=$(echo $1 | awk -F= '{print $1}')
+  VALUE=$(echo $1 | cut -d= -f2-)
+  case $PARAM in
+  --image)
+    OVN_IMAGE=$VALUE
+    ;;
+  --image-pull-policy)
+    OVN_IMAGE_PULL_POLICY=$VALUE
+    ;;
+  --gateway-mode)
+    OVN_GATEWAY_MODE=$VALUE
+    ;;
+  --gateway-options)
+    OVN_GATEWAY_OPTS=$VALUE
+    ;;
+  --net-cidr)
+    OVN_NET_CIDR=$VALUE
+    ;;
+  --svc-cidr)
+    OVN_SVC_CIDR=$VALUE
+    ;;
+  --k8s-apiserver)
+    OVN_K8S_APISERVER=$VALUE
+    ;;
+  --db-replicas)
+    OVN_DB_REPLICAS=$VALUE
+    ;;
+  --mtu)
+    OVN_MTU=$VALUE
+    ;;
+  --kind)
+    KIND=true
+    ;;
+  --ovn-unprivileged-mode)
+    OVN_UNPRIVILEGED_MODE=$VALUE
+    ;;
+  --master-loglevel)
+    MASTER_LOGLEVEL=$VALUE
+    ;;
+  --node-loglevel)
+    NODE_LOGLEVEL=$VALUE
+    ;;
+  --dbchecker-loglevel)
+    DBCHECKER_LOGLEVEL=$VALUE
+    ;;
+  --ovn-loglevel-northd)
+    OVN_LOGLEVEL_NORTHD=$VALUE
+    ;;
+  --ovn-loglevel-nb)
+    OVN_LOGLEVEL_NB=$VALUE
+    ;;
+  --ovn-loglevel-sb)
+    OVN_LOGLEVEL_SB=$VALUE
+    ;;
+  --ovn-loglevel-controller)
+    OVN_LOGLEVEL_CONTROLLER=$VALUE
+    ;;
+  --ovn-loglevel-nbctld)
+    OVN_LOGLEVEL_NBCTLD=$VALUE
+    ;;
+  --ovnkube-logfile-maxsize)
+    OVNKUBE_LOGFILE_MAXSIZE=$VALUE
+    ;;
+  --ovnkube-logfile-maxbackups)
+    OVNKUBE_LOGFILE_MAXBACKUPS=$VALUE
+    ;;
+  --ovnkube-logfile-maxage)
+    OVNKUBE_LOGFILE_MAXAGE=$VALUE
+    ;;
+  --ssl)
+    OVN_SSL_ENABLE="yes"
+    ;;
+  --ovn_nb_raft_election_timer)
+    OVN_NB_RAFT_ELECTION_TIMER=$VALUE
+    ;;
+  --ovn_sb_raft_election_timer)
+    OVN_SB_RAFT_ELECTION_TIMER=$VALUE
+    ;;
+  --ovn-master-count)
+    OVN_MASTER_COUNT=$VALUE
+    ;;
+  --ovn-nb-port)
+    OVN_NB_PORT=$VALUE
+    ;;
+  --ovn-sb-port)
+    OVN_SB_PORT=$VALUE
+    ;;
+  --ovn-nb-raft-port)
+    OVN_NB_RAFT_PORT=$VALUE
+    ;;
+  --ovn-sb-raft-port)
+    OVN_SB_RAFT_PORT=$VALUE
+    ;;
+  --hybrid-enabled)
+    OVN_HYBRID_OVERLAY_ENABLE=$VALUE
+    ;;
+  --disable-snat-multiple-gws)
+    OVN_DISABLE_SNAT_MULTIPLE_GWS=$VALUE
+    ;;
+  --multicast-enabled)
+    OVN_MULTICAST_ENABLE=$VALUE
+    ;;
+  --egress-ip-enable)
+    OVN_EGRESSIP_ENABLE=$VALUE
+    ;;
+  --v4-join-subnet)
+    OVN_V4_JOIN_SUBNET=$VALUE
+    ;;
+  --v6-join-subnet)
+    OVN_V6_JOIN_SUBNET=$VALUE
+    ;;
+  *)
+    echo "WARNING: unknown parameter \"$PARAM\""
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+# Create the daemonsets with the desired image
+# They are expanded into daemonsets in .${OVN_YAML_DIR}
+
+image=${OVN_IMAGE:-"docker.io/ovnkube/ovn-daemonset:latest"}
+echo "image: ${image}"
+
+image_pull_policy=${OVN_IMAGE_PULL_POLICY:-"IfNotPresent"}
+echo "imagePullPolicy: ${image_pull_policy}"
+
+ovn_gateway_mode=${OVN_GATEWAY_MODE}
+echo "ovn_gateway_mode: ${ovn_gateway_mode}"
+
+ovn_gateway_opts=${OVN_GATEWAY_OPTS}
+echo "ovn_gateway_opts: ${ovn_gateway_opts}"
+
+ovn_db_replicas=${OVN_DB_REPLICAS:-3}
+echo "ovn_db_replicas: ${ovn_db_replicas}"
+ovn_db_minAvailable=$(((${ovn_db_replicas} + 1) / 2))
+echo "ovn_db_minAvailable: ${ovn_db_minAvailable}"
+master_loglevel=${MASTER_LOGLEVEL:-"4"}
+echo "master_loglevel: ${master_loglevel}"
+node_loglevel=${NODE_LOGLEVEL:-"4"}
+echo "node_loglevel: ${node_loglevel}"
+db_checker_loglevel=${DBCHECKER_LOGLEVEL:-"4"}
+echo "db_checker_loglevel: ${db_checker_loglevel}"
+ovn_loglevel_northd=${OVN_LOGLEVEL_NORTHD:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_northd: ${ovn_loglevel_northd}"
+ovn_loglevel_nb=${OVN_LOGLEVEL_NB:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_nb: ${ovn_loglevel_nb}"
+ovn_loglevel_sb=${OVN_LOGLEVEL_SB:-"-vconsole:info -vfile:info"}
+echo "ovn_loglevel_sb: ${ovn_loglevel_sb}"
+ovn_loglevel_controller=${OVN_LOGLEVEL_CONTROLLER:-"-vconsole:info"}
+echo "ovn_loglevel_controller: ${ovn_loglevel_controller}"
+ovn_loglevel_nbctld=${OVN_LOGLEVEL_NBCTLD:-"-vconsole:info"}
+echo "ovn_loglevel_nbctld: ${ovn_loglevel_nbctld}"
+ovnkube_logfile_maxsize=${OVNKUBE_LOGFILE_MAXSIZE:-"100"}
+echo "ovnkube_logfile_maxsize: ${ovnkube_logfile_maxsize}"
+ovnkube_logfile_maxbackups=${OVNKUBE_LOGFILE_MAXBACKUPS:-"5"}
+echo "ovnkube_logfile_maxbackups: ${ovnkube_logfile_maxbackups}"
+ovnkube_logfile_maxage=${OVNKUBE_LOGFILE_MAXAGE:-"5"}
+echo "ovnkube_logfile_maxage: ${ovnkube_logfile_maxage}"
+ovn_hybrid_overlay_enable=${OVN_HYBRID_OVERLAY_ENABLE}
+echo "ovn_hybrid_overlay_enable: ${ovn_hybrid_overlay_enable}"
+ovn_egress_ip_enable=${OVN_EGRESSIP_ENABLE}
+echo "ovn_egress_ip_enable: ${ovn_egress_ip_enable}"
+ovn_hybrid_overlay_net_cidr=${OVN_HYBRID_OVERLAY_NET_CIDR}
+echo "ovn_hybrid_overlay_net_cidr: ${ovn_hybrid_overlay_net_cidr}"
+ovn_disable_snat_multiple_gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS}
+echo "ovn_disable_snat_multiple_gws: ${ovn_disable_snat_multiple_gws}"
+ovn_ssl_en=${OVN_SSL_ENABLE:-"no"}
+echo "ovn_ssl_enable: ${ovn_ssl_en}"
+ovn_unprivileged_mode=${OVN_UNPRIVILEGED_MODE:-"no"}
+echo "ovn_unprivileged_mode: ${ovn_unprivileged_mode}"
+ovn_nb_raft_election_timer=${OVN_NB_RAFT_ELECTION_TIMER:-1000}
+echo "ovn_nb_raft_election_timer: ${ovn_nb_raft_election_timer}"
+ovn_sb_raft_election_timer=${OVN_SB_RAFT_ELECTION_TIMER:-1000}
+echo "ovn_sb_raft_election_timer: ${ovn_sb_raft_election_timer}"
+ovn_master_count=${OVN_MASTER_COUNT:-"1"}
+echo "ovn_master_count: ${ovn_master_count}"
+ovn_remote_probe_interval=${OVN_REMOTE_PROBE_INTERVAL:-"100000"}
+echo "ovn_remote_probe_interval: ${ovn_remote_probe_interval}"
+ovn_nb_port=${OVN_NB_PORT:-6641}
+echo "ovn_nb_port: ${ovn_nb_port}"
+ovn_sb_port=${OVN_SB_PORT:-6642}
+echo "ovn_sb_port: ${ovn_sb_port}"
+ovn_nb_raft_port=${OVN_NB_RAFT_PORT:-6643}
+echo "ovn_nb_raft_port: ${ovn_nb_raft_port}"
+ovn_sb_raft_port=${OVN_SB_RAFT_PORT:-6644}
+echo "ovn_sb_raft_port: ${ovn_sb_raft_port}"
+ovn_multicast_enable=${OVN_MULTICAST_ENABLE}
+echo "ovn_multicast_enable: ${ovn_multicast_enable}"
+ovn_v4_join_subnet=${OVN_V4_JOIN_SUBNET}
+echo "ovn_v4_join_subnet: ${ovn_v4_join_subnet}"
+ovn_v6_join_subnet=${OVN_V6_JOIN_SUBNET}
+echo "ovn_v6_join_subnet: ${ovn_v6_join_subnet}"
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  kind=${KIND} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  ovn_gateway_mode=${ovn_gateway_mode} \
+  ovn_gateway_opts=${ovn_gateway_opts} \
+  ovnkube_node_loglevel=${node_loglevel} \
+  ovn_loglevel_controller=${ovn_loglevel_controller} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
+  ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_v4_join_subnet=${ovn_v4_join_subnet} \
+  ovn_v6_join_subnet=${ovn_v6_join_subnet} \
+  ovn_multicast_enable=${ovn_multicast_enable} \
+  ovn_egress_ip_enable=${ovn_egress_ip_enable} \
+  ovn_ssl_en=${ovn_ssl_en} \
+  ovn_remote_probe_interval=${ovn_remote_probe_interval} \
+  j2 ./templates/ovnkube-node.yaml.j2 -o ${OVN_YAML_DIR}/ovnkube-node.yaml
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovnkube_master_loglevel=${master_loglevel} \
+  ovn_loglevel_northd=${ovn_loglevel_northd} \
+  ovn_loglevel_nbctld=${ovn_loglevel_nbctld} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovn_hybrid_overlay_net_cidr=${ovn_hybrid_overlay_net_cidr} \
+  ovn_hybrid_overlay_enable=${ovn_hybrid_overlay_enable} \
+  ovn_disable_snat_multiple_gws=${ovn_disable_snat_multiple_gws} \
+  ovn_v4_join_subnet=${ovn_v4_join_subnet} \
+  ovn_v6_join_subnet=${ovn_v6_join_subnet} \
+  ovn_multicast_enable=${ovn_multicast_enable} \
+  ovn_egress_ip_enable=${ovn_egress_ip_enable} \
+  ovn_ssl_en=${ovn_ssl_en} \
+  ovn_master_count=${ovn_master_count} \
+  ovn_gateway_mode=${ovn_gateway_mode} \
+  j2 ./templates/ovnkube-master.yaml.j2 -o ${OVN_YAML_DIR}/ovnkube-master.yaml
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_loglevel_nb=${ovn_loglevel_nb} \
+  ovn_loglevel_sb=${ovn_loglevel_sb} \
+  ovn_ssl_en=${ovn_ssl_en} \
+  ovn_nb_port=${ovn_nb_port} \
+  ovn_sb_port=${ovn_sb_port} \
+  j2 ./templates/ovnkube-db.yaml.j2 -o ${OVN_YAML_DIR}/ovnkube-db.yaml
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_db_replicas=${ovn_db_replicas} \
+  ovn_db_minAvailable=${ovn_db_minAvailable} \
+  ovn_loglevel_nb=${ovn_loglevel_nb} ovn_loglevel_sb=${ovn_loglevel_sb} \
+  ovn_dbchecker_loglevel=${db_checker_loglevel} \
+  ovnkube_logfile_maxsize=${ovnkube_logfile_maxsize} \
+  ovnkube_logfile_maxbackups=${ovnkube_logfile_maxbackups} \
+  ovnkube_logfile_maxage=${ovnkube_logfile_maxage} \
+  ovn_ssl_en=${ovn_ssl_en} \
+  ovn_nb_raft_election_timer=${ovn_nb_raft_election_timer} \
+  ovn_sb_raft_election_timer=${ovn_sb_raft_election_timer} \
+  ovn_nb_port=${ovn_nb_port} \
+  ovn_sb_port=${ovn_sb_port} \
+  ovn_nb_raft_port=${ovn_nb_raft_port} \
+  ovn_sb_raft_port=${ovn_sb_raft_port} \
+  j2 ./templates/ovnkube-db-raft.yaml.j2 -o ${OVN_YAML_DIR}/ovnkube-db-raft.yaml
+
+ovn_image=${image} \
+  ovn_image_pull_policy=${image_pull_policy} \
+  ovn_unprivileged_mode=${ovn_unprivileged_mode} \
+  j2 ./templates/ovs-node.yaml.j2 -o ${OVN_YAML_DIR}/ovs-node.yaml
+
+# ovn-setup.yaml
+net_cidr=${OVN_NET_CIDR:-"10.128.0.0/14/23"}
+svc_cidr=${OVN_SVC_CIDR:-"172.30.0.0/16"}
+k8s_apiserver=${OVN_K8S_APISERVER:-"10.0.2.16:6443"}
+mtu=${OVN_MTU:-1400}
+
+echo "net_cidr: ${net_cidr}"
+echo "svc_cidr: ${svc_cidr}"
+echo "k8s_apiserver: ${k8s_apiserver}"
+echo "mtu: ${mtu}"
+
+net_cidr=${net_cidr} svc_cidr=${svc_cidr} \
+  mtu_value=${mtu} k8s_apiserver=${k8s_apiserver} \
+  j2 ./templates/ovn-setup.yaml.j2 -o ${OVN_YAML_DIR}/ovn-setup.yaml
+
+cp ./templates/ovnkube-monitor.yaml.j2 ${OVN_YAML_DIR}/ovnkube-monitor.yaml
+cp ./templates/k8s.ovn.org_egressfirewalls.yaml.j2 ${OVN_YAML_DIR}/k8s.ovn.org_egressfirewalls.yaml
+cp ./templates/k8s.ovn.org_egressips.yaml.j2 ${OVN_YAML_DIR}/k8s.ovn.org_egressips.yaml
+
+exit 0

--- a/ovn/ingress/mandatory.yaml
+++ b/ovn/ingress/mandatory.yaml
@@ -1,0 +1,294 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-clusterrole
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-clusterrole-nisa-binding
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+    spec:
+      # wait up to five minutes for the drain of connections
+      terminationGracePeriodSeconds: 300
+      serviceAccountName: nginx-ingress-serviceaccount
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0
+          args:
+            - /nginx-ingress-controller
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 101
+            runAsUser: 101
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown
+
+---
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  limits:
+    - min:
+        memory: 90Mi
+        cpu: 100m
+      type: Container

--- a/ovn/ingress/service-nodeport.yaml
+++ b/ovn/ingress/service-nodeport.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---

--- a/ovn/kind.sh
+++ b/ovn/kind.sh
@@ -1,0 +1,459 @@
+#!/usr/bin/env bash
+
+run_kubectl() {
+  local retries=0
+  local attempts=10
+  while true; do
+    if kubectl "$@"; then
+      break
+    fi
+
+    ((retries += 1))
+    if [[ "${retries}" -gt ${attempts} ]]; then
+      echo "error: 'kubectl $*' did not succeed, failing"
+      exit 1
+    fi
+    echo "info: waiting for 'kubectl $*' to succeed..."
+    sleep 1
+  done
+}
+
+# Some environments (Fedora32,31 on desktop), have problems when the cluster
+# is deleted directly with kind `kind delete cluster --name ovn`, it restarts the host.
+# The root cause is unknown, this also can not be reproduced in Ubuntu 20.04 or
+# with Fedora32 Cloud, but it does not happen if we clean first the ovn-kubernetes resources.
+delete()
+{
+  timeout 5 kubectl --kubeconfig ${KUBECONFIGS_DIR}/${KIND_CLUSTER_NAME} delete namespace ovn-kubernetes || true
+  sleep 5
+  kind delete cluster --name ${KIND_CLUSTER_NAME:-ovn}
+  rm -rf ${KUBECONFIGS_DIR}/${KIND_CLUSTER_NAME}
+}
+
+usage()
+{
+    echo "usage: kind.sh [[[-cf|--config-file <file>] [-kt|keep-taint] [-ha|--ha-enabled]"
+    echo "                 [-ho|--hybrid-enabled] [-ii|--install-ingress] [-n4|--no-ipv4]"
+    echo "                 [-i6|--ipv6] [-wk|--num-workers <num>] [-ds|--disable-snat-multiple-gws]"
+    echo "                 [-sw|--allow-system-writes] [-gm|--gateway-mode <mode>]] |"
+    echo "                [-h]]"
+    echo ""
+    echo "-cf | --config-file               Name of the KIND J2 configuration file."
+    echo "                                  DEFAULT: ./kind.yaml.j2"
+    echo "-kt | --keep-taint                Do not remove taint components."
+    echo "                                  DEFAULT: Remove taint components."
+    echo "-ha | --ha-enabled                Enable high availability. DEFAULT: HA Disabled."
+    echo "-ho | --hybrid-enabled            Enable hybrid overlay. DEFAULT: Disabled."
+    echo "-ds | --disable-snat-multiple-gws Disable SNAT for multiple gws. DEFAULT: Disabled."
+    echo "-ii | --install-ingress           Flag to install Ingress Components."
+    echo "                                  DEFAULT: Don't install ingress components."
+    echo "-n4 | --no-ipv4                   Disable IPv4. DEFAULT: IPv4 Enabled."
+    echo "-i6 | --ipv6                      Enable IPv6. DEFAULT: IPv6 Disabled."
+    echo "-wk | --num-workers               Number of worker nodes. DEFAULT: HA - 2 worker"
+    echo "                                  nodes and no HA - 0 worker nodes."
+    echo "-sw | --allow-system-writes       Allow script to update system. Intended to allow"
+    echo "                                  github CI to be updated with IPv6 settings."
+    echo "                                  DEFAULT: Don't allow."
+    echo "-gm | --gateway-mode              Enable 'shared' or 'local' gateway mode."
+    echo "                                  DEFAULT: local."
+    echo "-ov | --ovn-image            	    Use the specified docker image instead of building locally. DEFAULT: local build."
+    echo "-nm | --name                     	kind cluster name"
+    echo "--delete                     	    Delete current cluster"
+    echo ""
+}
+
+parse_args()
+{
+    while [ "$1" != "" ]; do
+        case $1 in
+            -cf | --config-file )               shift
+                                                if test ! -f "$1"; then
+                                                    echo "$1 does not  exist"
+                                                    usage
+                                                    exit 1
+                                                fi
+                                                KIND_CONFIG=$1
+                                                ;;
+            -ii | --install-ingress )           KIND_INSTALL_INGRESS=true
+                                                ;;
+            -ha | --ha-enabled )                OVN_HA=true
+                                                ;;
+            -me | --multicast-enabled)          OVN_MULTICAST_ENABLE=true
+                                                ;;
+            -ho | --hybrid-enabled )            OVN_HYBRID_OVERLAY_ENABLE=true
+                                                ;;
+            -ds | --disable-snat-multiple-gws ) OVN_DISABLE_SNAT_MULTIPLE_GWS=true
+                                                ;;
+            -kt | --keep-taint )                KIND_REMOVE_TAINT=false
+                                                ;;
+            -n4 | --no-ipv4 )                   KIND_IPV4_SUPPORT=false
+                                                ;;
+            -i6 | --ipv6 )                      KIND_IPV6_SUPPORT=true
+                                                ;;
+            -wk | --num-workers )               shift
+                                                if ! [[ "$1" =~ ^[0-9]+$ ]]; then
+                                                    echo "Invalid num-workers: $1"
+                                                    usage
+                                                    exit 1
+                                                fi
+                                                KIND_NUM_WORKER=$1
+                                                ;;
+            -sw | --allow-system-writes )       KIND_ALLOW_SYSTEM_WRITES=true
+                                                ;;
+            -gm | --gateway-mode )              shift
+                                                if [ "$1" != "local" ] && [ "$1" != "shared" ]; then
+                                                    echo "Invalid gateway mode: $1"
+                                                    usage
+                                                    exit 1
+                                                fi
+                                                OVN_GATEWAY_MODE=$1
+                                                ;;
+            -ov | --ovn-image )                 shift
+                                                OVN_IMAGE=$1
+                                                ;;
+            -nm | --name )                      shift
+                                                KIND_CLUSTER_NAME=$1
+                                                OVN_YAML_DIR=${DAPPER_OUTPUT}/${KIND_CLUSTER_NAME}-yamls
+                                                ;;
+            --delete )                          delete
+                                                exit
+                                                ;;
+            -h | --help )                       usage
+                                                exit
+                                                ;;
+            * )                                 usage
+                                                exit 1
+        esac
+        shift
+    done
+}
+
+print_params()
+{
+     echo "Using these parameters to install KIND"
+     echo ""
+     echo "KIND_INSTALL_INGRESS = $KIND_INSTALL_INGRESS"
+     echo "OVN_HA = $OVN_HA"
+     echo "KIND_CONFIG_FILE = $KIND_CONFIG"
+     echo "KIND_REMOVE_TAINT = $KIND_REMOVE_TAINT"
+     echo "KIND_IPV4_SUPPORT = $KIND_IPV4_SUPPORT"
+     echo "KIND_IPV6_SUPPORT = $KIND_IPV6_SUPPORT"
+     echo "KIND_NUM_WORKER = $KIND_NUM_WORKER"
+     echo "KIND_ALLOW_SYSTEM_WRITES = $KIND_ALLOW_SYSTEM_WRITES"
+     echo "OVN_GATEWAY_MODE = $OVN_GATEWAY_MODE"
+     echo "OVN_HYBRID_OVERLAY_ENABLE = $OVN_HYBRID_OVERLAY_ENABLE"
+     echo "OVN_DISABLE_SNAT_MULTIPLE_GWS = $OVN_DISABLE_SNAT_MULTIPLE_GWS"
+     echo "OVN_MULTICAST_ENABLE = $OVN_MULTICAST_ENABLE"
+     echo "OVN_IMAGE = $OVN_IMAGE"
+     echo "KUBECONFIG_DIRS = $KUBECONFIGS_DIR"
+     echo ""
+}
+
+
+KUBECONFIGS_DIR=${DAPPER_OUTPUT}/kubeconfigs
+
+parse_args $*
+
+# ensure j2 renderer installed
+#pip install wheel
+#pip freeze | grep j2cli || pip install j2cli[yaml] --user
+export PATH=~/.local/bin:$PATH
+
+# Set default values
+KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:-ovn}
+K8S_VERSION=${K8S_VERSION:-v1.17.0}
+OVN_GATEWAY_MODE=${OVN_GATEWAY_MODE:-local}
+KIND_INSTALL_INGRESS=${KIND_INSTALL_INGRESS:-false}
+OVN_HA=${OVN_HA:-false}
+KIND_CONFIG=${KIND_CONFIG:-./kind.yaml.j2}
+KIND_REMOVE_TAINT=${KIND_REMOVE_TAINT:-true}
+KIND_IPV4_SUPPORT=${KIND_IPV4_SUPPORT:-true}
+KIND_IPV6_SUPPORT=${KIND_IPV6_SUPPORT:-false}
+OVN_HYBRID_OVERLAY_ENABLE=${OVN_HYBRID_OVERLAY_ENABLE:-false}
+OVN_DISABLE_SNAT_MULTIPLE_GWS=${OVN_DISABLE_SNAT_MULTIPLE_GWS:-false}
+OVN_MULTICAST_ENABLE=${OVN_MULTICAST_ENABLE:-false}
+KIND_ALLOW_SYSTEM_WRITES=${KIND_ALLOW_SYSTEM_WRITES:-false}
+
+# To create this image locally follow instructions at:
+#   https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/kind.md
+# to deploy kind with `local` image.
+OVN_IMAGE=${OVN_IMAGE:-quay.io/vthapar/ovn-daemonset-f:latest}
+
+OVN_YAML_DIR=${OVN_YAML_DIR:-yaml}
+
+# Input not currently validated. Modify outside script at your own risk.
+# These are the same values defaulted to in KIND code (kind/default.go).
+# NOTE: KIND NET_CIDR_IPV6 default use a /64 but OVN have a /64 per host
+# so it needs to use a larger subnet
+#  Upstream - NET_CIDR_IPV6=fd00:10:244::/64 SVC_CIDR_IPV6=fd00:10:96::/112
+NET_CIDR_IPV4=${NET_CIDR_IPV4:-10.244.0.0/16}
+SVC_CIDR_IPV4=${SVC_CIDR_IPV4:-10.96.0.0/16}
+NET_CIDR_IPV6=${NET_CIDR_IPV6:-fd00:10:244::/48}
+SVC_CIDR_IPV6=${SVC_CIDR_IPV6:-fd00:10:96::/112}
+JOIN_SUBNET_IPV4=${JOIN_SUBNET_IPV4:-100.64.0.0/16}
+JOIN_SUBNET_IPV6=${JOIN_SUBNET_IPV6:-fd98::/64}
+KIND_NUM_MASTER=1
+if [ "$OVN_HA" == true ]; then
+  KIND_NUM_MASTER=3
+  KIND_NUM_WORKER=${KIND_NUM_WORKER:-0}
+else
+  KIND_NUM_WORKER=${KIND_NUM_WORKER:-2}
+fi
+
+print_params
+
+export OVN_YAML_DIR=${DAPPER_OUTPUT}/${KIND_CLUSTER_NAME}-yamls
+
+mkdir -p ${KUBECONFIGS_DIR}
+mkdir -p ${OVN_YAML_DIR}
+set -euxo pipefail
+
+# Detect IP to use as API server
+#
+# You can't use an IPv6 address for the external API, docker does not support
+# IPv6 port mapping. Always use the IPv4 host address for the API Server field.
+# This will keep compatibility and people will be able to connect with kubectl
+# from outside
+#
+# ip -4 addr -> Run ip command for IPv4
+# grep -oP '(?<=inet\s)\d+(\.\d+){3}' -> Use only the lines with the
+#   IPv4 Addresses and strip off the trailing subnet mask, /xx
+# grep -v "127.0.0.1" -> Remove local host
+# head -n 1 -> Of the remaining, use first entry
+#API_IP=$(ip -4 addr | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v "127.0.0.1" | head -n 1)
+#if [ -z "$API_IP" ]; then
+# echo "Error detecting machine IPv4 to use as API server. Default to 0.0.0.0."
+# API_IP=0.0.0.0
+#fi
+#API_IP=127.0.0.1
+
+function kind_fixup_config() {
+    local master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${KIND_CLUSTER_NAME}-control-plane | head -n 1)
+    sed -i -- "s/server: .*/server: https:\/\/$master_ip:6443/g" $KUBECONFIG
+    sed -i -- "s/user: kind-.*/user: ${KIND_CLUSTER_NAME}/g" $KUBECONFIG
+    sed -i -- "s/name: kind-.*/name: ${KIND_CLUSTER_NAME}/g" $KUBECONFIG
+    sed -i -- "s/cluster: kind-.*/cluster: ${KIND_CLUSTER_NAME}/g" $KUBECONFIG
+    sed -i -- "s/current-context: .*/current-context: ${KIND_CLUSTER_NAME}/g" $KUBECONFIG
+    chmod a+r $KUBECONFIG
+}
+
+check_ipv6() {
+  # Collect additional IPv6 data on test environment
+  ERROR_FOUND=false
+  TMPVAR=`sysctl net.ipv6.conf.all.forwarding | awk '{print $3}'`
+  echo "net.ipv6.conf.all.forwarding is equal to $TMPVAR"
+  if [ "$TMPVAR" != 1 ]; then
+    if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
+      sudo sysctl -w net.ipv6.conf.all.forwarding=1
+    else
+      echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.forwarding=1' to use IPv6."
+      ERROR_FOUND=true
+    fi
+  fi
+  TMPVAR=`sysctl net.ipv6.conf.all.disable_ipv6 | awk '{print $3}'`
+  echo "net.ipv6.conf.all.disable_ipv6 is equal to $TMPVAR"
+  if [ "$TMPVAR" != 0 ]; then
+    if [ "$KIND_ALLOW_SYSTEM_WRITES" == true ]; then
+      sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0
+    else
+      echo "RUN: 'sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0' to use IPv6."
+      ERROR_FOUND=true
+    fi
+  fi
+  if [ -f /proc/net/if_inet6 ]; then
+    echo "/proc/net/if_inet6 exists so IPv6 supported in kernel."
+  else
+    echo "/proc/net/if_inet6 does not exists so no IPv6 support found! Compile the kernel!!"
+    ERROR_FOUND=true
+  fi
+  if "$ERROR_FOUND"; then
+    exit 2
+  fi
+}
+
+if [ "$KIND_IPV6_SUPPORT" == true ]; then
+  check_ipv6
+fi
+
+if [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == false ]; then
+  IP_FAMILY=""
+  NET_CIDR=$NET_CIDR_IPV4
+  SVC_CIDR=$SVC_CIDR_IPV4
+  echo "IPv4 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+elif [ "$KIND_IPV4_SUPPORT" == false ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
+  IP_FAMILY="ipv6"
+  NET_CIDR=$NET_CIDR_IPV6
+  SVC_CIDR=$SVC_CIDR_IPV6
+  echo "IPv6 Only Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+elif [ "$KIND_IPV4_SUPPORT" == true ] && [ "$KIND_IPV6_SUPPORT" == true ]; then
+  IP_FAMILY="DualStack"
+  NET_CIDR=$NET_CIDR_IPV4,$NET_CIDR_IPV6
+  SVC_CIDR=$SVC_CIDR_IPV4,$SVC_CIDR_IPV6
+  echo "Dual Stack Support: --net-cidr=$NET_CIDR --svc-cidr=$SVC_CIDR"
+else
+  echo "Invalid setup. KIND_IPV4_SUPPORT and/or KIND_IPV6_SUPPORT must be true."
+  exit 1
+fi
+
+# Output of the j2 command
+KIND_CONFIG_LCL=${OVN_YAML_DIR}/kind-config-${KIND_CLUSTER_NAME}.yaml
+
+#ovn_apiServerAddress=${API_IP} \
+ovn_ip_family=${IP_FAMILY} \
+  ovn_ha=${OVN_HA} \
+  net_cidr=${NET_CIDR} \
+  svc_cidr=${SVC_CIDR} \
+  ovn_num_master=${KIND_NUM_MASTER} \
+  ovn_num_worker=${KIND_NUM_WORKER} \
+  cluster_log_level=${KIND_CLUSTER_LOGLEVEL:-4} \
+  j2 ${KIND_CONFIG} -o ${KIND_CONFIG_LCL}
+
+# Create KIND cluster. For additional debug, add '--verbosity <int>': 0 None .. 3 Debug
+#export KUBECONFIG=${KUBECONFIGS_DIR}/${KIND_CLUSTER_NAME}
+if kind get clusters | grep ${KIND_CLUSTER_NAME}; then
+  delete
+fi
+kind create cluster --name ${KIND_CLUSTER_NAME} --kubeconfig ${KUBECONFIG} --image kindest/node:${K8S_VERSION} --config=${KIND_CONFIG_LCL}
+kind_fixup_config
+
+cat ${KUBECONFIG}
+
+if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+  # Patch CoreDNS to work in Github CI
+  # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+  # to work in an offline environment:
+  # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+  # 2. Github CI adds following domains to resolv.conf search field:
+  # .net.
+  # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+  # otherwise pods stops trying to resolve the domain.
+  # Get the current config
+  original_coredns=$(kubectl get -oyaml -n=kube-system configmap/coredns)
+  echo "Original CoreDNS config:"
+  echo "${original_coredns}"
+  # Patch it
+  fixed_coredns=$(
+    printf '%s' "${original_coredns}" | sed \
+      -e 's/^.*kubernetes cluster\.local/& net/' \
+      -e '/^.*upstream$/d' \
+      -e '/^.*fallthrough.*$/d' \
+      -e '/^.*forward . \/etc\/resolv.conf$/d' \
+      -e '/^.*loop$/d' \
+  )
+  echo "Patched CoreDNS config:"
+  echo "${fixed_coredns}"
+  printf '%s' "${fixed_coredns}" | kubectl apply -f -
+fi
+
+echo "Checking for image: $OVN_IMAGE"
+if [ "$OVN_IMAGE" == local ]; then
+  echo "OVN_IMAGE=local currently not supported, specify non local image"
+  exit 1
+  # Build ovn docker image
+  pushd ../go-controller
+  make
+  popd
+
+  # Build ovn kube image
+  pushd ../dist/images
+  # Find all built executables, but ignore the 'windows' directory if it exists
+  BINS=$(find ../../go-controller/_output/go/bin/ -maxdepth 1 -type f | xargs)
+  sudo cp -f ${BINS} .
+  echo "ref: $(git rev-parse  --symbolic-full-name HEAD)  commit: $(git rev-parse  HEAD)" > git_info
+  docker build -t ovn-daemonset-f:dev -f Dockerfile.fedora .
+  OVN_IMAGE=ovn-daemonset-f:dev
+  popd
+elif [[ "$(docker image inspect ${OVN_IMAGE} 2> /dev/null)" == "[]" ]]; then
+  echo "Image not available, downloading..."
+  docker pull $OVN_IMAGE
+fi
+
+# Detect API IP address for OVN
+
+# Despite OVN run in pod they will only obtain the VIRTUAL apiserver address
+# and since OVN has to provide the connectivity to service
+# it can not be bootstrapped
+
+# This is the address of the node with the control-plane
+API_URL=$(kind get kubeconfig --internal --name ${KIND_CLUSTER_NAME} | grep server | awk '{ print $2 }')
+
+# Create ovn-kube manifests
+#pushd ../dist/images
+./daemonset.sh \
+  --image=${OVN_IMAGE} \
+  --net-cidr=${NET_CIDR} \
+  --svc-cidr=${SVC_CIDR} \
+  --gateway-mode=${OVN_GATEWAY_MODE} \
+  --hybrid-enabled=${OVN_HYBRID_OVERLAY_ENABLE} \
+  --disable-snat-multiple-gws=${OVN_DISABLE_SNAT_MULTIPLE_GWS} \
+  --multicast-enabled=${OVN_MULTICAST_ENABLE} \
+  --k8s-apiserver=${API_URL} \
+  --ovn-master-count=${KIND_NUM_MASTER} \
+  --kind \
+  --ovn-unprivileged-mode=no \
+  --master-loglevel=5 \
+  --dbchecker-loglevel=5\
+  --egress-ip-enable=true\
+  --v4-join-subnet=${JOIN_SUBNET_IPV4}\
+  --v6-join-subnet=${JOIN_SUBNET_IPV6}
+#popd
+
+kind load docker-image ${OVN_IMAGE} --name ${KIND_CLUSTER_NAME}
+
+pushd ${OVN_YAML_DIR}
+run_kubectl apply -f k8s.ovn.org_egressfirewalls.yaml
+run_kubectl apply -f k8s.ovn.org_egressips.yaml
+run_kubectl apply -f ovn-setup.yaml
+MASTER_NODES=$(kind get nodes --name ${KIND_CLUSTER_NAME} | sort | head -n ${KIND_NUM_MASTER})
+# We want OVN HA not Kubernetes HA
+# leverage the kubeadm well-known label node-role.kubernetes.io/master=
+# to choose the nodes where ovn master components will be placed
+for n in $MASTER_NODES; do
+  kubectl label node $n k8s.ovn.org/ovnkube-db=true node-role.kubernetes.io/master="" --overwrite
+  if [ "$KIND_REMOVE_TAINT" == true ]; then
+    # do not error if it fails to remove the taint
+    kubectl taint node $n node-role.kubernetes.io/master:NoSchedule- || true
+  fi
+done
+
+if [ "$OVN_HA" == true ]; then
+  run_kubectl apply -f ovnkube-db-raft.yaml
+else
+  run_kubectl apply -f ovnkube-db.yaml
+fi
+run_kubectl apply -f ovs-node.yaml
+run_kubectl apply -f ovnkube-master.yaml
+run_kubectl apply -f ovnkube-node.yaml
+popd
+
+# Delete kube-proxy
+run_kubectl -n kube-system delete ds kube-proxy
+kind get clusters
+kind get nodes --name ${KIND_CLUSTER_NAME}
+#kind export kubeconfig --name ${KIND_CLUSTER_NAME}
+#kind_fixup_config
+
+if [ "$KIND_INSTALL_INGRESS" == true ]; then
+  run_kubectl apply -f ingress/mandatory.yaml
+  run_kubectl apply -f ingress/service-nodeport.yaml
+fi
+
+# Check that everything is fine and running. IPv6 cluster seems to take a little
+# longer to come up, so extend the wait time.
+OVN_TIMEOUT=300s
+if [ "$KIND_IPV6_SUPPORT" == true ]; then
+  OVN_TIMEOUT=480s
+fi
+if ! kubectl wait -n ovn-kubernetes --for=condition=ready pods --all --timeout=${OVN_TIMEOUT} ; then
+  echo "some pods in OVN Kubernetes are not running"
+  kubectl get pods -A -o wide || true
+  exit 1
+fi
+if ! kubectl wait -n kube-system --for=condition=ready pods --all --timeout=300s ; then
+  echo "some pods in the system are not running"
+  kubectl get pods -A -o wide || true
+  exit 1
+fi
+
+echo "Pods are all up, allowing things settle for 30 seconds..."
+sleep 30

--- a/ovn/kind.yaml.j2
+++ b/ovn/kind.yaml.j2
@@ -1,0 +1,62 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # the default CNI will not be installed
+  disableDefaultCNI: true
+#  apiServerAddress: {{ ovn_apiServerAddress | default('0.0.0.0') }}
+# apiServerPort: 11337
+{%- if net_cidr %}
+  podSubnet: "{{ net_cidr }}"
+{%- endif %}
+{%- if svc_cidr %}
+  serviceSubnet: "{{ svc_cidr }}"
+{%- endif %}
+{%- if ovn_ip_family %}
+  ipFamily: {{ ovn_ip_family }}
+{%- endif %}
+#featureGates:
+#  SCTPSupport: true
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  metadata:
+    name: config
+  etcd:
+    local:
+      dataDir: "/tmp/lib/etcd"
+  apiServer:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  controllerManager:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  scheduler:
+    extraArgs:
+      "v": "{{ cluster_log_level }}"
+  ---
+  kind: InitConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "{{ cluster_log_level }}"
+  ---
+  kind: JoinConfiguration
+  nodeRegistration:
+    kubeletExtraArgs:
+      "v": "{{ cluster_log_level }}"
+nodes:
+ - role: control-plane
+   kubeadmConfigPatches:
+   - |
+     kind: InitConfiguration
+     nodeRegistration:
+       kubeletExtraArgs:
+         node-labels: "ingress-ready=true"
+         authorization-mode: "AlwaysAllow"
+{%- if ovn_ha is equalto "true" %}
+{%- for _ in range(1, ovn_num_master | int) %}
+ - role: worker
+{%- endfor %}
+{%- endif %}
+{%- for _ in range(ovn_num_worker | int) %}
+ - role: worker
+{%- endfor %}

--- a/ovn/templates/cleanup-ovn-cni.conf.j2
+++ b/ovn/templates/cleanup-ovn-cni.conf.j2
@@ -1,0 +1,2 @@
+r /etc/cni/net.d/10-ovn-kubernetes.conf
+r /etc/origin/openvswitch/conf.db

--- a/ovn/templates/k8s.ovn.org_egressfirewalls.yaml.j2
+++ b/ovn/templates/k8s.ovn.org_egressfirewalls.yaml.j2
@@ -1,0 +1,110 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: egressfirewalls.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressFirewall
+    listKind: EgressFirewallList
+    plural: egressfirewalls
+    singular: egressfirewall
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.status
+      name: EgressFirewall Status
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: EgressFirewall describes the current egress firewall for a Namespace. Traffic from a pod to an IP address outside the cluster will be checked against each EgressFirewallRule in the pod's namespace's EgressFirewall, in order. If no rule matches (or no EgressFirewall is present) then the traffic will be allowed by default.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+            properties:
+              name:
+                type: string
+                pattern: ^default$
+          spec:
+            description: Specification of the desired behavior of EgressFirewall.
+            properties:
+              egress:
+                description: a collection of egress firewall rule objects
+                items:
+                  description: EgressFirewallRule is a single egressfirewall rule object
+                  properties:
+                    ports:
+                      description: ports specify what ports and protocols the rule applies to
+                      items:
+                        description: EgressFirewallPort specifies the port to allow or deny traffic to
+                        properties:
+                          port:
+                            description: port that the traffic must match
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          protocol:
+                            description: protocol (tcp, udp, sctp) that the traffic must match.
+                            pattern: ^TCP|UDP|SCTP$
+                            type: string
+                        required:
+                        - port
+                        - protocol
+                        type: object
+                      type: array
+                    to:
+                      description: to is the target that traffic is allowed/denied to
+                      properties:
+                        cidrSelector:
+                          description: cidrSelector is the CIDR range to allow/deny traffic to. If this is set, dnsName must be unset.
+                          type: string
+                        dnsName:
+                          description: dnsName is the domain name to allow/deny traffic to. If this is set, cidrSelector must be unset.
+                          pattern: ^([A-Za-z0-9-]+\.)*[A-Za-z0-9-]+\.?$
+                          type: string
+                      type: object
+                      minProperties: 1
+                      maxProperties: 1
+                    type:
+                      description: type marks this as an "Allow" or "Deny" rule
+                      pattern: ^Allow|Deny$
+                      type: string
+                  required:
+                  - to
+                  - type
+                  type: object
+                type: array
+            required:
+            - egress
+            type: object
+          status:
+            description: Observed status of EgressFirewall
+            properties:
+              status:
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/ovn/templates/k8s.ovn.org_egressips.yaml.j2
+++ b/ovn/templates/k8s.ovn.org_egressips.yaml.j2
@@ -1,0 +1,144 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: egressips.k8s.ovn.org
+spec:
+  group: k8s.ovn.org
+  names:
+    kind: EgressIP
+    listKind: EgressIPList
+    plural: egressips
+    shortNames:
+    - eip
+    singular: egressip
+  scope: Cluster
+  versions:
+  - name: v1
+    additionalPrinterColumns:
+    - jsonPath: .spec.egressIPs[*]
+      name: EgressIPs
+      type: string
+    - jsonPath: .status.items[*].node
+      name: Assigned Node
+      type: string
+    - jsonPath: .status.items[*].egressIP
+      name: Assigned EgressIPs
+      type: string
+    served: true
+    storage: true
+    schema: 
+      openAPIV3Schema:
+        description: EgressIP is a CRD allowing the user to define a fixed source IP for all egress traffic originating from any pods which match the EgressIP resource according to its spec definition.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of EgressIP.
+            properties:
+              egressIPs:
+                description: EgressIPs is the list of egress IP addresses requested. Can be IPv4 and/or IPv6. This field is mandatory.
+                items:
+                  type: string
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector applies the egress IP only to the namespace(s) whose label matches this definition. This field is mandatory.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              podSelector:
+                description: 'PodSelector applies the egress IP only to the pods whose label matches this definition. This field is optional, and in case it is not set: results in the egress IP being applied to all pods in the namespace(s) matched by the NamespaceSelector. In case it is set: is intersected with the NamespaceSelector, thus applying the egress IP to the pods (in the namespace(s) already matched by the NamespaceSelector) which match this pod selector.'
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+            required:
+            - egressIPs
+            - namespaceSelector
+            type: object
+          status:
+            description: Observed status of EgressIP. Read-only.
+            properties:
+              items:
+                description: The list of assigned egress IPs and their corresponding node assignment.
+                items:
+                  description: The per node status, for those egress IPs who have been assigned.
+                  properties:
+                    egressIP:
+                      description: Assigned egress IP
+                      type: string
+                    node:
+                      description: Assigned node name
+                      type: string
+                  required:
+                  - egressIP
+                  - node
+                  type: object
+                type: array
+            required:
+            - items
+            type: object
+        required:
+        - spec
+        type: object
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/ovn/templates/ovn-setup.yaml.j2
+++ b/ovn/templates/ovn-setup.yaml.j2
@@ -1,0 +1,110 @@
+---
+# ovn-namespace.yaml
+#
+# Setup for Kubernetes to support the ovn-kubernetes plugin
+#
+# Create the namespace for ovn-kubernetes.
+#
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ovn-kubernetes
+
+---
+# ovn-policy.yaml
+#
+# Setup for Kubernetes to support the ovn-kubernetes plugin
+#
+# Create the service account and policies.
+# ovnkube interacts with kubernetes and the environment
+# must be properly set up.
+# 
+# This provisioning is done as part of installation after the cluster is
+# up and before the ovn daemonsets are created.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ovn
+  namespace: ovn-kubernetes
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ovn-kubernetes
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - nodes
+  - endpoints
+  - services
+  - configmaps
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - extensions
+  - networking.k8s.io
+  - apps
+  resources:
+  - networkpolicies
+  - statefulsets
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - endpoints
+  - configmaps
+  verbs: ["create", "patch", "update"]
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs: ["patch", "update"]
+- apiGroups:
+  - k8s.ovn.org
+  resources:
+  - egressfirewalls
+  - egressips
+  verbs: ["list", "get", "watch", "update"]
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ["list", "get", "watch"]
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ovn-kubernetes
+roleRef:
+  name: ovn-kubernetes
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: ovn
+  namespace: ovn-kubernetes
+
+---
+# The network cidr and service cidr are set in the ovn-config configmap
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ovn-config
+  namespace: ovn-kubernetes
+data:
+  net_cidr:      "{{ net_cidr }}"
+  svc_cidr:      "{{ svc_cidr }}"
+  k8s_apiserver: "{{ k8s_apiserver }}"
+  mtu:           "{{ mtu_value }}"

--- a/ovn/templates/ovnkube-db-raft.yaml.j2
+++ b/ovn/templates/ovnkube-db-raft.yaml.j2
@@ -1,0 +1,335 @@
+# service to expose the ovnkube-db pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: {{ ovn_nb_port }}
+    protocol: TCP
+    targetPort: {{ ovn_nb_port }}
+  - name: south
+    port: {{ ovn_sb_port }}
+    protocol: TCP
+    targetPort: {{ ovn_sb_port }}
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP
+
+---
+
+# ovndb-raft PodDisruptBudget to prevent majority of ovnkube raft cluster
+# nodes from disruption
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: ovndb-raft-pdb
+  namespace: ovn-kubernetes
+spec:
+  minAvailable: {{ ovn_db_minAvailable | default(2) }}
+  selector:
+    matchLabels:
+      name: ovnkube-db
+
+---
+
+# ovnkube-db raft statefulset
+# daemonset version 3
+# starts ovn NB/SB ovsdb daemons, each in a separate container
+#
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This statefulset launches the OVN Northbound/Southbound Database raft clusters.
+spec:
+  serviceName: ovnkube-db
+  podManagementPolicy: "Parallel"
+  replicas: {{ ovn_db_replicas | default(3) }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-db
+  template:
+    metadata:
+      labels:
+        ovn-db-pod: "true"
+        name: ovnkube-db
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      terminationGracePeriodSeconds: 30
+      imagePullSecrets:
+        - name: registry-credentials
+      serviceAccountName: ovn
+      hostNetwork: true
+
+      # required to be scheduled on node with k8s.ovn.org/ovnkube-db=true label but can
+      # only have one instance per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: k8s.ovn.org/ovnkube-db
+                operator: In
+                values:
+                - "true"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: name
+                operator: In
+                values:
+                - ovnkube-db
+            topologyKey: kubernetes.io/hostname
+
+      containers:
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command: ["/root/ovnkube.sh", "nb-ovsdb-raft"]
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value: "{{ ovn_loglevel_nb }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_nb_raft_election_timer }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
+        - name: OVN_NB_RAFT_PORT
+          value: "{{ ovn_nb_raft_port }}"
+      # end of container
+
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command: ["/root/ovnkube.sh", "sb-ovsdb-raft"]
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db-raft"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: "{{ ovn_loglevel_sb }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_SB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_sb_raft_election_timer }}"
+        - name: OVN_SB_PORT
+          value: "{{ ovn_sb_port }}"
+        - name: OVN_SB_RAFT_PORT
+          value: "{{ ovn_sb_raft_port }}"
+      # end of container
+
+
+      # ovn-dbchecker - v3
+      - name: ovn-dbchecker
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+        command: ["/root/ovnkube.sh", "ovn-dbchecker"]
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "{{ ovn_dbchecker_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_RAFT_ELECTION_TIMER
+          value: "{{ ovn_nb_raft_election_timer }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
+        - name: OVN_NB_RAFT_PORT
+          value: "{{ ovn_nb_raft_port }}"
+      # end of container
+
+      volumes:
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: "Exists"

--- a/ovn/templates/ovnkube-db.yaml.j2
+++ b/ovn/templates/ovnkube-db.yaml.j2
@@ -1,0 +1,221 @@
+# service to expose the ovnkube-db pod
+apiVersion: v1
+kind: Service
+metadata:
+  name: ovnkube-db
+  namespace: ovn-kubernetes
+spec:
+  ports:
+  - name: north
+    port: {{ ovn_nb_port }}
+    protocol: TCP
+    targetPort: {{ ovn_nb_port }}
+  - name: south
+    port: {{ ovn_sb_port }}
+    protocol: TCP
+    targetPort: {{ ovn_sb_port }}
+  sessionAffinity: None
+  clusterIP: None
+  type: ClusterIP
+
+---
+
+# ovnkube-db
+# daemonset version 3
+# starts ovn NB/SB ovsdb daemons, each in a separate container
+# it is running on master for now, but does not need to be the case
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-db
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This daemonset launches the OVN NB/SB ovsdb service components.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-db
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        ovn-db-pod: "true"
+        name: ovnkube-db
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn
+      hostNetwork: true
+      containers:
+      # firewall rules for ovn - assumed to be setup
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+      # iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+
+      # nb-ovsdb - v3
+      - name: nb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "nb-ovsdb"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NB
+          value: "{{ ovn_loglevel_nb }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_NB_PORT
+          value: "{{ ovn_nb_port }}"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnnb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+
+      # sb-ovsdb - v3
+      - name: sb-ovsdb
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "sb-ovsdb"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # ovn db is stored in the pod in /etc/openvswitch
+        # (or in /etc/ovn if OVN from new repository is used)
+        # and on the host in /var/lib/openvswitch/
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_SB
+          value: "{{ ovn_loglevel_sb }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_SB_PORT
+          value: "{{ ovn_sb_port }}"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnsb-db"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+      # end of container
+
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+        kubernetes.io/os: "linux"
+      volumes:
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      tolerations:
+      - operator: "Exists"

--- a/ovn/templates/ovnkube-master.yaml.j2
+++ b/ovn/templates/ovnkube-master.yaml.j2
@@ -1,0 +1,278 @@
+# ovnkube-master
+# daemonset version 3
+# starts master daemons, each in a separate container
+# it is run on the master(s)
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-master
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This Deployment launches the ovn-kubernetes master networking components.
+spec:
+  progressDeadlineSeconds: 600
+  replicas: {{ ovn_master_count | default(1|int) }}
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: ovnkube-master
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: ovnkube-master
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn
+      hostNetwork: true
+
+      # required to be scheduled on a linux node with node-role.kubernetes.io/master label and
+      # only one instance of ovnkube-master pod per node
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/master
+                    operator: In
+                    values:
+                      - ""
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: name
+                    operator: In
+                    values:
+                      - ovnkube-master
+              topologyKey: kubernetes.io/hostname
+
+      containers:
+      # ovn-northd - v3
+      - name: ovn-northd
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "run-ovn-northd"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NORTHD
+          value: "{{ ovn_loglevel_northd }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-northd"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+      # end of container
+
+      - name: nbctl-daemon
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "run-nbctld"]
+
+        securityContext:
+          runAsUser: 0
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOGLEVEL_NBCTLD
+          value: "{{ ovn_loglevel_nbctld }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-nbctld"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        # end of container
+
+      - name: ovnkube-master
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovn-master"]
+
+        securityContext:
+          runAsUser: 0
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # Run directories where we need to be able to access sockets
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "{{ ovnkube_master_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: "{{ ovn_hybrid_overlay_enable }}"
+        - name: OVN_EGRESSIP_ENABLE
+          value: "{{ ovn_egress_ip_enable }}"
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: "{{ ovn_hybrid_overlay_net_cidr }}"
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_V4_JOIN_SUBNET
+          value: "{{ ovn_v4_join_subnet }}"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "{{ ovn_v6_join_subnet }}"
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_GATEWAY_MODE
+          value: "{{ ovn_gateway_mode }}"
+        - name: OVN_MULTICAST_ENABLE
+          value: "{{ ovn_multicast_enable }}"
+      # end of container
+
+      volumes:
+      # TODO: Need to check why we need this?
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: "Exists"

--- a/ovn/templates/ovnkube-monitor.yaml.j2
+++ b/ovn/templates/ovnkube-monitor.yaml.j2
@@ -1,0 +1,100 @@
+# define ServiceMontior and Service resources for ovnkube-master, ovnkube-node,
+# and ovnkube-db (required for prometheus monitoring)
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: monitor-ovnkube-master
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: http-metrics
+    scheme: http
+    path: /metrics
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-master
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-master
+  name: ovnkube-master-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-master
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: http-metrics
+    port: 9409
+    protocol: TCP
+    targetPort: 9409
+---
+
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: monitor-ovnkube-node
+  namespace: ovn-kubernetes
+spec:
+  endpoints:
+  - interval: 30s
+    port: ovnkube-node-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovs-metrics
+    path: /metrics
+    scheme: http
+  - interval: 30s
+    port: ovn-metrics
+    path: /metrics
+    scheme: http
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - ovn-kubernetes
+  selector:
+    matchLabels:
+      k8s-app: ovnkube-node
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: ovnkube-node
+  name: ovnkube-node-prometheus-discovery
+  namespace: ovn-kubernetes
+spec:
+  selector:
+    name: ovnkube-node
+  type: ClusterIP
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+  - name: ovnkube-node-metrics
+    port: 9410
+    protocol: TCP
+    targetPort: 9410
+  - name: ovn-metrics
+    port: 9476
+    protocol: TCP
+    targetPort: 9476
+  - name: ovs-metrics
+    port: 9310
+    protocol: TCP
+    targetPort: 9310
+

--- a/ovn/templates/ovnkube-node.yaml.j2
+++ b/ovn/templates/ovnkube-node.yaml.j2
@@ -1,0 +1,308 @@
+---
+# ovnkube-node
+# daemonset version 3
+# starts node daemons for ovn, each in a separate container
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovnkube-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovn-kubernetes networking components for worker nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovnkube-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovnkube-node
+        name: ovnkube-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Requires fairly broad permissions - ability to read all services and network functions as well
+      # as all pods.
+      serviceAccountName: ovn
+      hostNetwork: true
+      {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
+      containers:
+
+      - name: ovn-controller
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovn-controller"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["SYS_NICE"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/log/ovn/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVN_LOG_CONTROLLER
+          value: "{{ ovn_loglevel_controller }}"
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovn-controller"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+      - name: ovnkube-node
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovn-node"]
+
+        securityContext:
+          runAsUser: 0
+          {% if ovn_unprivileged_mode=="no" -%}
+          privileged: true
+          {% else -%}
+          capabilities:
+            add:
+            - NET_ADMIN
+          {% endif %}
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        # for the iptables wrapper
+        - mountPath: /host
+          name: host-slash
+          readOnly: true
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/ovn-kubernetes/
+          name: host-var-log-ovnkube
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+        - mountPath: /var/run/ovn/
+          name: host-var-run-ovs
+        # We mount our socket here
+        - mountPath: /var/run/ovn-kubernetes
+          name: host-var-run-ovn-kubernetes
+        # CNI related mounts which we take over
+        - mountPath: /opt/cni/bin
+          name: host-opt-cni-bin
+        - mountPath: /etc/cni/net.d
+          name: host-etc-cni-netd
+        - mountPath: /ovn-cert
+          name: host-ovn-cert
+          readOnly: true
+        - mountPath: /etc/openvswitch/
+          name: host-var-lib-ovs
+          readOnly: true
+        - mountPath: /etc/ovn/
+          name: host-var-lib-ovs
+          readOnly: true
+        {% if kind is defined and kind -%}
+        - mountPath: /var/run/netns
+          name: host-netns
+          mountPropagation: Bidirectional
+        {% endif %}
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: OVNKUBE_LOGLEVEL
+          value: "{{ ovnkube_node_loglevel }}"
+        - name: OVNKUBE_LOGFILE_MAXSIZE
+          value: "{{ ovnkube_logfile_maxsize }}"
+        - name: OVNKUBE_LOGFILE_MAXBACKUPS
+          value: "{{ ovnkube_logfile_maxbackups }}"
+        - name: OVNKUBE_LOGFILE_MAXAGE
+          value: "{{ ovnkube_logfile_maxage }}"
+        - name: OVN_NET_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: net_cidr
+        - name: OVN_SVC_CIDR
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: svc_cidr
+        - name: K8S_APISERVER
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: k8s_apiserver
+        - name: OVN_MTU
+          valueFrom:
+            configMapKeyRef:
+              name: ovn-config
+              key: mtu
+        - name: K8S_NODE
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: OVN_GATEWAY_MODE
+          value: "{{ ovn_gateway_mode }}"
+        - name: OVN_GATEWAY_OPTS
+          value: "{{ ovn_gateway_opts }}"
+        - name: OVN_HYBRID_OVERLAY_ENABLE
+          value: "{{ ovn_hybrid_overlay_enable }}"
+        - name: OVN_EGRESSIP_ENABLE
+          value: "{{ ovn_egress_ip_enable }}"
+        - name: OVN_HYBRID_OVERLAY_NET_CIDR
+          value: "{{ ovn_hybrid_overlay_net_cidr }}"
+        - name: OVN_DISABLE_SNAT_MULTIPLE_GWS
+          value: "{{ ovn_disable_snat_multiple_gws }}"
+        - name: OVN_V4_JOIN_SUBNET
+          value: "{{ ovn_v4_join_subnet }}"
+        - name: OVN_V6_JOIN_SUBNET
+          value: "{{ ovn_v6_join_subnet }}"
+        - name: OVN_SSL_ENABLE
+          value: "{{ ovn_ssl_en }}"
+        - name: OVN_REMOTE_PROBE_INTERVAL
+          value: "{{ ovn_remote_probe_interval }}"
+        - name: OVN_MULTICAST_ENABLE
+          value: "{{ ovn_multicast_enable }}"
+        - name: OVN_UNPRIVILEGED_MODE
+          value: "{{ ovn_unprivileged_mode }}"
+
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/ovnkube.sh", "cleanup-ovn-node"]
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovnkube-node"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+        # ovs-metrics-exporter - v3
+      - name: ovs-metrics-exporter
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovs-metrics"]
+
+        securityContext:
+          runAsUser: 0
+          capabilities:
+            add: ["NET_ADMIN"]
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+          readOnly: true
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/run/openvswitch/
+          name: host-var-run-ovs
+          readOnly: true
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        - name: K8S_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        # end of container
+
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      volumes:
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-var-log-ovnkube
+        hostPath:
+          path: /var/log/ovn-kubernetes
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-var-run-ovn-kubernetes
+        hostPath:
+          path: /var/run/ovn-kubernetes
+      - name: host-opt-cni-bin
+        hostPath:
+          path: /opt/cni/bin
+      - name: host-etc-cni-netd
+        hostPath:
+          path: /etc/cni/net.d
+      - name: host-ovn-cert
+        hostPath:
+          path: /etc/ovn
+          type: DirectoryOrCreate
+      - name: host-slash
+        hostPath:
+          path: /
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+      {% if kind is defined and kind -%}
+      - name: host-netns
+        hostPath:
+          path: /var/run/netns
+      {% endif %}
+
+      tolerations:
+      - operator: "Exists"

--- a/ovn/templates/ovs-node.yaml.j2
+++ b/ovn/templates/ovs-node.yaml.j2
@@ -1,0 +1,127 @@
+---
+# ovs-node
+# daemonset version 3
+# starts node daemons for ovs
+# it is run on all nodes
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: ovs-node
+  # namespace set up by install
+  namespace: ovn-kubernetes
+  annotations:
+    kubernetes.io/description: |
+      This DaemonSet launches the ovs networking components for all nodes.
+spec:
+  selector:
+    matchLabels:
+      app: ovs-node
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: ovs-node
+        name: ovs-node
+        component: network
+        type: infra
+        kubernetes.io/os: "linux"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      {{ "hostPID: true" if ovn_unprivileged_mode=="no" }}
+      containers:
+
+      # ovsdb-server and ovs-switchd daemons
+      - name: ovs-daemons
+        image: "{{ ovn_image | default('docker.io/ovnkube/ovn-daemonset:latest') }}"
+        imagePullPolicy: "{{ ovn_image_pull_policy | default('IfNotPresent') }}"
+
+        command: ["/root/ovnkube.sh", "ovs-server"]
+
+        livenessProbe:
+          exec:
+            command:
+            - /usr/share/openvswitch/scripts/ovs-ctl
+            - status
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+        readinessProbe:
+          exec:
+            command: ["/usr/bin/ovn-kube-util", "readiness-probe", "-t", "ovs-daemons"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 30
+          periodSeconds: 60
+
+        securityContext:
+          runAsUser: 0
+          # Permission could be reduced by selecting an appropriate SELinux policy
+          privileged: true
+
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /lib/modules
+          name: host-modules
+          readOnly: true
+        - mountPath: /run/openvswitch
+          name: host-run-ovs
+        - mountPath: /var/run/openvswitch
+          name: host-var-run-ovs
+        - mountPath: /sys
+          name: host-sys
+        - mountPath: /etc/openvswitch
+          name: host-config-openvswitch
+        - mountPath: /var/run/dbus/
+          name: host-var-run-dbus
+        - mountPath: /var/log/openvswitch/
+          name: host-var-log-ovs
+        - mountPath: /var/lib/openvswitch/
+          name: host-var-lib-ovs
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 200m
+            memory: 400Mi
+        env:
+        - name: OVN_DAEMONSET_VERSION
+          value: "3"
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/root/ovnkube.sh", "cleanup-ovs-server"]
+
+      nodeSelector:
+        kubernetes.io/os: "linux"
+      volumes:
+      - name: host-modules
+        hostPath:
+          path: /lib/modules
+      - name: host-var-run-dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: host-var-log-ovs
+        hostPath:
+          path: /var/log/openvswitch
+      - name: host-run-ovs
+        hostPath:
+          path: /run/openvswitch
+      - name: host-var-run-ovs
+        hostPath:
+          path: /var/run/openvswitch
+      - name: host-sys
+        hostPath:
+          path: /sys
+      - name: host-config-openvswitch
+        hostPath:
+          path: /etc/origin/openvswitch
+      - name: host-var-lib-ovs
+        hostPath:
+          path: /var/lib/openvswitch
+
+      tolerations:
+      - operator: "Exists"

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -38,9 +38,10 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
-                   qemu-user-static && \
+                   qemu-user-static python3-pip && \
     npm install -g markdownlint-cli && \
-    rpm -e --nodeps containerd npm && \
+    pip install j2cli[yaml] --user && \
+    rpm -e --nodeps containerd npm python3-pip && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \
     rm -f /usr/bin/{dockerd,lto-dump} \


### PR DESCRIPTION
Use `make clusters using=ovn` to deploy kind with ovn

* Installs j2cli to dapper image
* Adds `using=ovn` flag
* Add scripts to deploy ovn on kind

Currently this copies over ovn-kind scripts and templates from
 * https://github.com/ovn-org/ovn-kubernetes/blob/master/contrib/
 * https://github.com/ovn-org/ovn-kubernetes/tree/master/dist

Fixes: #335

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>