### PR TITLE
Show K8s client/server versions in post mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -24,6 +24,9 @@ function print_pods_logs() {
 }
 
 function post_analyze() {
+    print_section "* Kubernetes client and server versions in $cluster *"
+    kubectl version || true
+
     print_section "* Overview of all resources in $cluster *"
     kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --show-kind -o wide --ignore-not-found
 


### PR DESCRIPTION
Run `kubectl version` in the shared post mortem script. Always exit 0 as
the server may not be running.

This is more important now that we're testing multiple K8s versions.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>