### PR TITLE
clusters.sh: support short K8s versions

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,7 +19,7 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
         cabledriver: ['libreswan']
-        k8s_version: ['1.17.17']
+        k8s_version: ['1.17']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -32,15 +32,14 @@ jobs:
           - project: submariner
             cabledriver: wireguard
             deploytool: operator
-            k8s_version: 1.17.17
+            k8s_version: '1.17'
           # Test multiple K8s versions only in submariner-operator, balancing coverage and jobs
-          # Recentness of K8s versions are limited by kindest/node image releases
           - project: submariner-operator
-            k8s_version: 1.18.15
+            k8s_version: '1.18'
           - project: submariner-operator
-            k8s_version: 1.19.7
+            k8s_version: '1.19'
           - project: submariner-operator
-            k8s_version: 1.20.2
+            k8s_version: '1.20'
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@v2

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -4,7 +4,7 @@ inputs:
   k8s_version:
     description: 'Version of Kubernetes to use for clusters'
     required: false
-    default: '1.17.17'
+    default: '1.17'
   using:
     description: 'Various options to pass via using="..."'
     required: false

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+## Kubernetes version mapping, as supported by kind ##
+# See the release notes of the kind version in use
+declare -A kind_k8s_versions
+kind_k8s_versions[1.17]=1.17.17
+kind_k8s_versions[1.18]=1.18.15
+kind_k8s_versions[1.19]=1.19.7
+kind_k8s_versions[1.20]=1.20.2
+
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'k8s_version' '1.20.2' 'Version of K8s to use'
+DEFINE_string 'k8s_version' '1.20' 'Version of K8s to use'
 DEFINE_string 'olm_version' '0.14.1' 'Version of OLM to use'
 DEFINE_boolean 'olm' false 'Deploy OLM'
 DEFINE_boolean 'prometheus' false 'Deploy Prometheus'
@@ -16,6 +24,7 @@ eval set -- "${FLAGS_ARGV}"
 
 k8s_version="${FLAGS_k8s_version}"
 olm_version="${FLAGS_olm_version}"
+[[ -n "${kind_k8s_versions[$k8s_version]}" ]] && k8s_version="${kind_k8s_versions[$k8s_version]}"
 [[ "${FLAGS_olm}" = "${FLAGS_TRUE}" ]] && olm=true || olm=false
 [[ "${FLAGS_prometheus}" = "${FLAGS_TRUE}" ]] && prometheus=true || prometheus=false
 [[ "${FLAGS_globalnet}" = "${FLAGS_TRUE}" ]] && globalnet=true || globalnet=false


### PR DESCRIPTION
Instead of specifying the full K8s version all the time, support only
specifying the major and minor; clusters.sh then fills in the patch
version with whatever is supported by the current kind version.

Once downstreams are updated to use this, we will be able to bump kind
versions without breaking them.

Fixes: #567
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
