### PR TITLE
Retrieve Global IngressIP during test_connection

### DIFF
--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -23,8 +23,11 @@ function get_globalip() {
     local gip
     gip=$(kubectl get svc "$svc_name" -o jsonpath='{.metadata.annotations.submariner\.io/globalIp}')
     if [[ -z "${gip}" ]]; then
-        sleep 1
-        return 1
+        gip=$(kubectl get giip "$svc_name" -o jsonpath='{.status.allocatedIP}')
+        if [[ -z "${gip}" ]]; then
+            sleep 1
+            return 1
+        fi
     fi
 
     echo "$gip"


### PR DESCRIPTION
After deploying KIND clusters, a simple test_connection is executed
to check if basic connectivity is working fine between the clusters.
This API is now updated to support querying the globalIP from the new
GlobalIngressIP objects and also retains backward compatibility with
the previous approach which can be removed in a later PR.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
