### PR TITLE
Move non-verbose output out of AwaitFinishVerbose

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -173,8 +173,6 @@ func (np *NetworkPod) AwaitFinishVerbose(verbose bool) {
 
 		if verbose {
 			Logf("Pod %q output:\n%s", np.Pod.Name, removeDupDataplaneLines(np.TerminationMessage))
-		} else {
-			fmt.Printf("%s", removeDupDataplaneLines(np.TerminationMessage))
 		}
 	}
 }


### PR DESCRIPTION
to the caller function

Depends-on https://github.com/submariner-io/submariner-operator/pull/1302

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>