### PR TITLE
Add k8s_version to shared E2E GHA options

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -1,6 +1,10 @@
 name: 'End to End'
 description: 'Runs end to end tests with multiple clusters'
 inputs:
+  k8s_version:
+    description: 'Version of Kubernetes to use for clusters'
+    required: false
+    default: '1.17.17'
   using:
     description: 'Various options to pass via using="..."'
     required: false
@@ -37,5 +41,7 @@ runs:
     - name: Run E2E deployment and tests
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        CLUSTERS_ARGS: --k8s_version="${{ inputs.k8s_version }}"
       run: |
         make e2e using="${{ inputs.using }}"


### PR DESCRIPTION
Allow setting the Kubernetes version used in clusters deployed by the
shared E2E GitHub Action. Pass the version via CLUSTER_ARGS to the
clusters.sh script.

Builds on fix in https://github.com/submariner-io/shipyard/pull/486.