### PR TITLE
Handle vendoring in multiple Go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ deploy: nettest
 
 nettest: package/.image.nettest
 
-e2e: vendor/modules.txt clusters
+e2e: $(VENDOR_MODULES) clusters
 
 else
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -122,8 +122,11 @@ gitlint:
 	    gitlint --config $(SHIPYARD_DIR)/.gitlint --commits origin/$(BASE_BRANCH)..HEAD; \
 	fi
 
+# List of vendor/modules.txt files we need
+VENDOR_MODULES := $(shell find . -name vendor -prune -o -name go.mod -printf "%h/vendor/modules.txt\n")
+
 # [golangci-lint] validates Go code in the project
-golangci-lint: vendor/modules.txt
+golangci-lint: $(VENDOR_MODULES)
 	golangci-lint linters
 	golangci-lint run --timeout 10m
 
@@ -157,16 +160,19 @@ shellcheck:
 	shellcheck $(SHELLCHECK_ARGS)
 
 # [unit] executes the Go unit tests of the project
-unit: vendor/modules.txt
+unit: $(VENDOR_MODULES)
 	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
 
-ifeq (go.mod,$(wildcard go.mod))
-# If go.mod exists (as determined above), assume we're vendoring
 vendor/modules.txt: go.mod
 	go mod download
 	go mod vendor
 	go mod tidy
-endif
+
+%/vendor/modules.txt: %/go.mod
+	cd $(patsubst %/vendor/,%,$(dir $@)) && \
+	go mod download && \
+	go mod vendor && \
+	go mod tidy
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners


### PR DESCRIPTION
Instead of depending explicitly on vendor/modules.txt, determine where
we need to handle Go modules; there can be multiple directories.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
