### PR TITLE
Linting in a small image

### DIFF
--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -1,0 +1,10 @@
+FROM quay.io/submariner/shipyard-linting:devel
+
+ENV DAPPER_ENV="GITHUB_SHA MAKEFLAGS" \
+    DAPPER_SOURCE=/go/src/github.com/submariner-io/shipyard DAPPER_DOCKER_SOCKET=true
+ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output SCRIPTS_DIR=${DAPPER_SOURCE}/scripts/shared
+
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["/opt/shipyard/scripts/entry"]
+CMD ["sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BASE_BRANCH ?= devel
-IMAGES ?= shipyard-dapper-base nettest
+IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 NON_DAPPER_GOALS += images
 FOCUS ?=
 SKIP ?=
@@ -53,7 +53,7 @@ include Makefile.versions
 # Shipyard-specific starts
 # We need to ensure images, including the Shipyard base image, are updated
 # before we start Dapper
-clusters deploy deploy-latest e2e gitlint golangci-lint markdownlint nettest post-mortem print-version unit upgrade-e2e: images
+clusters deploy deploy-latest e2e golangci-lint nettest post-mortem print-version unit upgrade-e2e: images
 
 images: export SCRIPTS_DIR=./scripts/shared
 
@@ -75,5 +75,9 @@ NON_DAPPER_GOALS += prune-images
 .PHONY: prune-images
 
 include Makefile.dapper
+
+# Make sure linting goals have up-to-date linting image
+$(LINTING_GOALS): export SCRIPTS_DIR=./scripts/shared
+$(LINTING_GOALS): package/.image.shipyard-linting
 
 endif

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -3,7 +3,11 @@
 # other projects (and needs to be copied, it can't be shared
 # via the Dapper image since it's needed to retrieve the image)
 
+LINTING_GOALS := gitlint shellcheck yamllint markdownlint
+NON_DAPPER_GOALS += .dapper shell targets $(LINTING_GOALS)
 export MAKEFLAGS
+
+.PHONY: $(LINTING_GOALS)
 
 .dapper:
 	@echo Downloading dapper
@@ -21,12 +25,16 @@ $(filter-out .dapper shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
 	-docker network create -d bridge kind
 	+$(RUN_IN_DAPPER) make --debug=b $@
 
+# Run silently as the commands are pretty straightforward and `make` hasn't a lot to do
+$(LINTING_GOALS): .dapper
+	@$(RUN_IN_DAPPER) -f Dockerfile.linting -q make $@
+
 shell: .dapper
 	$(RUN_IN_DAPPER) -s
 
 # Run silently to just list the targets (hence we can't use the generic dapper wrapper recipe).
 # This only lists targets accessible inside dapper (which are 99% of targets we use)
 targets:
-	@$(RUN_IN_DAPPER) -q eval "\$${SCRIPTS_DIR}/targets.sh"
+	@$(RUN_IN_DAPPER) -f Dockerfile.linting -q eval "\$${SCRIPTS_DIR}/targets.sh"
 
 .PHONY: shell targets

--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -1,0 +1,37 @@
+FROM alpine
+
+ENV DAPPER_HOST_ARCH=amd64 SHELL=/bin/bash \
+    SHIPYARD_DIR=/opt/shipyard
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
+    SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
+
+# Requirements:
+# Component        | Usage
+# -------------------------------------------------------------------
+# bash             | Just your basic shell
+# findutils        | Finding executables to compress
+# gitlint          | Git commit message linting
+# grep             | For listing targets
+# make             | Running makefiles inside the container
+# markdownlint     | Markdown linting
+# nodejs           | Used by markdownlint
+# npm              | Installing markdownlint (Removed afterwards)
+# py3-pip          | Installing gitlint (Removed afterwards)
+# shellcheck       | Shell script linting
+# upx              | Compressing executables to get a smaller image
+# yamllint         | YAML linting
+
+RUN apk add --no-cache bash findutils git grep make nodejs shellcheck upx yamllint && \
+    apk add --no-cache --virtual installers npm py3-pip && \
+    npm install -g markdownlint-cli && \
+    pip install gitlint && \
+    find /usr/bin/ -type f -executable -newercc /proc -size +1M  \( -execdir upx {} \; -o -true \) && \
+    find /usr/lib/ -name __pycache__ -type d -exec rm -rf {} + && \
+    apk del installers
+
+# Copy shared makefiles so that downstream projects can use it
+COPY Makefile.* ${SHIPYARD_DIR}/
+
+# Copy shared scripts into image to share with all submariner-io/* projects
+WORKDIR $SCRIPTS_DIR
+COPY scripts/shared/ .


### PR DESCRIPTION
Most linting commands (except golangci-lint) are self contained programs
with a relatively small footprint.
This change breaks them out to a separate Dockerfile which is based on
alpine and results in a tiny image (~80Mb on the filesystem) which
should make linting happen much faster (especially on the CI that has to
download the linting image).

If all consuming projects adopt this change, we can remove the linting
commands from the base image which should help reduce its size as well.

Related to: #540 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>