### PR TITLE
Enable custom pod to support HostNetworking

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -465,6 +465,7 @@ func (np *NetworkPod) buildLatencyServerPod() {
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will use the image specified and run command specified.
 func (np *NetworkPod) buildCustomPod() {
+	terminationGracePeriodSeconds := int64(5)
 	customPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "custom",
@@ -475,6 +476,8 @@ func (np *NetworkPod) buildCustomPod() {
 		Spec: v1.PodSpec{
 			Affinity:      nodeAffinity(np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
+			HostNetwork:   bool(np.Config.Networking),
+			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			Containers: []v1.Container{
 				{
 					Name:            np.Config.ContainerName,


### PR DESCRIPTION
Also, it was seen that because we were not explicitly configuring the
terminationGracePeriodSeconds, the default value of 30 secs is used
and Pod is getting terminated only after 30 secs. This PR configures
some reasonable value of 5 secs, until we have a use-case where we
require a configurable value.

Related to: https://github.com/submariner-io/submariner/issues/1164
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
