### PR TITLE
Use the right subctl version on image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,12 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      - name: Find the right subctl version
+        run: echo "SUBCTL_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Build and release new images
         uses: ./gh-actions/release-images
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+          image_args: --buildargs SUBCTL_VERSION=${{ env.SUBCTL_VERSION }}

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -7,12 +7,15 @@ inputs:
   password:
     description: 'Password for the registry'
     required: true
+  image_args:
+    description: 'Additional image building arguments'
+    required: false
 runs:
   using: "composite"
   steps:
     - shell: bash
       env:
-        IMAGES_ARGS: --nocache
+        IMAGES_ARGS: --nocache ${{ inputs.image_args }}
       run: |
         echo "::group::Build new images"
         make images


### PR DESCRIPTION
This also adds support for additional image args on the image builder GHA

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>