### PR TITLE
Remove settings flag from E2E arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 override CLUSTERS_ARGS += $(CLUSTER_SETTINGS_FLAG)
 override DEPLOY_ARGS += $(CLUSTER_SETTINGS_FLAG)
-override E2E_ARGS += $(CLUSTER_SETTINGS_FLAG) --nolazy_deploy cluster1
+override E2E_ARGS += --nolazy_deploy cluster1
 
 # Prevent rebuilding images inside dapper since thy're already built outside it in Shipyard's case
 package/.image.nettest package/.image.shipyard-dapper-base: ;

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -3,8 +3,6 @@
 ## Process command line flags ##
 
 source ${SCRIPTS_DIR}/lib/shflags
-DEFINE_string 'cluster_settings' '' "Settings file to customize cluster deployments (deprecated, use settings instead)"
-DEFINE_string 'settings' '' "Settings YAML file to customize cluster deployments"
 DEFINE_string 'focus' '' "Ginkgo focus for the E2E tests"
 DEFINE_string 'skip' '' "Ginkgo skip for the E2E tests"
 DEFINE_string 'testdir' 'test/e2e' "Directory under to be used for E2E testing"
@@ -18,8 +16,6 @@ eval set -- "${FLAGS_ARGV}"
 ginkgo_args=()
 [[ -n "${FLAGS_focus}" ]] && ginkgo_args+=("-ginkgo.focus=${FLAGS_focus}")
 [[ -n "${FLAGS_skip}" ]] && ginkgo_args+=("-ginkgo.skip=${FLAGS_skip}")
-cluster_settings="${FLAGS_cluster_settings}"
-settings="${FLAGS_settings}"
 [[ "${FLAGS_lazy_deploy}" = "${FLAGS_TRUE}" ]] && lazy_deploy=true || lazy_deploy=false
 
 if [[ $# == 0 ]]; then
@@ -81,7 +77,6 @@ function test_with_subctl {
 
 ### Main ###
 
-load_settings
 declare_kubeconfig
 [[ "${lazy_deploy}" = "false" ]] || deploy_env_once
 


### PR DESCRIPTION
The E2E script is not using anything from the settings, so there's no
need to load them.

Depends on: https://github.com/submariner-io/lighthouse/pull/643

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
