### PR TITLE
Fix link to job results in the periodic link check

### DIFF
--- a/.github/ISSUE_TEMPLATE/broken-link.md
+++ b/.github/ISSUE_TEMPLATE/broken-link.md
@@ -1,2 +1,2 @@
 Periodic link aliveness CI detected a broken link. Please see the [periodic job
-results](https://github.com/submariner-io/submariner-operator/actions?query=workflow%3APeriodic) for details.
+results](https://github.com/submariner-io/shipyard/actions?query=workflow%3APeriodic) for details.


### PR DESCRIPTION
The periodic link check files issues with links to
submariner-operator; this fixes that.

Signed-off-by: Stephen Kitt <skitt@redhat.com>