### PR TITLE
Install subctl as part of post_mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -62,6 +62,7 @@ function post_analyze() {
 ### Main ###
 
 declare_kubeconfig
+bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash"
 for cluster in $(kind get clusters); do
     post_analyze
 done


### PR DESCRIPTION
Currently, in CI when any error happens, post_mortem is unable to collect
certain logs due to missing subctl binary. This PR includes it.

Fixes issue: https://github.com/submariner-io/shipyard/issues/621
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
