### PR TITLE
[release-0.8] backports for branch-based subctl handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,12 @@ jobs:
           submodules: true
           fetch-depth: 0
 
+      - name: Find the right subctl version
+        run: echo "SUBCTL_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
       - name: Build and release new images
         uses: ./gh-actions/release-images
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+          image_args: --buildargs SUBCTL_VERSION=${{ env.SUBCTL_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,9 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Build new images
-        env:
-          IMAGES_ARGS: --nocache
-        run: make images nettest
-
-      - name: Release the images
-        env:
-          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
-          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
-          IMAGES: shipyard-dapper-base nettest
-        # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
-        run: make release RELEASE_ARGS="$IMAGES --tag '${GITHUB_REF##*/}'"
+      - name: Build and release new images
+        uses: ./gh-actions/release-images
+        with:
+          images: shipyard-dapper-base nettest
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,5 @@ jobs:
       - name: Build and release new images
         uses: ./gh-actions/release-images
         with:
-          images: shipyard-dapper-base nettest
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+IMAGES ?= shipyard-dapper-base nettest
+
 ifneq (,$(DAPPER_HOST_ARCH))
 
 # Running in Dapper
@@ -44,8 +46,6 @@ include Makefile.versions
 clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test: images
 
 images: export SCRIPTS_DIR=./scripts/shared
-
-images: package/.image.shipyard-dapper-base package/.image.nettest
 
 .DEFAULT_GOAL := lint
 # Shipyard-specific ends

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ else
 include Makefile.images
 include Makefile.versions
 
+IMAGES_ARGS ?= --buildargs "SUBCTL_VERSION=${CUTTING_EDGE}"
+
 # Shipyard-specific starts
 clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-test: images
 

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit-
 
 images: export SCRIPTS_DIR=./scripts/shared
 
-images: package/.image.shipyard-dapper-base
+images: package/.image.shipyard-dapper-base package/.image.nettest
 
 .DEFAULT_GOAL := lint
 # Shipyard-specific ends

--- a/Makefile.images
+++ b/Makefile.images
@@ -23,3 +23,6 @@ docker_deps = $(shell files=($(1) $$(awk '/COPY/ { if (substr($$2, 1, 7) != "--f
 package/.image.%: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_image_rebuild,$$*)
 	$(SCRIPTS_DIR)/build_image.sh -i $(lastword $(subst ., ,$@)) -f $< $(IMAGES_ARGS)
 	touch $@
+
+# Default target to build images based on IMAGES variable
+images: $(foreach image,$(IMAGES),package/.image.$(image))

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -73,7 +73,7 @@ yamllint:
 	yamllint .
 
 release:
-	$(SCRIPTS_DIR)/release.sh $(RELEASE_ARGS)
+	$(SCRIPTS_DIR)/release.sh $(IMAGES) $(RELEASE_ARGS)
 
 post-mortem:
 	$(SCRIPTS_DIR)/post_mortem.sh

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -7,12 +7,15 @@ inputs:
   password:
     description: 'Password for the registry'
     required: true
+  image_args:
+    description: 'Additional image building arguments'
+    required: false
 runs:
   using: "composite"
   steps:
     - shell: bash
       env:
-        IMAGES_ARGS: --nocache
+        IMAGES_ARGS: --nocache ${{ inputs.image_args }}
       run: |
         echo "::group::Build new images"
         make images

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -1,0 +1,30 @@
+name: 'Release Images'
+description: 'Builds images and uploads them to the public registry'
+inputs:
+  images:
+    description: 'Space separated list of images to build'
+    required: true
+  username:
+    description: 'User name for the registry'
+    required: true
+  password:
+    description: 'Password for the registry'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        IMAGES_ARGS: --nocache
+      run: |
+        echo "::group::Build new images"
+        make images
+        echo "::endgroup::"
+
+    - name: Release newly built images
+      shell: bash
+      env:
+        QUAY_USERNAME: ${{ inputs.username }}
+        QUAY_PASSWORD: ${{ inputs.password }}
+      # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
+      run: make release RELEASE_ARGS="${{ inputs.images }} --tag '${GITHUB_REF##*/}'"

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -1,9 +1,6 @@
 name: 'Release Images'
 description: 'Builds images and uploads them to the public registry'
 inputs:
-  images:
-    description: 'Space separated list of images to build'
-    required: true
   username:
     description: 'User name for the registry'
     required: true
@@ -27,4 +24,4 @@ runs:
         QUAY_USERNAME: ${{ inputs.username }}
         QUAY_PASSWORD: ${{ inputs.password }}
       # Pass RELEASE_ARGS on the call, since GITHUB_REF set in the `env` directive doesn't get properly expanded
-      run: make release RELEASE_ARGS="${{ inputs.images }} --tag '${GITHUB_REF##*/}'"
+      run: make release RELEASE_ARGS="--tag '${GITHUB_REF##*/}'"

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -3,6 +3,7 @@ FROM fedora:33
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.
 ARG UPX_LEVEL=-5
+ARG SUBCTL_VERSION=devel
 ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/local/go/bin:$PATH \
     GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${DAPPER_HOST_ARCH} \
@@ -52,8 +53,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v3.4.1 \
     KIND_VERSION=v0.7.0 \
-    BUILDX_VERSION=v0.4.2 \
-    SUBCTL_VERSION=devel
+    BUILDX_VERSION=v0.4.2
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -53,14 +53,14 @@ ENV LINT_VERSION=v1.28.0 \
     HELM_VERSION=v3.4.1 \
     KIND_VERSION=v0.7.0 \
     BUILDX_VERSION=v0.4.2 \
-    SUBCTL_VERSION=subctl-devel
+    SUBCTL_VERSION=devel
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
-    curl -L "https://github.com/submariner-io/submariner-operator/releases/download/${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH}.tar.xz" | tar xJf - && mv subctl-${SUBCTL_VERSION}/subctl-${SUBCTL_VERSION}-linux-${ARCH} /go/bin/subctl && \
+    curl -Ls https://get.submariner.io | VERSION=${SUBCTL_VERSION} DESTDIR=/go/bin bash && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     mkdir -p ~/.docker/cli-plugins && \
     curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \


### PR DESCRIPTION
* a92f109a207f32b35de5442b4b0aac3bacdf5243 Create composite `release-images` GitHub Action
* 912fded670a71faf449cc968d8a5a0ee02454ae0 Add default `images` build target
* 25ffa2a3b3ac49dbb63e32b3e3ee341b4881974a Use get.submariner.io to download subctl
* 25188b76affdfb7cc1ae07fa9a0646a8c7ded1dd Pull the specific subctl version based on "CUTTING_EDGE"
* 044f4913ad9b110f0ed9a761666679051f26cbf4 Use the right subctl version on image release
