### PR TITLE
Provide package descriptions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -76,6 +76,15 @@ jobs:
       - name: Run markdownlint
         run: make markdownlint
 
+  packagedoc-lint:
+    name: Package Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Run packagedoc-lint
+        run: make packagedoc-lint
+
   shellcheck:
     name: Shell
     runs-on: ubuntu-latest

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -123,6 +123,17 @@ golangci-lint: vendor/modules.txt
 	golangci-lint linters
 	golangci-lint run --timeout 10m
 
+# [packagedoc-lint] checks that the package docs don’t include the SPDX header
+packagedoc-lint:
+	result=0; \
+	for package in $$(find . -name vendor -prune -o -name \*.go -printf "%h\n" | sort -u); do \
+		if go doc $$package | grep -q SPDX; then \
+			echo $$package has an invalid package documentation; \
+			result=1; \
+		fi; \
+	done 2>/dev/null; \
+	exit $$result
+
 lint: gitlint golangci-lint markdownlint yamllint
 
 # [markdownlint] validates Markdown files in the project

--- a/test/e2e/dataplane/tcp_connectivity.go
+++ b/test/e2e/dataplane/tcp_connectivity.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package dataplane runs the TCP/IP connectivity test.
 package dataplane
 
 import (

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package e2e
 
 import (

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package example contains example tests demonstrating the use of the test framework.
 package example
 
 import (

--- a/test/e2e/framework/api_errors.go
+++ b/test/e2e/framework/api_errors.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import "sync"

--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/doc.go
+++ b/test/e2e/framework/doc.go
@@ -16,12 +16,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-import "fmt"
-
-var MYVAR = "nobody"
-
-func main() {
-	fmt.Println("hello " + MYVAR)
-}
+// Package framework contains the shared test framework for Submariner projects.
+package framework

--- a/test/e2e/framework/exec.go
+++ b/test/e2e/framework/exec.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/ginkgo_framework.go
+++ b/test/e2e/framework/ginkgo_framework.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import "github.com/onsi/ginkgo"

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/logging.go
+++ b/test/e2e/framework/logging.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (
@@ -348,7 +349,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 						{Name: "TARGET_PORT", Value: strconv.Itoa(np.Config.Port)},
 						{Name: "CONN_TRIES", Value: strconv.Itoa(int(np.Config.ConnectionAttempts))},
 						{Name: "RETRY_SLEEP", Value: strconv.Itoa(int(np.Config.ConnectionTimeout))},
-						{Name: "CONN_TIMEOUT", Value: strconv.Itoa(int(np.Config.ConnectionTimeout*1000))},
+						{Name: "CONN_TIMEOUT", Value: strconv.Itoa(int(np.Config.ConnectionTimeout * 1000))},
 					},
 				},
 			},
@@ -476,9 +477,9 @@ func (np *NetworkPod) buildCustomPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
-			HostNetwork:   bool(np.Config.Networking),
+			Affinity:                      nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                 v1.RestartPolicyNever,
+			HostNetwork:                   bool(np.Config.Networking),
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
 			Containers: []v1.Container{
 				{

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/service_exports.go
+++ b/test/e2e/framework/service_exports.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -15,6 +15,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package framework
 
 import (

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -15,6 +15,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
+// Package tcp implements a TCP/IP connectivity test.
 package tcp
 
 import (


### PR DESCRIPTION
Currently, our package descriptions are our license headers, because
the header blocks aren’t separated from the package declarations.
This patch separates them, adds short package description, and adds a
GHA to check that the SPDX header isn’t shown in the package
description.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
