### PR TITLE
Automated backport of #631: Implement .mdignore for ignoring Markdown files

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -142,7 +142,11 @@ lint: gitlint golangci-lint markdownlint yamllint
 
 # [markdownlint] validates Markdown files in the project
 markdownlint:
-	markdownlint markdownlint -c .markdownlint.yml -i vendor .
+	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
+	if [ -r .mdignore ]; then \
+		md_ignored+=($$(< .mdignore)); \
+	fi; \
+	markdownlint -c .markdownlint.yml $${md_ignored[@]/#/-i } .
 
 # [yamllint] validates YAML files in the project
 yamllint:


### PR DESCRIPTION
Backport of #631 on release-0.10.

#631: Implement .mdignore for ignoring Markdown files

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.