### PR TITLE
Automated backport of #630: Use SHAs for GHA versions
#631: Implement .mdignore for ignoring Markdown files

### DIFF
--- a/.github/workflows/clean-tests.yml
+++ b/.github/workflows/clean-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Deploy clusters
         env:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Build images
         run: make images

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Delete current CODEOWNERS file
         run: rm CODEOWNERS
       - name: Run gen-codeowners to rebuild CODEOWNERS file

--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -42,13 +42,13 @@ jobs:
             k8s_version: '1.20'
     steps:
       - name: Check out the Shipyard repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Build the latest Shipyard image
         run: make images
 
       - name: Check out the ${{ matrix.project }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # This is replaced to stable branch by auto release process
           ref: release-0.10
@@ -85,13 +85,13 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
     steps:
       - name: Check out the Shipyard repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Build the latest Shipyard image
         run: make images
 
       - name: Check out the ${{ matrix.project }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # This is replaced to stable branch by auto release process
           ref: release-0.10
@@ -120,13 +120,13 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
     steps:
       - name: Check out the Shipyard repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Build the latest Shipyard image
         run: make images
 
       - name: Check out the ${{ matrix.project }} repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           # This is replaced to stable branch by auto release process
           ref: release-0.10

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,24 +11,35 @@ jobs:
     steps:
       - name: Get PR commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.1.0
+        uses: tim-actions/get-pr-commits@55b867b9b28954e6f5c1a0fe2f729dc926c306d0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Verify no "Apply suggestions from code review" commits'
-        uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}
           pattern: '^(?!.*(apply suggestions from code review))'
           flags: 'i'
           error: 'Commits addressing code review feedback should typically be squashed into the commits under review'
 
+  commit-size:
+    name: Commit Size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Make sure each commit in the PR is within reviewable size
+        uses: ./gh-actions/commit-size
+        with:
+          size: 200
+
   gitlint:
     name: Commit Message(s)
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           fetch-depth: 0
       - name: Run gitlint
@@ -39,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run golangci-lint
         run: make golangci-lint
 
@@ -48,20 +59,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Check License Headers
-        uses: kt3k/license_checker@v1.0.6
+        uses: kt3k/license_checker@d12a6d90c58e30fefed09f2c4d03ba57f4c673a8
 
   markdown-link-check:
     name: Markdown Links (modified files)
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
         with:
           config-file: ".markdownlinkcheck.json"
           check-modified-files-only: "yes"
@@ -72,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run markdownlint
         run: make markdownlint
 
@@ -81,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run packagedoc-lint
         run: make packagedoc-lint
 
@@ -90,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run shellcheck
         run: make shellcheck
 
@@ -99,6 +110,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Run yamllint
         run: make yamllint

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Run markdown-link-check
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
         with:
           config-file: ".markdownlinkcheck.json"
 
       - name: Raise an Issue to report broken links
         if: ${{ failure() }}
-        uses: peter-evans/create-issue-from-file@v2.3.2
+        uses: peter-evans/create-issue-from-file@a04ce672e3acedb1f8e416b46716ddfd09905326
         with:
           title: Broken link detected by CI
           content-filepath: .github/ISSUE_TEMPLATE/broken-link.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           submodules: true
 

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Deploy clusters
         env:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Test the compile.sh script
         run: make script-test SCRIPT_TEST_ARGS="test/scripts/compile/test.sh"
@@ -58,7 +58,7 @@ jobs:
         run: rm -rf /usr/share/dotnet
 
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           submodules: true
 
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Run E2E deployment and tests
         run: make e2e
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Deploy some clusters
         run: make clusters

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -12,7 +12,8 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Install an old cluster, upgrade it and check it
         uses: ./gh-actions/upgrade-e2e

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -142,7 +142,11 @@ lint: gitlint golangci-lint markdownlint yamllint
 
 # [markdownlint] validates Markdown files in the project
 markdownlint:
-	markdownlint markdownlint -c .markdownlint.yml -i vendor .
+	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
+	if [ -r .mdignore ]; then \
+		md_ignored+=($$(< .mdignore)); \
+	fi; \
+	markdownlint -c .markdownlint.yml $${md_ignored[@]/#/-i } .
 
 # [yamllint] validates YAML files in the project
 yamllint:


### PR DESCRIPTION
Backport of #630 #631 on release-0.10.

#630: Use SHAs for GHA versions
#631: Implement .mdignore for ignoring Markdown files

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.