### PR TITLE
Disable swap on E2E jobs

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -25,6 +25,12 @@ runs:
 
     - shell: bash
       run: |
+        echo "::group::Disable swap"
+        sudo swapoff -a
+        echo "::endgroup::"
+
+    - shell: bash
+      run: |
         echo "::group::Report available RAM"
         free -h
         echo "::endgroup::"

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -13,6 +13,12 @@ runs:
 
     - shell: bash
       run: |
+        echo "::group::Disable swap"
+        sudo swapoff -a
+        echo "::endgroup::"
+
+    - shell: bash
+      run: |
         echo "::group::Report available RAM"
         free -h
         echo "::endgroup::"


### PR DESCRIPTION
We prefer out-of-memory errors to timing-out jobs that we can't debug
and understand.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
