### PR TITLE
Switch to k8s v1.20.2 by default

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -3,7 +3,7 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'k8s_version' '1.17.17' 'Version of K8s to use'
+DEFINE_string 'k8s_version' '1.20.2' 'Version of K8s to use'
 DEFINE_string 'olm_version' '0.14.1' 'Version of OLM to use'
 DEFINE_boolean 'olm' false 'Deploy OLM'
 DEFINE_boolean 'prometheus' false 'Deploy Prometheus'


### PR DESCRIPTION
This provides broader compatibility and kernel versions support
fixing issues with cgroups2 in Fedora 33 & Fedora 34 while on CI
our gh-action scripts will still default to 1.17 for the 1.17 jobs.

Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>
