### PR TITLE
Automated cherry pick of #632: Revert to a r/w version of dependent-issues
#623: When deploying subctl, fall back to devel

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -24,7 +24,7 @@ jobs:
     name: Check Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: z0al/dependent-issues@v1
+      - uses: z0al/dependent-issues@1208b4dd978973b14de5b0b227a2871dbbf34ffb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Cherry pick of #632 #623 on release-0.10.

#632: Revert to a r/w version of dependent-issues
#623: When deploying subctl, fall back to devel

For details on the cherry pick process, see the [cherry pick requests](https://submariner.io/development/backports/) page.