### PR TITLE
Specify the repo/version when deploying the broker

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -24,11 +24,20 @@ function setup_broker() {
     local gn
     [[ $globalnet != true ]] || gn="--globalnet"
     echo "Installing broker..."
+
+    # We use the "subctl" image_tag to indicate that we want to let
+    # subctl use its default repository and version
+    subctlrepver=
+    if [ "${SUBM_GATEWAY_IMAGE_TAG}" != "subctl" ]; then
+        subctlrepver="--repository ${SUBM_GATEWAY_IMAGE_REPO} --version ${SUBM_GATEWAY_IMAGE_TAG}"
+    fi
+
     # shellcheck disable=SC2086 # Split on purpose
     (
         cd "${OUTPUT_DIR}" && \
         "${SUBCTL}" deploy-broker \
                --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
+               ${subctlrepver} \
                ${gn} \
                ${deploytool_broker_args}
     )


### PR DESCRIPTION
Now that the broker is operator-based, we need to specify the
repository and version we want to use.

This needs https://github.com/submariner-io/submariner-operator/pull/1118

Fixes: submariner-io/submariner-operator#1110
Signed-off-by: Stephen Kitt <skitt@redhat.com>