### PR TITLE
fix(bundle): match the submariner values to the verify script

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -45,6 +45,7 @@ source "${SCRIPTS_DIR}/lib/cluster_settings"
 ### Constants ###
 readonly CE_IPSEC_IKEPORT=500
 readonly CE_IPSEC_NATTPORT=4500
+readonly SUBM_COLORCODES=blue
 readonly SUBM_IMAGE_REPO=localhost:5000
 readonly SUBM_IMAGE_TAG=${image_tag:-local}
 readonly BROKER_NAMESPACE="submariner-k8s-broker"

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -4,7 +4,6 @@
 
 ### Constants ###
 
-readonly SUBM_COLORCODES=blue
 # shellcheck disable=SC2034 # this variable is used elsewhere
 # Some projects rely on the default subctl being determined by the PATH
 readonly SUBCTL=${SUBCTL:-subctl}

--- a/scripts/shared/resources/bundle/submariner.yaml
+++ b/scripts/shared/resources/bundle/submariner.yaml
@@ -9,8 +9,9 @@ spec:
   clusterCIDR: "${cluster_CIDRs[$cluster]}"
   globalCIDR: "${global_CIDRs[$cluster]}"
   clusterID: "${cluster}"
-  debug: true
-  natEnabled: true
+  colorCodes: "${SUBM_COLORCODES}"
+  debug: false
+  natEnabled: false
   serviceDiscoveryEnabled: ${service_discovery}
   broker: "k8s"
   brokerK8sApiServer: "${BROKER_K8S_API_SERVER}"
@@ -19,7 +20,7 @@ spec:
   brokerK8sCA: "${BROKER_K8S_CA}"
   cableDriver: "libreswan"
   ceIPSecPSK: "${IPSEC_PSK}"
-  ceIPSecDebug: true
+  ceIPSecDebug: false
   ceIPSecIKEPort: ${CE_IPSEC_IKEPORT}
   ceIPSecNATTPort: ${CE_IPSEC_NATTPORT}
   namespace: "${SUBM_NS}"


### PR DESCRIPTION
The periodic test fails because the `lib_operator_verify_subm.sh` script expects specific values.
 
Signed-off-by: Steve Mattar <smattar@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
