### PR TITLE
Allow specifying the Go implementation to use

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -70,6 +70,9 @@ override DEPLOY_ARGS += --plugin $(PLUGIN)
 override CLEANUP_ARGS += --plugin $(PLUGIN)
 endif
 
+GO ?= go
+export GO
+
 # Shipyard provided targets
 
 # [clean] cleans everything (running clusters, generated files ...)
@@ -134,7 +137,7 @@ golangci-lint: $(VENDOR_MODULES)
 packagedoc-lint:
 	result=0; \
 	for package in $$(find . -name vendor -prune -o -name \*.go -printf "%h\n" | sort -u); do \
-		if go doc $$package | grep -q SPDX; then \
+		if $(GO) doc $$package | grep -q SPDX; then \
 			echo $$package has an invalid package documentation; \
 			result=1; \
 		fi; \
@@ -164,15 +167,15 @@ unit: $(VENDOR_MODULES)
 	$(SCRIPTS_DIR)/unit_test.sh $(UNIT_TEST_ARGS)
 
 vendor/modules.txt: go.mod
-	go mod download
-	go mod vendor
-	go mod tidy
+	$(GO) mod download
+	$(GO) mod vendor
+	$(GO) mod tidy
 
 %/vendor/modules.txt: %/go.mod
 	cd $(patsubst %/vendor/,%,$(dir $@)) && \
-	go mod download && \
-	go mod vendor && \
-	go mod tidy
+	$(GO) mod download && \
+	$(GO) mod vendor && \
+	$(GO) mod tidy
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners

--- a/scripts/shared/compile.sh
+++ b/scripts/shared/compile.sh
@@ -34,6 +34,6 @@ if [ "$build_debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"
 fi
 
-CGO_ENABLED=0 go build -trimpath -ldflags "${ldflags}" -o $binary $source_file
+CGO_ENABLED=0 ${GO:-go} build -trimpath -ldflags "${ldflags}" -o $binary $source_file
 [[ "$build_upx" = "false" ]] || [[ "$build_debug" = "true" ]] || upx $binary
 

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -69,7 +69,7 @@ function generate_kubecontexts() {
 function test_with_e2e_tests {
     cd ${DAPPER_SOURCE}/${FLAGS_testdir}
 
-    go test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace\
+    ${GO:-go} test -v -timeout 30m -args -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace\
         -submariner-namespace $SUBM_NS $(generate_context_flags) ${globalnet} \
         -ginkgo.reportPassed -test.timeout 15m \
         "${ginkgo_args[@]}" \

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -11,4 +11,4 @@ packages="$(find_unit_test_dirs "$@")"
 
 echo "Running tests in ${packages}"
 [ "${ARCH}" == "amd64" ] && race=-race
-go test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml
+${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml


### PR DESCRIPTION
The default continues to be "go", but users can override that by
setting the GO variable:

        make GO=go1.16 ...

would use "go1.16" instead.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
