### PR TITLE
Drop support for strongSwan

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -29,9 +29,6 @@ jobs:
         include:
           # Test the same set of cable driver combinations as the consuming projects do in their CI
           - project: submariner
-            cabledriver: strongswan
-            deploytool: operator
-          - project: submariner
             cabledriver: wireguard
             deploytool: operator
     steps:

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -9,7 +9,7 @@ include $(SHIPYARD_DIR)/Makefile.versions
 ifneq (,$(filter libreswan,$(_using)))
 override DEPLOY_ARGS += --cable_driver libreswan
 else ifneq (,$(filter strongswan,$(_using)))
-override DEPLOY_ARGS += --cable_driver strongswan
+$(error strongSwan is no longer supported)
 else ifneq (,$(filter wireguard,$(_using)))
 # Wireguard requires kernel module install on the host
 override DEPLOY_ARGS += --cable_driver wireguard

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -10,7 +10,7 @@ DEFINE_string 'deploytool_submariner_args' '' 'Any extra arguments to pass to th
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"
 DEFINE_string 'timeout' '5m' "Timeout flag to pass to kubectl when waiting (e.g. 30s)"
 DEFINE_string 'image_tag' 'local' "Tag to use for the images"
-DEFINE_string 'cable_driver' 'libreswan' "Tunneling method for connections between clusters (libreswan, strongswan, wireguard requires kernel module on host)"
+DEFINE_string 'cable_driver' 'libreswan' "Tunneling method for connections between clusters (libreswan, wireguard requires kernel module on host)"
 
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"


### PR DESCRIPTION
This stops tests with strongSwan, and causes Make to abort with an
error if "using" contains "strongswan".

Signed-off-by: Stephen Kitt <skitt@redhat.com>