### PR TITLE
Only remove dotnet on cleanup

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -39,7 +39,7 @@ runs:
       run: |
         echo "::group::Reclaiming free space"
         # Clean up tools we don't need for our CI to free up more space on the hosted runner
-        rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
+        rm -rf /usr/share/dotnet
         df -h
         echo "::endgroup::"
 

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -7,7 +7,7 @@ runs:
       run: |
         echo "::group::Reclaiming free space"
         # Clean up tools we don't need for our CI to free up more space on the hosted runner
-        rm -rf /opt/ghc /usr/share/dotnet /usr/share/swift
+        rm -rf /usr/share/dotnet
         df -h
         echo "::endgroup::"
 


### PR DESCRIPTION
Seems that the other directories are full of small files which take up
to 2 minutes to remove, while the dotnet directory takes up ~10x space
of them cobmined, and deleted within a few seconds.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>