### PR TITLE
Linting in a small image

### DIFF
--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -1,0 +1,10 @@
+FROM quay.io/submariner/shipyard-linting:devel
+
+ENV DAPPER_ENV="GITHUB_SHA MAKEFLAGS" \
+    DAPPER_SOURCE=/opt/linting
+ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
+
+WORKDIR ${DAPPER_SOURCE}
+
+ENTRYPOINT ["/opt/shipyard/scripts/entry"]
+CMD ["sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BASE_BRANCH ?= devel
-IMAGES ?= shipyard-dapper-base nettest
+IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 NON_DAPPER_GOALS += images
 FOCUS ?=
 SKIP ?=
@@ -47,15 +47,15 @@ else
 
 # Not running in Dapper
 
+export SCRIPTS_DIR=./scripts/shared
+
 include Makefile.images
 include Makefile.versions
 
 # Shipyard-specific starts
 # We need to ensure images, including the Shipyard base image, are updated
 # before we start Dapper
-clusters deploy deploy-latest e2e gitlint golangci-lint markdownlint nettest post-mortem print-version unit upgrade-e2e: images
-
-images: export SCRIPTS_DIR=./scripts/shared
+clusters deploy deploy-latest e2e golangci-lint nettest post-mortem print-version unit upgrade-e2e: images
 
 .DEFAULT_GOAL := lint
 # Shipyard-specific ends
@@ -75,5 +75,8 @@ NON_DAPPER_GOALS += prune-images
 .PHONY: prune-images
 
 include Makefile.dapper
+
+# Make sure linting goals have up-to-date linting image
+$(LINTING_GOALS): package/.image.shipyard-linting
 
 endif

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -3,6 +3,9 @@
 # other projects (and needs to be copied, it can't be shared
 # via the Dapper image since it's needed to retrieve the image)
 
+LINTING_DAPPER := Dockerfile.linting
+LINTING_GOALS := gitlint shellcheck yamllint markdownlint
+NON_DAPPER_GOALS += .dapper shell targets $(LINTING_GOALS)
 export MAKEFLAGS
 
 .dapper:
@@ -21,12 +24,21 @@ $(filter-out .dapper shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper
 	-docker network create -d bridge kind
 	+$(RUN_IN_DAPPER) make --debug=b $@
 
+# The original dockerfile will live in Shipyard and be downloaded by consuming projects.
+$(LINTING_DAPPER):
+	@echo Downloading $@
+	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/$(BASE_BRANCH)/$@
+
+# Run silently as the commands are pretty straightforward and `make` hasn't a lot to do
+$(LINTING_GOALS): .dapper $(LINTING_DAPPER)
+	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -q make $@
+
 shell: .dapper
 	$(RUN_IN_DAPPER) -s
 
 # Run silently to just list the targets (hence we can't use the generic dapper wrapper recipe).
 # This only lists targets accessible inside dapper (which are 99% of targets we use)
-targets:
-	@$(RUN_IN_DAPPER) -q eval "\$${SCRIPTS_DIR}/targets.sh"
+targets: $(LINTING_DAPPER)
+	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -q eval "\$${SCRIPTS_DIR}/targets.sh"
 
-.PHONY: shell targets
+.PHONY: shell targets $(LINTING_GOALS)

--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -1,0 +1,37 @@
+FROM alpine
+
+ENV DAPPER_HOST_ARCH=amd64 SHELL=/bin/bash \
+    SHIPYARD_DIR=/opt/shipyard
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
+    SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
+
+# Requirements:
+# Component        | Usage
+# -------------------------------------------------------------------
+# bash             | Just your basic shell
+# findutils        | Finding executables to compress
+# gitlint          | Git commit message linting
+# grep             | For listing targets
+# make             | Running makefiles inside the container
+# markdownlint     | Markdown linting
+# nodejs           | Used by markdownlint
+# npm              | Installing markdownlint (Removed afterwards)
+# py3-pip          | Installing gitlint (Removed afterwards)
+# shellcheck       | Shell script linting
+# upx              | Compressing executables to get a smaller image
+# yamllint         | YAML linting
+
+RUN apk add --no-cache bash findutils git grep make nodejs shellcheck upx yamllint && \
+    apk add --no-cache --virtual installers npm py3-pip && \
+    npm install -g markdownlint-cli && \
+    pip install gitlint && \
+    find /usr/bin/ -type f -executable -newercc /proc -size +1M  \( -execdir upx {} \; -o -true \) && \
+    find /usr/lib/ -name __pycache__ -type d -exec rm -rf {} + && \
+    apk del installers
+
+# Copy shared makefiles so that downstream projects can use it
+COPY Makefile.* ${SHIPYARD_DIR}/
+
+# Copy shared scripts into image to share with all submariner-io/* projects
+WORKDIR $SCRIPTS_DIR
+COPY scripts/shared/ .


### PR DESCRIPTION
Most linting commands (except golangci-lint) are self contained programs
with a relatively small footprint.
This change breaks them out to a separate Dockerfile which is based on
alpine and results in a tiny image (~80Mb on the filesystem) which
should make linting happen much faster (especially on the CI that has to
download the linting image).

If all consuming projects adopt this change, we can remove the linting
commands from the base image which should help reduce its size as well.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
