### PR TITLE
Add GlobalEgressIP create, retrieve methods

### DIFF
--- a/test/e2e/framework/globalegressip.go
+++ b/test/e2e/framework/globalegressip.go
@@ -1,0 +1,59 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var globalEgressIPGVR = &schema.GroupVersionResource{
+	Group:    "submariner.io",
+	Version:  "v1",
+	Resource: "globalegressips",
+}
+
+func globalEgressIPClient(cluster ClusterIndex, namespace string) dynamic.ResourceInterface {
+	return DynClients[cluster].Resource(*globalEgressIPGVR).Namespace(namespace)
+}
+
+func CreateGlobalEgressIP(cluster ClusterIndex, obj *unstructured.Unstructured) error {
+	geipClient := globalEgressIPClient(cluster, obj.GetNamespace())
+	AwaitUntil("create GlobalEgressIP", func() (interface{}, error) {
+		egressIP, err := geipClient.Create(context.TODO(), obj, metav1.CreateOptions{})
+		if apierrors.IsAlreadyExists(err) {
+			err = nil
+		}
+
+		return egressIP, err
+	}, NoopCheckResult)
+
+	return nil
+}
+
+func AwaitGlobalEgressIPs(cluster ClusterIndex, name, namespace string) []string {
+	gipClient := globalEgressIPClient(cluster, namespace)
+
+	return AwaitAllocatedEgressIPs(gipClient, name)
+}


### PR DESCRIPTION
This PR includes methods in the e2e framework to create and read the
GlobalEgressIP objects which can be used in e2e tests.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
