### PR TITLE
Test additional K8s versions

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,6 +19,7 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
         cabledriver: ['libreswan']
+        k8s_version: ['1.17.17']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -31,6 +32,15 @@ jobs:
           - project: submariner
             cabledriver: wireguard
             deploytool: operator
+            k8s_version: 1.17.17
+          # Test multiple K8s versions only in submariner-operator, balancing coverage and jobs
+          # Recentness of K8s versions are limited by kindest/node image releases
+          - project: submariner-operator
+            k8s_version: 1.18.15
+          - project: submariner-operator
+            k8s_version: 1.19.7
+          - project: submariner-operator
+            k8s_version: 1.20.2
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@v2
@@ -54,6 +64,7 @@ jobs:
       - name: Run E2E deployment and tests
         uses: ./gh-actions/e2e
         with:
+          k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.cabledriver }} ${{ matrix.deploytool }}
           working-directory: ./${{ matrix.project }}
 


### PR DESCRIPTION
Test recent patch-releases for the 1.18, 1.19, and 1.20 minor releases.

The recentness of versions available to test are limited by kindest/node
image available.

https://hub.docker.com/r/kindest/node/tags

Only test in the submariner-operator repository for now, to give maximum
coverage for minimal jobs.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>