### PR TITLE
Avoid deploying Lighthouse when not requested

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -24,7 +24,11 @@ function setup_broker() {
     local gn
     local sd
     [[ $globalnet != true ]] || gn="--globalnet"
-    [[ $service_discovery != true ]] || sd="--components service-discovery,connectivity"
+    if [[ $service_discovery != true ]]; then
+        sd="--components service-discovery,connectivity"
+    else
+        sd="--components connectivity"
+    fi
     echo "Installing broker..."
 
     # We use the "subctl" image_tag to indicate that we want to let


### PR DESCRIPTION
Explicitly pass only the connectivity flag to subctl when service
discovery is not requested. This will override the subctl default of
always deploying service discovery, allowing negative config from
Make commands (like `make deploy`) to be honored.

Closes: submariner-io/submariner#1550
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
