### PR TITLE
Fix OVN for kind 0.10

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -135,6 +135,7 @@ function deploy_kind_ovn(){
     export KIND_CLUSTER_NAME="${cluster}"
 
     export OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
+    export REGISTRY_IP="kind-registry"
     docker pull "${OVN_SRC_IMAGE}"
     docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
     docker push "${OVN_IMAGE}"


### PR DESCRIPTION
As part of changes for kind 0.10 we use `kind-registry` as endpoint
for registry instead of `$registry_ip`.

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>