### PR TITLE
Use our own implementation of Dapper

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+file=Dockerfile.dapper
+socket=false
+dockerargs=
+
+while true
+do
+    case "$1" in
+        --file|-f)
+            file="$2"
+            shift 2
+            ;;
+        --socket|-k)
+            socket=true
+            shift
+            ;;
+        --directory|-C)
+            cd "$2" || exit
+            shift 2
+            ;;
+        --shell|-s)
+            command=bash
+            DAPPER_ENV="${DAPPER_ENV} TERM"
+            shift
+            ;;
+        --debug|-d)
+            shift
+            set -x
+            ;;
+        --version|-v)
+            echo Submariner Dapper
+            exit 0
+            ;;
+        --mount-suffix|-S)
+            suffix=":$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "$0 doesn't support $1" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+[ -n "$command" ] && set -- "$command"
+
+gitid="$(git symbolic-ref --short HEAD 2>/dev/null | tr / _ || :)"
+gitid="${gitid:-$(git show --format=%h -s)}"
+container="$(basename "$(pwd)"):${gitid}"
+docker build -t "${container}" -f "${file}" --build-arg "BASE_BRANCH=${BASE_BRANCH:-devel}" .
+
+extract_var() {
+    docker inspect "$1" | sed -n -E "/\"$2=/{s/[[:space:]]+\"$2=([^\"]+)\",/\1/;p;q}"
+}
+
+DAPPER_CP="$(extract_var "${container}" DAPPER_CP)"
+[ -z "${DAPPER_CP}" ] && DAPPER_CP="$(pwd)"
+DAPPER_ENV="${DAPPER_ENV} $(extract_var "${container}" DAPPER_ENV)"
+DAPPER_SOURCE="$(extract_var "${container}" DAPPER_SOURCE)"
+[ -z "${DAPPER_SOURCE}" ] && DAPPER_SOURCE="/source/"
+DAPPER_DOCKER_SOCKET="$(extract_var "${container}" DAPPER_DOCKER_SOCKET)"
+DAPPER_RUN_ARGS="$(extract_var "${container}" DAPPER_RUN_ARGS)"
+
+if [ "${socket}" = true ] || [ "${DAPPER_DOCKER_SOCKET}" = true ]
+then
+    if [ -S /var/run/docker.sock ]; then
+        # Docker
+        dockerargs="${dockerargs} -v /var/run/docker.sock:/var/run/docker.sock${suffix}"
+    else
+        # Assume rootless Podman
+        dockerargs="${dockerargs} -v /run/user/$(id -u)/podman/podman.sock:/var/run/docker.sock${suffix}"
+    fi
+fi
+
+[ -t 1 ] && dockerargs="${dockerargs} -t"
+
+docker run -i --rm $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$(id -u)" -e "DAPPER_GID=$(id -g)" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"

--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -56,7 +56,7 @@ jobs:
           path: ${{ matrix.project }}
 
       - name: Copy Shipyard resources
-        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
+        run: cp -n Dockerfile.* Makefile.dapper .dapper ${{ matrix.project }}/
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
@@ -99,7 +99,7 @@ jobs:
           path: ${{ matrix.project }}
 
       - name: Copy Shipyard resources
-        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
+        run: cp -n Dockerfile.* Makefile.dapper .dapper ${{ matrix.project }}/
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
@@ -134,7 +134,7 @@ jobs:
           path: ${{ matrix.project }}
 
       - name: Copy Shipyard resources
-        run: cp -n Dockerfile.* Makefile.dapper ${{ matrix.project }}/
+        run: cp -n Dockerfile.* Makefile.dapper .dapper ${{ matrix.project }}/
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
         run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /vendor
-.dapper
 .idea
 .shflags
 /bin

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -1,7 +1,5 @@
 # This Makefile contains the rules required to set up our
-# Dapper-based build environment; it can be copied as-is to
-# other projects (and needs to be copied, it can't be shared
-# via the Dapper image since it's needed to retrieve the image)
+# Dapper-based build environment
 
 PROJECT ?= $(notdir $(CURDIR))
 BASE_DAPPER := Dockerfile.dapper
@@ -13,19 +11,18 @@ export PROJECT
 
 .dapper:
 	@echo Downloading dapper
-	@curl -sL https://releases.rancher.com/dapper/latest/dapper-`uname -s`-`uname -m` > .dapper.tmp
-	@@chmod +x .dapper.tmp
-	@./.dapper.tmp -v
-	@mv .dapper.tmp .dapper
+	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/$(BASE_BRANCH)/$@
+	@chmod +x .dapper
+	@./.dapper -v
 
 SELINUX_CONTEXT := $(shell (selinuxenabled && echo -S z) 2>/dev/null)
-RUN_IN_DAPPER := ./.dapper -m bind $(SELINUX_CONTEXT)
+RUN_IN_DAPPER := ./.dapper $(DAPPER_ARGS) $(SELINUX_CONTEXT)
 
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
 $(filter-out .dapper prune-images shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper $(BASE_DAPPER)
 	-docker network create -d bridge kind
-	+$(RUN_IN_DAPPER) make --debug=b $@
+	+$(RUN_IN_DAPPER) -- make --debug=b $@
 
 # The original dockerfiles will live in Shipyard and be downloaded by consuming projects.
 $(BASE_DAPPER) $(LINTING_DAPPER):
@@ -34,7 +31,7 @@ $(BASE_DAPPER) $(LINTING_DAPPER):
 
 # Run silently as the commands are pretty straightforward and `make` hasn't a lot to do
 $(LINTING_GOALS): .dapper $(LINTING_DAPPER)
-	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -q make $@
+	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -- make $@
 
 # [prune-images] removes all Submariner-provided images and all untagged images
 # Use this to ensure you use current images
@@ -55,6 +52,6 @@ shell: .dapper $(BASE_DAPPER)
 # Run silently to just list the targets (hence we can't use the generic dapper wrapper recipe).
 # This only lists targets accessible inside dapper (which are 99% of targets we use)
 targets: $(LINTING_DAPPER)
-	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -q eval "\$${SCRIPTS_DIR}/targets.sh"
+	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -- eval "\$${SCRIPTS_DIR}/targets.sh"
 
 .PHONY: prune-images shell targets $(LINTING_GOALS)


### PR DESCRIPTION
This provides all the features we actually use from Dapper, and will
allow support for Podman (with other changes in the images).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
