### PR TITLE
Add VxLAN cable driver

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -22,6 +22,8 @@ $(error strongSwan is no longer supported)
 else ifneq (,$(filter wireguard,$(_using)))
 # Wireguard requires kernel module install on the host
 override DEPLOY_ARGS += --cable_driver wireguard
+else ifneq (,$(filter vxlan,$(_using)))
+override DEPLOY_ARGS += --cable_driver vxlan
 endif
 
 ifneq (,$(filter lighthouse,$(_using)))


### PR DESCRIPTION
Support for VxLAN cable driver is being added currently (https://github.com/submariner-io/submariner/pull/1171). The idea is to add a GH workflow to test VxLAN while it is being developed in CI itself.

This patch makes that happen.

Signed-off-by: Janki Chhatbar <jchhatba@redhat.com>