### PR TITLE
Change globalCIDR to 242.254.x.0

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -100,7 +100,7 @@ function add_cluster_cidrs() {
     [[ $globalnet != "true" ]] || val="0"
     cluster_CIDRs[$idx]="10.${val}.0.0/16"
     service_CIDRs[$idx]="100.${val}.0.0/16"
-    [[ $globalnet != "true" ]] || global_CIDRs[$idx]="169.254.${1}.0/24"
+    [[ $globalnet != "true" ]] || global_CIDRs[$idx]="242.254.${1}.0/24"
 }
 
 function declare_cidrs() {


### PR DESCRIPTION
Current default globalCIDR of `169.254.x.0` cannot be used for
headless services as EndpointSlices can't have IP in link-local
CIDR range. Change to `242.254.x.0`

Reference https://github.com/kubernetes/kubernetes/pull/101084

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
