### PR TITLE
Export nginx-demo service

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -33,3 +33,8 @@ spec:
       targetPort: 8080
   selector:
     app: nginx-demo
+---
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: nginx-demo


### PR DESCRIPTION
When deploying nginx-demo service for connection test, need to
export the service too. GlobalnetIP will no longer be allocated
for services that are not exported, leading to test failures
with globalnet deployments.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>