### PR TITLE
Make AwaitFinishVerbose return the output

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -148,7 +148,7 @@ func (np *NetworkPod) AwaitFinish() {
 	np.AwaitFinishVerbose(true)
 }
 
-func (np *NetworkPod) AwaitFinishVerbose(verbose bool) {
+func (np *NetworkPod) AwaitFinishVerbose(verbose bool) string {
 	pods := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
 	_, np.TerminationErrorMsg, np.TerminationError = AwaitResultOrError(fmt.Sprintf("await pod %q finished", np.Pod.Name), func() (interface{}, error) {
@@ -177,6 +177,7 @@ func (np *NetworkPod) AwaitFinishVerbose(verbose bool) {
 			fmt.Printf("%s", removeDupDataplaneLines(np.TerminationMessage))
 		}
 	}
+	return np.TerminationMessage
 }
 
 func (np *NetworkPod) CheckSuccessfulFinish() {


### PR DESCRIPTION
that is consumed by subctl benchmark latecny command

Closes: https://github.com/submariner-io/submariner-operator/issues/1273

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>