### PR TITLE
Tag released image with branch name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,5 +53,6 @@ jobs:
         env:
           QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
           QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          RELEASE_ARGS: shipyard-dapper-base nettest --tag "${GITHUB_REF##*/}"
-        run: make release
+          IMAGES: shipyard-dapper-base nettest
+        # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
+        run: make release RELEASE_ARGS="$IMAGES --tag '${GITHUB_REF##*/}'"


### PR DESCRIPTION
This will ensure that stable branches have images tagged correctly.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 19691e5a909f65024f57f976ce6e0c53d90d546a)