### PR TITLE
Add APIs to read GlobalIP for GN2.0 objects

### DIFF
--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -1,0 +1,76 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var clusterGlobalEgressIPGVR = &schema.GroupVersionResource{
+	Group:    "submariner.io",
+	Version:  "v1",
+	Resource: "clusterglobalegressips",
+}
+
+func (f *Framework) AwaitClusterGlobalEgressIPs(cluster ClusterIndex, name string) []string {
+	if TestContext.GlobalnetEnabled {
+		gipClient := clusterGlobalEgressIPClient(cluster)
+		obj := AwaitUntil(fmt.Sprintf("await ClusterGlobalEgressIP %s", name),
+			func() (interface{}, error) {
+				resGip, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				}
+				return resGip, err
+			},
+			func(result interface{}) (bool, string, error) {
+				if result == nil {
+					return false, fmt.Sprintf("ClusterGlobalEgressIP %s not found yet", name), nil
+				}
+
+				globalIPs := getGlobalIPs(result.(*unstructured.Unstructured))
+				if len(globalIPs) == 0 {
+					return false, fmt.Sprintf("ClusterGlobalEgressIP %q exists but allocatedIPs not available yet", name), nil
+				}
+				return true, "", nil
+			})
+
+		return getGlobalIPs(obj.(*unstructured.Unstructured))
+	}
+	return []string{}
+}
+
+func clusterGlobalEgressIPClient(cluster ClusterIndex) dynamic.ResourceInterface {
+	return DynClients[cluster].Resource(*clusterGlobalEgressIPGVR).Namespace(corev1.NamespaceAll)
+}
+
+func getGlobalIPs(obj *unstructured.Unstructured) []string {
+	if obj != nil {
+		globalIPs, _, _ := unstructured.NestedStringSlice(obj.Object, "status", "allocatedIPs")
+		return globalIPs
+	}
+	return []string{}
+}

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -1,0 +1,92 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package framework
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var globalIngressIPGVR = &schema.GroupVersionResource{
+	Group:    "submariner.io",
+	Version:  "v1",
+	Resource: "globalingressips",
+}
+
+func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace string) string {
+	if TestContext.GlobalnetEnabled {
+		gipClient := globalIngressIPClient(cluster, namespace)
+		obj := AwaitUntil(fmt.Sprintf("await GlobalIngressIP %s/%s", namespace, name),
+			func() (interface{}, error) {
+				resGip, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return nil, nil
+				}
+				return resGip, err
+			},
+			func(result interface{}) (bool, string, error) {
+				if result == nil {
+					return false, fmt.Sprintf("GlobalEgressIP %s not found yet", name), nil
+				}
+
+				globalIP := getGlobalIP(result.(*unstructured.Unstructured))
+				if globalIP == "" {
+					return false, fmt.Sprintf("GlobalIngress %q exists but allocatedIP not available yet",
+						name), nil
+				}
+				return true, "", nil
+			})
+
+		return getGlobalIP(obj.(*unstructured.Unstructured))
+	}
+	return ""
+}
+
+func (f *Framework) AwaitGlobalIngressIPRemoved(cluster ClusterIndex, name, namespace string) {
+	gipClient := globalIngressIPClient(cluster, namespace)
+	AwaitUntil(fmt.Sprintf("await GlobalIngressIP %s/%s removed", namespace, name),
+		func() (interface{}, error) {
+			_, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		},
+		func(result interface{}) (bool, string, error) {
+			gone := result.(bool)
+			return gone, "", nil
+		})
+}
+
+func globalIngressIPClient(cluster ClusterIndex, namespace string) dynamic.ResourceInterface {
+	return DynClients[cluster].Resource(*globalIngressIPGVR).Namespace(namespace)
+}
+
+func getGlobalIP(obj *unstructured.Unstructured) string {
+	if obj != nil {
+		globalIP, _, _ := unstructured.NestedString(obj.Object, "status", "allocatedIP")
+		return globalIP
+	}
+	return ""
+}


### PR DESCRIPTION
This PR implements APIs that return the GlobalIPs part of ClusterGlobalEgressIP
as well as GlobalIngressIP objects.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>
Co-authored-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
