### PR TITLE
Make sure consuming jobs use correct branch

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@v2
         with:
+          # This is replaced to stable branch by auto release process
+          ref: devel
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 
@@ -91,6 +93,8 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@v2
         with:
+          # This is replaced to stable branch by auto release process
+          ref: devel
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 
@@ -124,6 +128,8 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@v2
         with:
+          # This is replaced to stable branch by auto release process
+          ref: devel
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 


### PR DESCRIPTION
Without specifying the branch, checkout action checks out the default
GitHub branch.

Specifying the branch explicitly allows auto release procedure to set
the branch correctly when a stable branch is cut.

Related to: #611 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
