### PR TITLE
Clean buildx builders

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -76,7 +76,7 @@ export GO
 # Shipyard provided targets
 
 # [clean] cleans everything (running clusters, generated files ...)
-clean: clean-clusters clean-generated
+clean: clean-clusters clean-generated clean-buildx
 
 # [clean-generated] removes files we generated
 clean-generated:
@@ -86,6 +86,12 @@ clean-generated:
 clean-clusters:
 	$(SCRIPTS_DIR)/cleanup.sh $(CLEANUP_ARGS)
 cleanup: clean-clusters
+
+# [clean-buildx] removes the buildx builder, if any
+clean-buildx:
+	docker buildx version > /dev/null 2>&1 && \
+	docker buildx use buildx_builder > /dev/null 2>&1 && \
+	docker buildx rm
 
 # [clusters] creates KIND clusters that can then be used to deploy Submariner
 clusters:


### PR DESCRIPTION
If we've created a buildx builder, make sure we delete it in "make
clean".

Fixes: #608
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
