### PR TITLE
Implement .mdignore for ignoring Markdown files

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -142,7 +142,11 @@ lint: gitlint golangci-lint markdownlint yamllint
 
 # [markdownlint] validates Markdown files in the project
 markdownlint:
-	markdownlint markdownlint -c .markdownlint.yml -i vendor .
+	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
+	if [ -r .mdignore ]; then \
+		md_ignored+=($$(< .mdignore)); \
+	fi; \
+	markdownlint -c .markdownlint.yml $${md_ignored[@]/#/-i } .
 
 # [yamllint] validates YAML files in the project
 yamllint:


### PR DESCRIPTION
Add logic to read Markdown files to ignore when running markdownlint
from an .mdignore file in the root of each repo. This allows
configuration of the linter close to the source, and config to be
adjusted per-repo.

The submariner-operator repo has an apis/vendor directory that contains
external repos with markdown files. They should not be linted, and are
causing the Consuming Projects/Lint (submariner-operator) CI to fail.

Go mod vendoring directories are ignored by default.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
