### PR TITLE
Specify --natt=false instead of --disable-nat

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -72,7 +72,7 @@ function subctl_install_subm() {
                 --ikeport "${CE_IPSEC_IKEPORT}" \
                 --colorcodes "${SUBM_COLORCODES}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \
-                --disable-nat \
+                --natt=false \
                 --cable-driver "${cable_driver}" \
                 ${deploytool_submariner_args} \
                 ${cidr_args} \


### PR DESCRIPTION
The latter is deprecated and results in a warning in the logs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>