### PR TITLE
Fix inotify warning

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -177,7 +177,10 @@ mkdir -p ${KUBECONFIGS_DIR}
 
 run_local_registry
 declare_cidrs
-if ! run_all_clusters with_retries 3 create_kind_cluster; then
+
+# Run in subshell to check response, otherwise `set -e` is not honored
+( run_all_clusters with_retries 3 create_kind_cluster; ) &
+if ! wait $!; then
     warn_inotify
     exit 1
 fi


### PR DESCRIPTION
Running commands inside `if ... then` in bash will make `set -e` moot
for any function executed in that context, so when cluster deployments
would fail they would actually continue running as if they passed.

The correct way is running in a background subshell and waiting for it
to end, and then checking the return code.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>