### PR TITLE
When deploying with Helm, use the operator

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -44,6 +44,7 @@ declare_kubeconfig
 
 # nettest is always referred to using :local
 import_image quay.io/submariner/nettest
+import_image quay.io/submariner/submariner-operator ${image_tag}
 import_image quay.io/submariner/submariner ${image_tag}
 import_image quay.io/submariner/submariner-route-agent ${image_tag}
 [[ $globalnet != "true" ]] || import_image quay.io/submariner/submariner-globalnet ${image_tag}

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -37,15 +37,15 @@ function helm_install_subm() {
     local crd_create=false
     [[ "${cluster}" = "${broker}" ]] || crd_create=true
 
-    if kubectl wait --for=condition=Ready pods -l app=submariner-engine -n "${SUBM_NS}" --timeout=60s > /dev/null 2>&1; then
+    if kubectl wait --for=condition=Ready pods -l app=submariner-operator -n "${SUBM_NS}" --timeout=60s > /dev/null 2>&1; then
         echo "Submariner already installed, skipping installation..."
         return
     fi
 
     echo "Installing Submariner..."
     # shellcheck disable=SC2086 # Split on purpose
-    helm --kube-context "${cluster}" install submariner \
-        submariner-latest/submariner \
+    helm --kube-context "${cluster}" install submariner-operator \
+        submariner-latest/submariner-operator \
         --create-namespace \
         --namespace "${SUBM_NS}" \
         --set ipsec.psk="${SUBMARINER_PSK}" \
@@ -60,16 +60,12 @@ function helm_install_subm() {
         --set submariner.globalCidr="${global_CIDRs[$cluster]}" \
         --set serviceAccounts.globalnet.create="${globalnet}" \
         --set submariner.natEnabled="false" \
-        --set routeAgent.image.repository="localhost:5000/submariner-route-agent" \
-        --set routeAgent.image.tag="local" \
-        --set routeAgent.image.pullPolicy="IfNotPresent" \
-        --set engine.image.repository="localhost:5000/submariner" \
-        --set engine.image.tag="local" \
-        --set engine.image.pullPolicy="IfNotPresent" \
-        --set globalnet.image.repository="localhost:5000/submariner-globalnet" \
-        --set globalnet.image.tag="local" \
-        --set globalnet.image.pullPolicy="IfNotPresent" \
-        --set crd.create="${crd_create}" \
+        --set operator.image.repository="localhost:5000/submariner-operator" \
+        --set operator.image.tag="local" \
+        --set operator.image.pullPolicy="IfNotPresent" \
+        --set submariner.images.repository="localhost:5000" \
+        --set submariner.images.tag="local" \
+        --set brokercrds.create="${crd_create}" \
         ${deploytool_submariner_args}
 }
 


### PR DESCRIPTION
Our Helm charts now support deployments using the operator, switch to
that (this will allow us to drop support for non-operator-based
installation options).

**THIS MUST NOT BE MERGED UNTIL ALL THE HELM TESTS PASS**

Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit e5fddc15b5c3d3d9df89cd3742788e8a4c954585)