### PR TITLE
Fix Dapper-in-Dapper comma handling

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -58,7 +58,7 @@ container="$(basename "$(pwd)"):${gitid}"
 docker build -t "${container}" -f "${file}" --build-arg "BASE_BRANCH=${BASE_BRANCH:-devel}" .
 
 extract_var() {
-    docker inspect "$1" | sed -n -E "/\"$2=/{s/[[:space:]]+\"$2=([^\"]+)\",/\1/;p;q}"
+    docker inspect "$1" | sed -n -E "/\"$2=/{s/[[:space:]]+\"$2=([^\"]+)\",?/\1/;p;q}"
 }
 
 DAPPER_CP="$(extract_var "${container}" DAPPER_CP)"


### PR DESCRIPTION
The last environment variable in a list in the output of docker
inspect doesn't have a comma, so avoid requiring one; but remove it if
it is present.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
