### PR TITLE
Fix double printing targets in Shipyard

### DIFF
--- a/scripts/shared/targets.sh
+++ b/scripts/shared/targets.sh
@@ -10,6 +10,6 @@ make_targets=($(make -pRrq : 2>/dev/null |\
     grep -oP '^(?!Makefile.*)[-[:alnum:]]*(?=:)' | sort -u))
 
 for target in ${make_targets[*]}; do
-    print_indent "${target}" \
-    "$(grep -hoP -m1 "(?<=\[${target}\] ).*" Makefile* ${SHIPYARD_DIR}/Makefile*)"
+    description=$(grep -hoP -m1 "(?<=\[${target}\] ).*" Makefile* ${SHIPYARD_DIR}/Makefile* | head -1)
+    print_indent "${target}" "${description}"
 done


### PR DESCRIPTION
In shipyard the source files and `${SHIPYARD_DIR}` files are the same,
causing double printing.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>