### PR TITLE
Quick fix to ignore any devel versions

### DIFF
--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,7 +1,7 @@
 # Calculate versions; these can be overridden
 CUTTING_EDGE := devel
 DEV_VERSION := dev
-override CALCULATED_VERSION := $(shell git describe --tags --dirty="-$(DEV_VERSION)" --exclude="$(CUTTING_EDGE)" --exclude="latest")
+override CALCULATED_VERSION := $(shell git describe --tags --dirty="-$(DEV_VERSION)" --exclude="*$(CUTTING_EDGE)*" --exclude="latest")
 VERSION ?= $(CALCULATED_VERSION)
 
 export CUTTING_EDGE DEV_VERSION VERSION


### PR DESCRIPTION
Downstream rpeositores (notably submariner-operator) use extra "devel"
version tags which mess up version calculations.

For now, ignore any tags matching devel versions, until we have a more
proper solution.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>