### PR TITLE
Don't expand command substitution in debug

### DIFF
--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -9,9 +9,11 @@ NO_COLOR=$(echo -e '\e[0m')
 
 function trap_commands() {
     # Function to print each bash command before it is executed
-    trap '! [[ "$BASH_COMMAND" =~ ^(echo|read|\[|while|for) ]] &&
+    trap 'cmd="$BASH_COMMAND" &&
+          ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local) ]] &&
+          { [[ ! "$cmd" =~ \$\( ]] || cmd="${cmd@Q}"; } &&
           ctxt="${cluster:+[${cluster}]}" &&
-          cmd=`eval echo "[${PWD##*/}]\$ $ctxt $BASH_COMMAND" 2>/dev/null` &&
+          cmd=`eval echo "[${PWD##*/}]\$ $ctxt $cmd" 2>/dev/null` &&
           echo "${CYAN_COLOR}$cmd${NO_COLOR}" >&2; true' DEBUG
 }
 


### PR DESCRIPTION
This should make sure command substitution isn't being expanded when
printing the debug messages, causing some command to be executed twice.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 78f65956d57af76050e12def5bc1e4030fb4229d)
