### PR TITLE
Stop flagging -dev on release tags

### DIFF
--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,7 +1,7 @@
 # Calculate versions; these can be overridden
 CUTTING_EDGE := devel
 DEV_VERSION := dev
-override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short HEAD)$(shell test -z `git diff-index HEAD` || echo "-$(DEV_VERSION)")
+override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short HEAD)
 VERSION ?= $(CALCULATED_VERSION)
 
 export CUTTING_EDGE DEV_VERSION VERSION


### PR DESCRIPTION
This is happening on most image repositories, and the release
scripts don't work when we publish with -dev tag.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
