### PR TITLE
Set CUTTING_EDGE to release-0.8

### DIFF
--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,5 +1,5 @@
 # Calculate versions; these can be overridden
-CUTTING_EDGE := devel
+CUTTING_EDGE := release-0.8
 DEV_VERSION := dev
 override CALCULATED_VERSION := $(shell git describe --tags --dirty="-$(DEV_VERSION)" --exclude="$(CUTTING_EDGE)" --exclude="latest")
 VERSION ?= $(CALCULATED_VERSION)


### PR DESCRIPTION
This will ensure shipyard scripts use release-0.8 images for testing and
such.

This should pass E2E once corresponding PRs are merge to release the images

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>