### PR TITLE
0.9 backport: Bump to kind 0.11.1 to support k8s v1.20

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -52,7 +52,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.39.0 \
     HELM_VERSION=v3.4.1 \
-    KIND_VERSION=v0.10.0 \
+    KIND_VERSION=v0.11.1 \
     BUILDX_VERSION=v0.5.1
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions


### PR DESCRIPTION
This will fix the e2e failures in 0.9

(cherry picked from commit 6b7087e0cdea2af5f8104ca7aa02ad1a2f886c93)

Closes #607

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
