### PR TITLE
Update the copyright statements to match CNCF recs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Check License Headers
-        uses: nilp0inter/search-legal-headers@v0.1.0
+        uses: kt3k/license_checker@v1.0.6
 
   markdown-link-check:
     name: Markdown Links (modified files)

--- a/.legal.json
+++ b/.legal.json
@@ -1,4 +1,0 @@
-{
-  "**/*.go": "Licensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.\n",
-  "LICENSE": "Apache License"
-}

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,31 @@
+[
+    {
+	"**/*.{go,proto}": [
+	    "Licensed under the Apache License, Version 2.0 (the \"License\");",
+	    "you may not use this file except in compliance with the License.",
+	    "You may obtain a copy of the License at",
+	    "    http://www.apache.org/licenses/LICENSE-2.0",
+	    "Unless required by applicable law or agreed to in writing, software",
+	    "distributed under the License is distributed on an \"AS IS\" BASIS,",
+	    "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+	    "See the License for the specific language governing permissions and",
+	    "limitations under the License."
+	],
+ 	"ignore": [
+	    "vendor/"
+	]
+    },
+    {
+	"**/*.{go,proto}": [
+	    "SPDX-License-Identifier: Apache-2.0",
+	    "Copyright Contributors to the Submariner project."
+	],
+	"ignore": [
+	    "test/e2e/framework/ginkgowrapper/wrapper.go",
+	    "vendor/"
+	]
+    },
+    {
+	"LICENSE": "Apache License"
+    }
+]

--- a/test/e2e/dataplane/tcp_connectivity.go
+++ b/test/e2e/dataplane/tcp_connectivity.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/api_errors.go
+++ b/test/e2e/framework/api_errors.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/docker.go
+++ b/test/e2e/framework/docker.go
@@ -1,4 +1,8 @@
 /*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -1,5 +1,7 @@
 /*
-© 2021 Red Hat, Inc. and others
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/ginkgo_framework.go
+++ b/test/e2e/framework/ginkgo_framework.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/logging.go
+++ b/test/e2e/framework/logging.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/service_exports.go
+++ b/test/e2e/framework/service_exports.go
@@ -1,5 +1,7 @@
 /*
-© 2021 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/scripts/compile/hello.go
+++ b/test/scripts/compile/hello.go
@@ -1,5 +1,7 @@
 /*
-© 2020 Red Hat, Inc.
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
This updates the copyright statements to match the CNCF
recommendation, as per
https://github.com/cncf/foundation/blob/master/copyright-notices.md

We also add SPDX headers, and add enforcement.

Signed-off-by: Stephen Kitt <skitt@redhat.com>