### PR TITLE
Pass cluster/service CIDRs to subctl join

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -66,6 +66,8 @@ function subctl_install_subm() {
                 --nattport "${CE_IPSEC_NATTPORT}" \
                 --ikeport "${CE_IPSEC_IKEPORT}" \
                 --colorcodes "${SUBM_COLORCODES}" \
+                --clustercidr "${cluster_CIDRs[$cluster]}" \
+                --servicecidr "${service_CIDRs[$cluster]}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \
                 --disable-nat \
                 --cable-driver "${cable_driver}" \


### PR DESCRIPTION
These CIDRs are always generated in utils/add_cluster_cidrs, along with
the existing global_cidr. They are also already passed by default in
deploy_helm/helm_install_subm.

Alternative implementation of idea in #504.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>