### PR TITLE
Remove obsolete E2E GHA inputs

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -4,7 +4,6 @@ extends: default
 rules:
   line-length:
     max: 140
-    ignore: gh-actions/e2e/action.yaml # TODO: Delete once fixed
   # Allow standard GHA syntax for "on: *"
   truthy:
     ignore: '.github/workflows/*.yml'

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -1,22 +1,6 @@
 name: 'End to End'
 description: 'Runs end to end tests with multiple clusters'
 inputs:
-  # TODO: Remove once it's not being used in consuming projects
-  cabledriver:
-    description: 'Cable driver to use when deploying'
-    required: false
-  # TODO: Remove once it's not being used in consuming projects
-  deploytool:
-    description: 'Deploy tool to use when deploying'
-    required: false
-  # TODO: Remove once it's not being used in consuming projects
-  globalnet:
-    description: 'Should the deployment be with globalnet or not'
-    required: false
-  # TODO: Remove once it's not being used in consuming projects
-  lighthouse:
-    description: 'Should the deployment be with lighthouse or not'
-    required: false
   using:
     description: 'Various options to pass via using="..."'
     required: false
@@ -44,7 +28,7 @@ runs:
     - name: Install WireGuard specific modules
       shell: bash
       run: |
-        [[ "${{ inputs.cabledriver }}" == "wireguard" ]] || [[ "${{ inputs.using }}" =~ "wireguard" ]] || exit 0
+        [[ "${{ inputs.using }}" =~ "wireguard" ]] || exit 0
         echo "::group::Installing WireGuard modules"
         sudo apt install -y linux-headers-$(uname -r) wireguard
         sudo modprobe wireguard
@@ -54,4 +38,4 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        make e2e using="${{ inputs.using }} ${{ inputs.globalnet }} ${{ inputs.deploytool }} ${{ inputs.cabledriver }} ${{ inputs.lighthouse }}"
+        make e2e using="${{ inputs.using }}"


### PR DESCRIPTION
Now that we have `using` and all projects are using that, remove these
inputs

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>