### PR TITLE
Fix consuming project E2E, use using= flag for GHA

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -50,8 +50,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: ./gh-actions/e2e
         with:
-          cabledriver: ${{ matrix.cabledriver }}
-          deploytool: ${{ matrix.deploytool }}
+          using: ${{ matrix.cabledriver }} ${{ matrix.deploytool }}
           working-directory: ./${{ matrix.project }}
 
       - name: Post mortem


### PR DESCRIPTION
The var-specific GHA inputs were recently removed, which broke these
tests. Move to the new GHA input, the using= flag.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>