### PR TITLE
dapper: add project definition

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -55,7 +55,10 @@ done
 gitid="$(git symbolic-ref --short HEAD 2>/dev/null | tr / _ || :)"
 gitid="${gitid:-$(git show --format=%h -s)}"
 container="$(basename "$(pwd)"):${gitid}"
-docker build -t "${container}" -f "${file}" --build-arg "BASE_BRANCH=${BASE_BRANCH:-devel}" .
+docker build -t "${container}" -f "${file}" \
+       --build-arg "BASE_BRANCH=${BASE_BRANCH:-devel}" \
+       --build-arg "PROJECT=${PROJECT}" \
+       .
 
 extract_var() {
     docker inspect "$1" | sed -n -E "/\"$2=/{s/[[:space:]]+\"$2=([^\"]+)\",?/\1/;p;q}"


### PR DESCRIPTION
This will fix code generation in the Submariner project.

Ultimately we should add generic ARG handling.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
