### PR TITLE
Fix yamllint strict config, fail on warnings

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -12,5 +12,3 @@ ignore: |
   /vendor
   /scripts/shared/resources/cluster*-config.yaml
   /scripts/shared/resources/prometheus/bundle.yaml
-
-strict: true

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -146,7 +146,7 @@ markdownlint:
 
 # [yamllint] validates YAML files in the project
 yamllint:
-	yamllint .
+	yamllint --strict .
 
 # [post-mortem] prints a heap of information, to help in debugging failures on the KIND clusters
 post-mortem:


### PR DESCRIPTION
Setting yamllint to exit non-zero on warnings doesn't work from the
.yamllint config file. Set the --strict flag at CLI invocation.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
