### PR TITLE
Always pull `subctl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,8 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Find the right subctl version
-        run: echo "SUBCTL_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
       - name: Build and release new images
         uses: ./gh-actions/release-images
         with:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-          image_args: --buildargs SUBCTL_VERSION=${{ env.SUBCTL_VERSION }}

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ else
 include Makefile.images
 include Makefile.versions
 
-IMAGES_ARGS ?= --buildargs "SUBCTL_VERSION=${CUTTING_EDGE}"
-
 # Shipyard-specific starts
 clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit: images
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -3,7 +3,6 @@ FROM fedora:33
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.
 ARG UPX_LEVEL=-5
-ARG SUBCTL_VERSION=devel
 ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/local/go/bin:$PATH \
     GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${DAPPER_HOST_ARCH} \
@@ -60,7 +59,6 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf - && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
-    curl -Ls https://get.submariner.io | VERSION=${SUBCTL_VERSION} DESTDIR=/go/bin bash && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     mkdir -p ~/.docker/cli-plugins && \
     curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -42,6 +42,9 @@ source "${SCRIPTS_DIR}/lib/cluster_settings"
 declare_cidrs
 declare_kubeconfig
 
+# Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
+bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash"
+
 # nettest is always referred to using :local
 import_image quay.io/submariner/nettest
 import_image quay.io/submariner/submariner ${image_tag}


### PR DESCRIPTION
Always get subctl since we're using "moving versions" and putting it in
the image has the layer cached (and stale)

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>