### PR TITLE
Run LH flag only with/without deploy tool

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -47,7 +47,12 @@ jobs:
       matrix:
         globalnet: ['', 'globalnet']
         deploytool: ['operator', 'helm']
-        lighthouse: ['', 'lighthouse']
+        lighthouse: ['']
+        include:
+          - deploytool: operator
+            lighthouse: lighthouse
+          - deploytool: helm
+            lighthouse: lighthouse
     steps:
       - name: Check out the repository
         uses: actions/checkout@v2


### PR DESCRIPTION
As differences can stem from the deploytool used, but not from other
parameters (e.g. globalnet), run lighthouse deploy only with the
specific combinations that make sense to test.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>