### PR TITLE
Disable Markdown link checker for modified files

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,19 +39,6 @@ jobs:
       - name: Run golangci-lint
         run: make golangci-lint
 
-  markdown-link-check:
-    name: Markdown Links (modified files)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
-
-      - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          config-file: ".markdownlinkcheck.json"
-          check-modified-files-only: "yes"
-
   markdownlint:
     name: Markdown
     runs-on: ubuntu-latest


### PR DESCRIPTION
As seen in [1] the check-modified-files-only flag doesn't work properly
making the stable branch "red".

I propose we disable this for now at least until it's resolved.

Backport-To: release-0.8

[1] https://github.com/submariner-io/shipyard/pull/407/checks?check_run_id=1696280421

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>