### PR TITLE
Add a failing check on PRs not targeting devel

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,0 +1,14 @@
+---
+name: Branch Checks
+
+on:
+  pull_request:
+
+jobs:
+  target_devel:
+    name: PR targets devel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that the PR targets devel
+        if: ${{ github.base_ref != 'devel' }}
+        run: exit 1


### PR DESCRIPTION
See https://github.com/submariner-io/shipyard/pull/506/checks?check_run_id=2225767489 for a failing run targeting another branch.