### PR TITLE
Rely on subctl to deploy the release

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -55,7 +55,7 @@ upgrade-e2e: deploy-latest deploy e2e
 # are *not* rebuilt (we want to deploy the published images only)
 deploy-latest:
 	curl -L get.submariner.io | VERSION=latest bash
-	$(MAKE) -o images deploy SUBCTL=~/.local/bin/subctl DEV_VERSION=latest CUTTING_EDGE=latest VERSION=latest DEPLOY_ARGS="$(DEPLOY_ARGS) --image_tag=latest" using=$(using)
+	$(MAKE) -o images deploy SUBCTL=~/.local/bin/subctl DEV_VERSION=latest CUTTING_EDGE=latest VERSION=latest DEPLOY_ARGS="$(DEPLOY_ARGS) --image_tag=subctl" using=$(using)
 
 gitlint:
 	gitlint --commits origin/master..HEAD

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -42,11 +42,17 @@ function subctl_install_subm() {
         return
     fi
 
+    # We use the "subctl" image_tag to indicate that we want to let
+    # subctl use its default repository and version
+    subctlrepver=
+    if [ "${SUBM_ENGINE_IMAGE_TAG}" != "subctl" ]; then
+        subctlrepver="--repository ${SUBM_ENGINE_IMAGE_REPO} --version ${SUBM_ENGINE_IMAGE_TAG}"
+    fi
+
     # shellcheck disable=SC2086 # Split on purpose
     "${SUBCTL}" join --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
                 --clusterid "${cluster}" \
-                --repository "${SUBM_ENGINE_IMAGE_REPO}" \
-                --version "${SUBM_ENGINE_IMAGE_TAG}" \
+                ${subctlrepver} \
                 --nattport "${CE_IPSEC_NATTPORT}" \
                 --ikeport "${CE_IPSEC_IKEPORT}" \
                 --colorcodes "${SUBM_COLORCODES}" \


### PR DESCRIPTION
... instead of relying on "latest" image tags (which we no longer
publish).

Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit 96f82b6602651fa1efa5e067577045584cd66ae5)