### PR TITLE
Test upgrades with 1.18.15

### DIFF
--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -25,4 +25,4 @@ runs:
 
     - shell: bash
       run: |
-        make upgrade-e2e
+        make upgrade-e2e CLUSTERS_ARGS=--k8s_version=1.18.15


### PR DESCRIPTION
Thanks to investigation by @mangelajo, we suspect that upgrade failures
are caused by https://github.com/kubernetes/kubernetes/issues/90692 or
one of the related issues; these are supposed to be fixed in 1.18.9,
1.19.0 and later versions.

Signed-off-by: Stephen Kitt <skitt@redhat.com>