### PR TITLE
Add various "make clean" targets

### DIFF
--- a/.github/workflows/clean-tests.yml
+++ b/.github/workflows/clean-tests.yml
@@ -1,0 +1,42 @@
+---
+name: Clean Target Verification
+
+on:
+  pull_request:
+
+jobs:
+  clean-clusters:
+    name: Cluster Clean-up
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Deploy clusters
+        env:
+          CLUSTERS_ARGS: --timeout 1m
+        run: make clusters
+
+      - name: Clean up clusters
+        run: make clean-clusters
+
+      - name: Check that clusters are gone
+        run: test "$(kind get clusters 2>&1)" = "No kind clusters found."
+
+  clean-generated:
+    name: Generated Files Clean-up
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+
+      - name: Build images
+        run: make images
+
+      - name: Clean up generated files
+        run: make clean-generated
+
+      - name: Check that image markers are gone
+        run: test package/.image.* = "package/.image.*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./gh-actions/post-mortem
 
       - name: Clean up E2E deployment
-        run: make cleanup
+        run: make clean-clusters
 
   release:
     name: Release Images

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./gh-actions/post-mortem
 
       - name: Clean up clusters
-        run: make cleanup
+        run: make clean-clusters
 
   compile:
     name: Compile
@@ -62,7 +62,7 @@ jobs:
         uses: ./gh-actions/post-mortem
 
       - name: Clean up deployment
-        run: make cleanup
+        run: make clean-clusters
 
   e2e:
     name: E2E

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -45,8 +45,17 @@ endif
 
 # Shipyard provided targets
 
-cleanup:
+# clean cleans everything (running clusters, generated files ...)
+clean: clean-clusters clean-generated
+
+# clean-generated removes files we generated
+clean-generated:
+	git clean -X -f
+
+# clean-clusters removes running clusters
+clean-clusters:
 	$(SCRIPTS_DIR)/cleanup.sh
+cleanup: clean-clusters
 
 clusters:
 	$(SCRIPTS_DIR)/clusters.sh $(CLUSTERS_ARGS)

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -126,6 +126,6 @@ export KUBECONFIG=\$(find \$(git rev-parse --show-toplevel)/output/kubeconfigs/ 
 
 $ kubectl config use-context cluster1 # or cluster2, cluster3..
 
-To clean everthing up, just run: make cleanup
+To clean everthing up, just run: make clean-clusters
 EOM
 }


### PR DESCRIPTION
"make clean-generated" removes generated files (by relying on the fact
that we tell git to ignore them).

"make clean-clusters" removes running clusters (this is the old "make
cleanup", which is preserved for backwards compatibility).

"make clean" cleans everything.

Signed-off-by: Stephen Kitt <skitt@redhat.com>