### PR TITLE
Revert "Add clang and enable -msan"

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -12,8 +12,6 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # Requirements:
 # Component        | Usage
 # -------------------------------------------------------------
-# clang            | needed by `go test -race` (https://github.com/golang/go/issues/27089)
-# compiler-rt      | needed by `go test -msan`
 # curl             | download other tools
 # findutils        | make unit (find unit test dirs)
 # gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
@@ -38,7 +36,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   clang compiler-rt git-core curl moby-engine make golang kubernetes-client \
+                   gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
                    qemu-user-static python3-pip && \
     npm install -g markdownlint-cli && \

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -12,4 +12,3 @@ packages="$(find_unit_test_dirs "$@")"
 echo "Running tests in ${packages}"
 [ "${ARCH}" == "amd64" ] && race=-race
 go test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml
-[ "$(uname)" == "Linux" -a \( "${ARCH}" == "amd64" -o "${ARCH}" == "arm64" \) ] && CC=clang go test -v -msan -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml


### PR DESCRIPTION
Reverts submariner-io/shipyard#312

We don’t need eBPF, and adding 200MiB just for -msan seems overkill.

Signed-off-by: Stephen Kitt <skitt@redhat.com>