### PR TITLE
Add GlobalPodIP to EndpointType

### DIFF
--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -33,7 +33,10 @@ type EndpointType int
 const (
 	PodIP EndpointType = iota
 	ServiceIP
+	// TODO: Remove GlobalIP once all consumer code switches to GlobalServiceIP
 	GlobalIP
+	GlobalPodIP
+	GlobalServiceIP = GlobalIP
 )
 
 type ConnectivityTestParams struct {
@@ -66,7 +69,7 @@ func RunConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fram
 	Expect(connectorPod.TerminationMessage).To(ContainSubstring(listenerPod.Config.Data))
 
 	if p.Networking == framework.PodNetworking {
-		if p.ToEndpointType == GlobalIP {
+		if p.ToEndpointType == GlobalServiceIP {
 			// When Globalnet is enabled (i.e., remoteEndpoint is a globalIP) and POD uses PodNetworking,
 			// Globalnet Controller MASQUERADEs the source-ip of the POD to the corresponding global-ip
 			// that is assigned to the POD.
@@ -74,7 +77,7 @@ func RunConnectivityTest(p ConnectivityTestParams) (*framework.NetworkPod, *fram
 			podGlobalIP := connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
 			Expect(podGlobalIP).ToNot(Equal(""))
 			Expect(listenerPod.TerminationMessage).To(ContainSubstring(podGlobalIP))
-		} else if p.ToEndpointType != GlobalIP {
+		} else if p.ToEndpointType != GlobalServiceIP {
 			By("Verifying the output of listener pod which must contain the source IP")
 			Expect(listenerPod.TerminationMessage).To(ContainSubstring(connectorPod.Pod.Status.PodIP))
 		}
@@ -128,12 +131,12 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 
 	remoteIP := listenerPod.Pod.Status.PodIP
 	var service *v1.Service
-	if p.ToEndpointType == ServiceIP || p.ToEndpointType == GlobalIP {
+	if p.ToEndpointType == ServiceIP || p.ToEndpointType == GlobalServiceIP {
 		By(fmt.Sprintf("Pointing a service ClusterIP to the listener pod in cluster %q", framework.TestContext.ClusterIDs[p.ToCluster]))
 		service = listenerPod.CreateService()
 		remoteIP = service.Spec.ClusterIP
 
-		if p.ToEndpointType == GlobalIP {
+		if p.ToEndpointType == GlobalServiceIP {
 			p.Framework.CreateServiceExport(p.ToCluster, service.Name)
 			// Wait for the globalIP annotation on the service.
 			service = p.Framework.AwaitUntilAnnotationOnService(p.ToCluster, globalnetGlobalIPAnnotation, service.Name, service.Namespace)
@@ -154,7 +157,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		Networking:         p.Networking,
 	})
 
-	if p.ToEndpointType == GlobalIP && p.Networking == framework.PodNetworking {
+	if p.ToEndpointType == GlobalServiceIP && p.Networking == framework.PodNetworking {
 		// Wait for the globalIP annotation on the connectorPod.
 		connectorPod.Pod = p.Framework.AwaitUntilAnnotationOnPod(p.FromCluster, globalnetGlobalIPAnnotation, connectorPod.Pod.Name, connectorPod.Pod.Namespace)
 		sourceIP := connectorPod.Pod.GetAnnotations()[globalnetGlobalIPAnnotation]
@@ -178,7 +181,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	// Globalnet removes the reference only when the service itself is deleted. Until Globalnet is enhanced [*]
 	// to remove this dependency with iptables-chain, lets delete the service after the listener Pod is terminated.
 	// [*] https://github.com/submariner-io/submariner/issues/1166
-	if p.ToEndpointType == GlobalIP {
+	if p.ToEndpointType == GlobalServiceIP {
 		p.Framework.DeleteService(p.ToCluster, service.Name)
 		p.Framework.DeleteServiceExport(p.ToCluster, service.Name)
 	}


### PR DESCRIPTION
With support for Headless services in Globalnetv2,
we need to distinguish between GlobalIP for Service
and Pod in EndpointType to allow different E2E test
cases.

* Add `GlobalPodIP`
* Add `GlobalServiceIP = GlobalIP`
* Replace all references to `GlobalIP` with `GlobalServiceIP`

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
