### PR TITLE
Build nettest with -fcommon

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --update --no-cache gcc libc-dev make curl
 
 RUN curl -L https://github.com/HewlettPackard/netperf/archive/netperf-2.7.0.tar.gz | tar xzf -
-RUN cd netperf-netperf-2.7.0 && ./configure \
+RUN cd netperf-netperf-2.7.0 && ./configure CFLAGS=-fcommon \
     && make && make install
 
 


### PR DESCRIPTION
Now that alpine uses gcc 10, the nettest build fails because of the
switch to -fno-common by default (because external functions aren’t
declared correctly). The quick fix is to revert to -fcommon.

See https://gcc.gnu.org/gcc-10/porting_to.html for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>