### PR TITLE
When deploying subctl, fall back to devel

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -48,7 +48,8 @@ declare_cidrs
 declare_kubeconfig
 
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
-bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash"
+bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash" ||
+bash -c "curl -Ls https://get.submariner.io | VERSION=devel DESTDIR=/go/bin bash"
 
 load_deploytool $deploytool
 deploytool_prereqs


### PR DESCRIPTION
During releases from branches, the e2e jobs look for a subctl matching
the target release; but that doesn't exist yet, so the download fails.
To avoid that, if installing the target release version fails, fall
back to devel subctl (which should provide the behaviour we need for a
release, and is more appropriate than the default, which is the latest
release).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
