### PR TITLE
Make sure not to exclude 'images' for all projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 IMAGES ?= shipyard-dapper-base nettest
+NON_DAPPER_GOALS += images
 
 ifneq (,$(DAPPER_HOST_ARCH))
 

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -12,7 +12,7 @@
 
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
-$(filter-out .dapper images shell $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
+$(filter-out .dapper shell $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
 	+./.dapper -m bind make --debug=b $@ $(MAKEFLAGS)
 
 shell: .dapper


### PR DESCRIPTION
Since we're now sharing the `Makefile.dapper` file, the exclusion of the
`images` target should be local to Shipyard.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>