### PR TITLE
Specify the :z mount suffix on the registry

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -163,7 +163,10 @@ function run_local_registry() {
     else
         echo "Deploying local registry $KIND_REGISTRY to serve images centrally."
         local volume_flag
-        [[ $registry_inmemory != "true" ]] || volume_flag="-v /dev/shm/${KIND_REGISTRY}:/var/lib/registry"
+        if [[ $registry_inmemory = true ]]; then
+            volume_flag="-v /dev/shm/${KIND_REGISTRY}:/var/lib/registry"
+            selinuxenabled && volume_flag="${volume_flag}:z" 2>/dev/null
+        fi
         docker run -d $volume_flag -p 127.0.0.1:5000:5000 --restart=always --name $KIND_REGISTRY registry:2
         docker network connect kind $KIND_REGISTRY || true
     fi


### PR DESCRIPTION
This allows the registry to work with SELinux in enforcing mode.

Signed-off-by: Stephen Kitt <skitt@redhat.com>