### PR TITLE
Improve E2E cluster ID check

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -286,8 +286,11 @@ func fetchClusterIDs() {
 		found := false
 		for _, envVar := range daemonSet.Spec.Template.Spec.Containers[0].Env {
 			if envVar.Name == envVarName {
-				By(fmt.Sprintf("Setting cluster ID %q for kube context name %q", TestContext.ClusterIDs[i], envVar.Value))
-				TestContext.ClusterIDs[i] = envVar.Value
+				if TestContext.ClusterIDs[i] != envVar.Value {
+					By(fmt.Sprintf("Setting new cluster ID %q, previous cluster ID was %q", envVar.Value, TestContext.ClusterIDs[i]))
+					TestContext.ClusterIDs[i] = envVar.Value
+				}
+
 				found = true
 				break
 			}


### PR DESCRIPTION
in `framework.fetchClusterIDs`:

-  the order of the format params for the message are reversed
-  don't print the message if the found ID and previous ID match
-  for the message string, don't assume the previous ID is the kube context name

