### PR TITLE
Upgrade to kind 0.10

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
 
+      - name: Create the kind network
+        # TODO skitt remove this once the patch is merged
+        run: docker network create -d bridge kind || true
+
       - name: Run E2E deployment and tests
         uses: ./gh-actions/e2e
         with:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Test the compile.sh script
         run: |
           make images .dapper
+          docker network create -d bridge kind || true
           ./.dapper -m bind test/scripts/compile/test.sh
 
   deploy:
@@ -94,4 +95,5 @@ jobs:
       - name: Test the post_mortem.sh script
         run: |
           make clusters
+          docker network create -d bridge kind || true
           ./.dapper -m bind test/scripts/post_mortem/test.sh

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ include Makefile.versions
 # Shipyard-specific starts
 # We need to ensure images, including the Shipyard base image, are updated
 # before we start Dapper
-clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit upgrade-e2e: images
+clusters deploy deploy-latest e2e gitlint golangci-lint markdownlint nettest post-mortem unit upgrade-e2e: images
 
 images: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,9 @@ include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
-clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit: images
+# We need to ensure images, including the Shipyard base image, are updated
+# before we start Dapper
+clusters deploy e2e gitlint golangci-lint markdownlint nettest post-mortem unit upgrade-e2e: images
 
 images: export SCRIPTS_DIR=./scripts/shared
 

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -13,6 +13,7 @@
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
 $(filter-out .dapper shell $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
+	-docker network create -d bridge kind
 	+./.dapper -m bind make --debug=b $@ $(MAKEFLAGS)
 
 shell: .dapper

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -3,7 +3,8 @@ FROM fedora:33
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.
 ARG UPX_LEVEL=-5
-ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash
+ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash \
+    DAPPER_RUN_ARGS="--net=kind"
 ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/local/go/bin:$PATH \
     GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${DAPPER_HOST_ARCH} \
     GOPATH=/go GO111MODULE=on GOFLAGS=-mod=vendor GOPROXY=https://proxy.golang.org \
@@ -51,7 +52,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.36.0 \
     HELM_VERSION=v3.4.1 \
-    KIND_VERSION=v0.7.0 \
+    KIND_VERSION=v0.10.0 \
     BUILDX_VERSION=v0.5.1
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions

--- a/scripts/shared/resources/kind-cluster-config.yaml
+++ b/scripts/shared/resources/kind-cluster-config.yaml
@@ -8,7 +8,7 @@ networking:
 containerdConfigPatches:
   - |-
     [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:5000\"]
-      endpoint = [\"http://${registry_ip}:5000\"]
+      endpoint = [\"http://kind-registry:5000\"]
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta2


### PR DESCRIPTION
Changes since 0.7.0:
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.0
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.8.1
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.9.0
* https://github.com/kubernetes-sigs/kind/releases/tag/v0.10.0

The Kubernetes 1.17 image for kind 0.10 uses 1.17.17, so we upgrade to
that too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>