### PR TITLE
Add service methods for headless service e2e

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -28,12 +28,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// AwaitPodsByAppLabel finds pods in a given cluster whose 'app' label value matches a specified value. If the specified
+// AwaitPodsByLabelSelector finds pods in a given cluster whose labels match a specified label selector. If the specified
 // expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
-func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, namespace string, expectedCount int) *v1.PodList {
-	return AwaitUntil("find pods for app "+appName, func() (interface{}, error) {
+func (f *Framework) AwaitPodsByLabelSelector(cluster ClusterIndex, labelSelector string, namespace string, expectedCount int) *v1.PodList {
+	return AwaitUntil("find pods for label "+labelSelector, func() (interface{}, error) {
 		return KubeClients[cluster].CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "app=" + appName,
+			LabelSelector: labelSelector,
 		})
 	}, func(result interface{}) (bool, string, error) {
 		pods := result.(*v1.PodList)
@@ -49,6 +49,12 @@ func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, na
 
 		return true, "", nil
 	}).(*v1.PodList)
+}
+
+// AwaitPodsByAppLabel finds pods in a given cluster whose 'app' label value matches a specified value. If the specified
+// expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
+func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName string, namespace string, expectedCount int) *v1.PodList {
+	return f.AwaitPodsByLabelSelector(cluster, "app=" + appName, namespace, expectedCount)
 }
 
 // AwaitSubmarinerGatewayPod finds the submariner gateway pod in a given cluster, waiting if necessary for a period of time

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,27 +34,48 @@ const (
 	TestAppLabel = "test-app"
 )
 
-func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, port int) *corev1.Service {
-	tcpService := corev1.Service{
+func (f *Framework) NewService(name, portName string, port int, protocol corev1.Protocol, selector map[string]string,
+		isHeadless bool) *corev1.Service {
+	service := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("test-svc-%s", selectorName),
+			Name: name,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{{
 				Port:       int32(port),
-				Name:       "tcp",
+				Name:       portName,
 				TargetPort: intstr.FromInt(port),
-				Protocol:   corev1.ProtocolTCP,
+				Protocol:   protocol,
 			}},
-			Selector: map[string]string{
-				TestAppLabel: selectorName,
-			},
 		},
 	}
 
+	if selector != nil {
+		service.Spec.Selector = selector
+	}
+
+	if isHeadless {
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		service.Spec.ClusterIP = corev1.ClusterIPNone
+	}
+
+	return &service
+}
+
+func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, port int) *corev1.Service {
+	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
+		map[string]string{TestAppLabel:selectorName}, false)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return createService(sc, &tcpService)
+	return f.CreateService(sc, tcpService)
+}
+
+func (f *Framework) CreateHeadlessTCPService(cluster ClusterIndex, selectorName string, port int) *corev1.Service {
+	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
+		map[string]string{TestAppLabel:selectorName}, true)
+	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
+
+	return f.CreateService(sc, tcpService)
 }
 
 func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
@@ -98,30 +118,17 @@ func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
 
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return createService(sc, &nginxService)
+	return f.CreateService(sc, &nginxService)
 }
 
 func (f *Framework) CreateTCPServiceWithoutSelector(cluster ClusterIndex, svcName, portName string, port int) *corev1.Service {
-	serviceSpec := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: svcName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
-				Port:       int32(port),
-				Name:       portName,
-				TargetPort: intstr.FromInt(port),
-				Protocol:   corev1.ProtocolTCP,
-			}},
-		},
-	}
-
+	serviceSpec := f.NewService(svcName, portName, port, corev1.ProtocolTCP, nil, false)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return createService(sc, &serviceSpec)
+	return f.CreateService(sc, serviceSpec)
 }
 
-func createService(sc typedv1.ServiceInterface, serviceSpec *corev1.Service) *corev1.Service {
+func (f *Framework) CreateService(sc typedv1.ServiceInterface, serviceSpec *corev1.Service) *corev1.Service {
 	return AwaitUntil("create service", func() (interface{}, error) {
 		service, err := sc.Create(context.TODO(), serviceSpec, metav1.CreateOptions{})
 		if errors.IsAlreadyExists(err) {
@@ -145,7 +152,7 @@ func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
 }
 
 // AwaitUntilAnnotationOnService queries the service and looks for the presence of annotation.
-func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation string, svcName string, namespace string) *v1.Service {
+func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation string, svcName string, namespace string) *corev1.Service {
 	return AwaitUntil("get"+annotation+" annotation for service "+svcName, func() (interface{}, error) {
 		service, err := KubeClients[cluster].CoreV1().Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -157,7 +164,7 @@ func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotati
 			return false, "No Service found", nil
 		}
 
-		service := result.(*v1.Service)
+		service := result.(*corev1.Service)
 		if service.GetAnnotations()[annotation] == "" {
 			return false, fmt.Sprintf("Service %q does not have annotation %q yet", svcName, annotation), nil
 		}


### PR DESCRIPTION
* Add methods to create HeadlessService
* Refactor some existing methods for reusability
* Add AwaitPodsByLabelSelector

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
