### PR TITLE
Increase connect-timeout in benchmark tests

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -345,7 +345,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 						{Name: "TARGET_PORT", Value: strconv.Itoa(np.Config.Port)},
 						{Name: "CONN_TRIES", Value: strconv.Itoa(int(np.Config.ConnectionAttempts))},
 						{Name: "RETRY_SLEEP", Value: strconv.Itoa(int(np.Config.ConnectionTimeout))},
-						{Name: "CONN_TIMEOUT", Value: strconv.Itoa(int(np.Config.ConnectionTimeout))},
+						{Name: "CONN_TIMEOUT", Value: strconv.Itoa(int(np.Config.ConnectionTimeout*1000))},
 					},
 				},
 			},


### PR DESCRIPTION
Currently, while using subctl benchmark tests, the client pod is
using a connect-timeout of 10ms which is too low. It was working
fine in KIND Clusters as the latency between the clusters is generally
less, but in an OnPrem vs Public cluster environments the benchmark
tests it was creating issues. This PR fixes the issue by increasing
the connect-timeout value to 10 secs.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>