### PR TITLE
Don't tag as `devel` by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - release-*
 
 jobs:
   e2e:
@@ -52,5 +53,5 @@ jobs:
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          RELEASE_ARGS: shipyard-dapper-base nettest
+          RELEASE_ARGS: shipyard-dapper-base nettest --tag "${GITHUB_REF##*/}"
         run: make release

--- a/scripts/shared/release.sh
+++ b/scripts/shared/release.sh
@@ -4,7 +4,7 @@
 
 source ${SCRIPTS_DIR}/lib/shflags
 source ${SCRIPTS_DIR}/lib/version
-DEFINE_string 'tag' "${CUTTING_EDGE}" "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
+DEFINE_string 'tag' '' "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to deploy to"
 FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"
 FLAGS "$@" || exit $?


### PR DESCRIPTION
Instead, we should set the tag to the branch name that's being merged
to, in accordance with the stable release policy.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>