### PR TITLE
Copy Shipyard resources into consuming projects

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -53,6 +53,9 @@ jobs:
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 
+      - name: Copy Shipyard resources
+        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
+
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
 
@@ -89,12 +92,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: submariner-io/${{ matrix.project }}
+          path: ${{ matrix.project }}
+
+      - name: Copy Shipyard resources
+        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
-        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
+        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
 
       - name: Run all linters
-        run: make lint
+        run: make -C ${{ matrix.project }} lint
 
   unit-consuming:
     name: Unit Tests
@@ -118,9 +125,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: submariner-io/${{ matrix.project }}
+          path: ${{ matrix.project }}
+
+      - name: Copy Shipyard resources
+        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
-        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
+        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
 
       - name: Run all unit tests
-        run: make unit
+        run: make -C ${{ matrix.project }} unit


### PR DESCRIPTION
For consuming jobs, the projects being checked should be updated to
use the Shipyard resources from the Shipyard PR being tested, not
those from the base branch.

Fixes: #491
Fixes: #575
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
