### PR TITLE
Don't expand command substitution in debug

### DIFF
--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -9,9 +9,11 @@ NO_COLOR=$(echo -e '\e[0m')
 
 function trap_commands() {
     # Function to print each bash command before it is executed
-    trap '! [[ "$BASH_COMMAND" =~ ^(echo|read|\[|while|for|local) ]] &&
+    trap 'cmd="$BASH_COMMAND" &&
+          ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local) ]] &&
+          { [[ ! "$cmd" =~ \$\( ]] || cmd="${cmd@Q}"; } &&
           ctxt="${cluster:+[${cluster}]}" &&
-          cmd=`eval echo "[${PWD##*/}]\$ $ctxt $BASH_COMMAND" 2>/dev/null` &&
+          cmd=`eval echo "[${PWD##*/}]\$ $ctxt $cmd" 2>/dev/null` &&
           echo "${CYAN_COLOR}$cmd${NO_COLOR}" >&2; true' DEBUG
 }
 


### PR DESCRIPTION
This should make sure command substitution isn't being expanded when
printing the debug messages, causing some command to be executed twice.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
