### PR TITLE
Add linter to check no "Apply suggestions" commits

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,24 @@ on:
   pull_request:
 
 jobs:
+  apply-suggestions-commits:
+    name: 'No "Apply suggestions from code review" Commits'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR commits
+        id: 'get-pr-commits'
+        uses: tim-actions/get-pr-commits@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Verify no "Apply suggestions from code review" commits'
+        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^(?!.*(apply suggestions from code review))'
+          flags: 'i'
+          error: 'Commits addressing code review feedback should typically be squashed into the commits under review'
+
   gitlint:
     name: Commit Message(s)
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add a linting job to verify that no commit message in a PR contains the
case insensitive string "Apply suggestions from code review". Commits
with exactly this title are generated by GitHub automatically when a
batch of proposed changes from code review are accepted from the GitHub
UI. A number of such commits have made it into various Submariner/*
repos.

Commits addressing code review feedback should typically be squashed
into the commits under review, or made into well-commented discrete
commits.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
