### PR TITLE
Bump to kind 0.11

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -52,7 +52,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.39.0 \
     HELM_VERSION=v3.4.1 \
-    KIND_VERSION=v0.10.0 \
+    KIND_VERSION=v0.11.1 \
     BUILDX_VERSION=v0.5.1
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -4,9 +4,10 @@
 # See the release notes of the kind version in use
 declare -A kind_k8s_versions
 kind_k8s_versions[1.17]=1.17.17
-kind_k8s_versions[1.18]=1.18.15
-kind_k8s_versions[1.19]=1.19.7
-kind_k8s_versions[1.20]=1.20.2
+kind_k8s_versions[1.18]=1.18.19
+kind_k8s_versions[1.19]=1.19.11
+kind_k8s_versions[1.20]=1.20.7
+kind_k8s_versions[1.21]=1.21.1
 
 ## Process command line flags ##
 


### PR DESCRIPTION
See https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.0 for
details. This bumps the supported K8s versions to 1.18.19, 1.19.11,
1.20.7, and adds support for 1.21 (1.21.1).

Depends on https://github.com/submariner-io/shipyard/issues/567
Depends on https://github.com/submariner-io/lighthouse/pull/548
Depends on https://github.com/submariner-io/submariner/pull/1371
Depends on https://github.com/submariner-io/submariner-charts/pull/145
Depends on https://github.com/submariner-io/submariner-operator/pull/1392
Depends on https://github.com/submariner-io/shipyard/issues/575

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
