### PR TITLE
clusters.sh: handle empty k8s_version

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -2,6 +2,7 @@
 
 ## Kubernetes version mapping, as supported by kind ##
 # See the release notes of the kind version in use
+DEFAULT_K8S_VERSION=1.20
 declare -A kind_k8s_versions
 kind_k8s_versions[1.17]=1.17.17
 kind_k8s_versions[1.18]=1.18.19
@@ -12,7 +13,7 @@ kind_k8s_versions[1.21]=1.21.1
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'k8s_version' '1.20' 'Version of K8s to use'
+DEFINE_string 'k8s_version' "${DEFAULT_K8S_VERSION}" 'Version of K8s to use'
 DEFINE_string 'olm_version' '0.14.1' 'Version of OLM to use'
 DEFINE_boolean 'olm' false 'Deploy OLM'
 DEFINE_boolean 'prometheus' false 'Deploy Prometheus'
@@ -25,6 +26,7 @@ eval set -- "${FLAGS_ARGV}"
 
 k8s_version="${FLAGS_k8s_version}"
 olm_version="${FLAGS_olm_version}"
+[[ -z "${k8s_version}" ]] && k8s_version="${DEFAULT_K8S_VERSION}"
 [[ -n "${kind_k8s_versions[$k8s_version]}" ]] && k8s_version="${kind_k8s_versions[$k8s_version]}"
 [[ "${FLAGS_olm}" = "${FLAGS_TRUE}" ]] && olm=true || olm=false
 [[ "${FLAGS_prometheus}" = "${FLAGS_TRUE}" ]] && prometheus=true || prometheus=false


### PR DESCRIPTION
If the Kubernetes version flag is specified in the arguments, but with
an empty value, shflags doesn't set the default for us. We need to
handle this case explicitly before looking up the value in the
associative array.

Fixes: #578
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
