### PR TITLE
Run unit tests in multiple modules

### DIFF
--- a/scripts/shared/lib/find_functions
+++ b/scripts/shared/lib/find_functions
@@ -1,5 +1,5 @@
 # shellcheck shell=bash
-function _find_pkg_dirs() {
+function _build_find_exclude() {
     local find_exclude
     excluded_dirs+=" vendor .git .trash-cache bin"
 
@@ -7,8 +7,17 @@ function _find_pkg_dirs() {
         find_exclude+=" -path ./$dir -prune -o"
     done
 
-    # shellcheck disable=SC2086
-    find . ${find_exclude} -path "$1" -printf "%h\n" | sort -u
+    echo "${find_exclude}"
+}
+
+function _find_pkg_dirs() {
+    # shellcheck disable=SC2046
+    find . $(_build_find_exclude) -path "$1" -printf "%h\n" | sort -u
+}
+
+function find_modules() {
+    # shellcheck disable=SC2046
+    find . $(_build_find_exclude) -name go.mod -printf "%h\n" | sort -u
 }
 
 function find_unit_test_dirs() {

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -7,8 +7,27 @@ source ${SCRIPTS_DIR}/lib/find_functions
 
 echo "Looking for packages to test"
 
-packages="$(find_unit_test_dirs "$@")"
+modules=($(find_modules))
 
-echo "Running tests in ${packages}"
-[ "${ARCH}" == "amd64" ] && race=-race
-${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml
+result=0
+
+for module in "${modules[@]}"; do
+    printf "Looking for tests in module %s\n" ${module}
+
+    excluded_modules=""
+    for exc_module in "${modules[@]}"; do
+	if [ "$exc_module" != "$module" -a "$exc_module" != "." ]; then
+	    excluded_modules+=" ${exc_module:2}"
+	fi
+    done
+
+    packages="$(cd $module; find_unit_test_dirs "$excluded_modules" "$@" | tr '\n' ' ')"
+
+    if [ -n "${packages}" ]; then
+	echo "Running tests in ${packages}"
+	[ "${ARCH}" == "amd64" ] && race=-race
+	(cd $module && ${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml) || result=1
+    fi
+done
+
+exit $result


### PR DESCRIPTION
In repositories with multiple modules, tests must be run in each
module separately, excluding any packages which are in a
“sub-module”.

This fixes unit_test.sh to look for modules, and run the tests in each
module. If tests fail, subsequent modules will still be tested, but
the overall result will reflect the failure.

Fixes: #626
Depends on #634
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
