### PR TITLE
Remove unused unit-test make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
-clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test: images
+clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit: images
 
 images: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -81,10 +81,6 @@ post-mortem:
 unit: vendor/modules.txt
 	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
 
-# TODO: Remove once all consumers are migrated to "unit"
-unit-test: vendor/modules.txt
-	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
-
 ifeq (go.mod,$(wildcard go.mod))
 # If go.mod exists (as determined above), assume we're vendoring
 vendor/modules.txt: go.mod


### PR DESCRIPTION
The "unit-test" make target was deprecated in favor of "unit", and all
of the consuming projects have been converted to use the new target.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>