### PR TITLE
Treat `null` as empty in settings

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -164,7 +164,9 @@ EOM
 }
 
 function _yq() {
-    yq e "$*" "${settings}"
+    local output
+    output=$(yq e "$*" "${settings}")
+    [[ "${output}" == "null" ]] || echo "${output}"
 }
 
 function load_settings_from_yaml() {
@@ -181,6 +183,6 @@ function load_settings_from_yaml() {
         cluster_cni["${cluster}"]=$(_yq ".clusters.${cluster}.cni // .cni")
         cluster_nodes["${cluster}"]=$(_yq ".clusters.${cluster}.nodes // .nodes")
         cluster_subm["${cluster}"]=$(_yq ".clusters.${cluster}.submariner")
-        [[ "${cluster_subm[${cluster}]}" != "null" ]] || cluster_subm["${cluster}"]=$(_yq ".submariner")
+        cluster_subm["${cluster}"]=$(_yq ".submariner")
     done
 }


### PR DESCRIPTION
YQ reads unset/null fields as `null` but we already expect them to be
empty, so treat any unset or null field in YAML settings as empty.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
