### PR TITLE
Don't run E2E on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,35 +8,8 @@ on:
       - release-*
 
 jobs:
-  e2e:
-    name: E2E
-    if: github.repository_owner == 'submariner-io'
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v2
-
-      - name: Reclaim free space
-        run: |
-          sudo swapoff -a
-          sudo rm -f /swapfile
-
-      - name: Run E2E deployment and tests
-        run: make e2e
-        env:
-          IMAGES_ARGS: --nocache
-
-      - name: Post mortem
-        if: failure()
-        uses: ./gh-actions/post-mortem
-
-      - name: Clean up E2E deployment
-        run: make clean-clusters
-
   release:
     name: Release Images
-    needs: e2e
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository


### PR DESCRIPTION
We're already running E2E (in greater capacity) on each PR, and have
branch protections to make sure only up to date, tested, and approved
code can be merged, so having E2E run on push is just redundant (and
detrimental since it's prone to "hidden" failures which prevent latest
images from publishing).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
