### PR TITLE
test(deploy): add OCM deploy tool

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        deploytool: ['operator', 'helm', 'bundle']
+        deploytool: ['operator', 'helm', 'bundle', 'ocm']
         lighthouse: ['']
         ovn: ['']
         include:
@@ -54,6 +54,10 @@ jobs:
             lighthouse: lighthouse
           - deploytool: bundle
             lighthouse: lighthouse
+        exclude:
+          # OCM does not support globalnet at this moment
+          - deploytool: ocm
+            globalnet: globalnet
     steps:
       - name: Set up kernel, increase the inotify settings
         if: ${{ matrix.deploytool == 'bundle' || matrix.deploytool == 'ocm' }}

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        deploytool: ['operator', 'helm', 'olm']
+        deploytool: ['operator', 'helm', 'bundle']
         lighthouse: ['']
         ovn: ['']
         include:
@@ -52,15 +52,12 @@ jobs:
             lighthouse: lighthouse
           - deploytool: helm
             lighthouse: lighthouse
-          - deploytool: olm
+          - deploytool: bundle
             lighthouse: lighthouse
     steps:
-      - name: Setup kernel for react native, increase watchers
-        if: ${{ matrix.deploytool == 'olm' }}
-        run: |
-          echo -e "fs.inotify.max_user_watches=524288\nfs.inotify.max_user_instances=512" \
-          | sudo tee -a /etc/sysctl.conf && \
-          sudo sysctl -p
+      - name: Set up kernel, increase the inotify settings
+        if: ${{ matrix.deploytool == 'bundle' || matrix.deploytool == 'ocm' }}
+        run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
 
       - name: Reclaim space on GHA host (if the job needs it)
         if: ${{ matrix.ovn != '' }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BASE_BRANCH ?= devel
+OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 NON_DAPPER_GOALS += images
 SHELLCHECK_ARGS := scripts/shared/lib/*
@@ -6,7 +7,7 @@ FOCUS ?=
 SKIP ?=
 PLUGIN ?=
 
-export BASE_BRANCH
+export BASE_BRANCH OCM_BASE_BRANCH
 
 ifneq (,$(DAPPER_HOST_ARCH))
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -47,6 +47,12 @@ override DEPLOY_ARGS += --deploytool bundle
 PRELOAD_IMAGES += submariner-operator-index
 endif
 
+ifneq (,$(filter ocm,$(_using)))
+override CLUSTERS_ARGS += --olm
+override DEPLOY_ARGS += --service_discovery --deploytool ocm
+PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns submariner-operator-index
+endif
+
 ifneq (,$(filter prometheus,$(_using)))
 override CLUSTERS_ARGS += --prometheus
 endif

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -41,7 +41,7 @@ ifneq (,$(filter helm,$(_using)))
 override DEPLOY_ARGS += --deploytool helm
 endif
 
-ifneq (,$(filter olm,$(_using)))
+ifneq (,$(filter bundle,$(_using)))
 override CLUSTERS_ARGS += --olm
 override DEPLOY_ARGS += --deploytool bundle
 PRELOAD_IMAGES += submariner-operator-index

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -35,6 +35,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # subctl *         | Submariner's deploy tool (operator)
 # upx              | binary compression
 # yamllint         | YAML linting
+# yq               | YAML processing (OCM deploy tool)
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
@@ -64,13 +65,13 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
+    GOFLAGS="" go get -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
     mkdir -p ~/.docker/cli-plugins && \
     curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \
     chmod 755 ~/.docker/cli-plugins/docker-buildx && \
     curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz | tar xzf - && \
     mv gh_${GH_VERSION}_linux_${ARCH}/bin/gh /go/bin/ && \
     rm -rf gh_${GH_VERSION}_linux_${ARCH} && \
-    curl -Lo /go/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${ARCH}" && chmod a+x /go/bin/yq && \
     find /go/bin ~/.docker/cli-plugins -type f -executable -newercc /proc -exec strip {} + && \
     find /go/bin ~/.docker/cli-plugins -type f -executable -newercc /proc \( -execdir upx ${UPX_LEVEL} {} \; -o -true \)
 

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -15,7 +15,7 @@ kind_k8s_versions[1.22]=1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a545
 
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'k8s_version' "${DEFAULT_K8S_VERSION}" 'Version of K8s to use'
-DEFINE_string 'olm_version' '0.16.1' 'Version of OLM to use'
+DEFINE_string 'olm_version' 'v0.18.3' 'Version of OLM to use'
 DEFINE_boolean 'olm' false 'Deploy OLM'
 DEFINE_boolean 'prometheus' false 'Deploy Prometheus'
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"
@@ -171,9 +171,10 @@ function run_local_registry() {
 
 function deploy_olm() {
     echo "Applying OLM CRDs..."
-    kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$olm_version/crds.yaml --validate=false
+    kubectl apply -f "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${olm_version}/crds.yaml" --validate=false
+    kubectl wait --for=condition=Established -f "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${olm_version}/crds.yaml"
     echo "Applying OLM resources..."
-    kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/$olm_version/olm.yaml
+    kubectl apply -f "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${olm_version}/olm.yaml"
 
     echo "Waiting for olm-operator deployment to be ready..."
     kubectl rollout status deployment/olm-operator --namespace=olm --timeout="${timeout}"

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -4,7 +4,7 @@
 
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'settings' '' "Settings YAML file to customize cluster deployments"
-DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm/bundle)'
+DEFINE_string 'deploytool' 'operator' 'Tool to use for deploying (operator/helm/bundle/ocm)'
 DEFINE_string 'deploytool_broker_args' '' 'Any extra arguments to pass to the deploytool when deploying the broker'
 DEFINE_string 'deploytool_submariner_args' '' 'Any extra arguments to pass to the deploytool when deploying submariner'
 DEFINE_boolean 'globalnet' false "Deploy with operlapping CIDRs (set to 'true' to enable)"

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -44,9 +44,90 @@ readonly CE_IPSEC_NATTPORT=4500
 readonly SUBM_COLORCODES=blue
 readonly SUBM_IMAGE_REPO=localhost:5000
 readonly SUBM_IMAGE_TAG=${image_tag:-local}
+readonly SUBM_CS="submariner-catalog-source"
+readonly SUBM_INDEX_IMG=localhost:5000/submariner-operator-index:local
 readonly BROKER_NAMESPACE="submariner-k8s-broker"
 readonly BROKER_CLIENT_SA="submariner-k8s-broker-client"
+readonly MARKETPLACE_NAMESPACE="olm"
 readonly IPSEC_PSK="$(dd if=/dev/urandom count=64 bs=8 | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)"
+
+### Common functions ###
+
+# Create a namespace
+# 1st argument is the namespace
+function create_namespace {
+  local ns=$1
+  echo "[INFO](${cluster}) Create the ${ns} namespace..."
+  kubectl create namespace "${ns}" || :
+}
+
+# Create a CatalogSource
+# 1st argument is the catalogsource name
+# 2nd argument is the namespace
+# 3rd argument is index image url
+function create_catalog_source() {
+  local cs=$1
+  local ns=$2
+  # shellcheck disable=SC2034 # this variable is used elsewhere
+  local iib=$3  # Index Image Build
+  echo "[INFO](${cluster}) Create the catalog source ${cs}..."
+
+  kubectl delete catalogsource/operatorhubio-catalog -n "${MARKETPLACE_NAMESPACE}" --wait --ignore-not-found
+  kubectl delete catalogsource/"${cs}" -n "${MARKETPLACE_NAMESPACE}" --wait --ignore-not-found
+
+  # Create the CatalogSource
+  render_template "${RESOURCES_DIR}"/common/catalogSource.yaml | kubectl apply -f -
+
+  # Wait for the CatalogSource readiness
+  if ! with_retries 60 kubectl get catalogsource -n "${MARKETPLACE_NAMESPACE}" "${cs}" -o jsonpath='{.status.connectionState.lastObservedState}'; then
+    echo "[ERROR](${cluster}) CatalogSource ${cs} is not ready."
+    exit 1
+  fi
+
+  echo "[INFO](${cluster}) Catalog source ${cs} created"
+}
+
+# Create an OperatorGroup
+# 1st argument is the operatorgroup name
+# 2nd argument is the target namespace
+function create_operator_group() {
+  local og=$1
+  local ns=$2
+
+  echo "[INFO](${cluster}) Create the OperatorGroup ${og}..."
+  # Create the OperatorGroup
+  render_template "${RESOURCES_DIR}"/common/operatorGroup.yaml | kubectl apply -f -
+}
+
+# Install the bundle, subscript and approve.
+# 1st argument is the subscription name
+# 2nd argument is the target catalogsource name
+# 3nd argument is the source namespace
+# 4th argument is the bundle name
+function install_bundle() {
+  local sub=$1
+  local cs=$2
+  local ns=$3
+  local bundle=$4
+  local installPlan
+
+  # Delete previous CatalogSource and Subscription
+  kubectl delete sub/"${sub}" -n "${ns}" --wait --ignore-not-found
+
+  # Create the Subscription (Approval should be Manual not Automatic in order to pin the bundle version)
+  echo "[INFO](${cluster}) Install the bundle ${bundle} ..."
+  render_template "${RESOURCES_DIR}"/common/subscription.yaml | kubectl apply -f -
+
+  # Manual Approve
+  echo "[INFO](${cluster}) Approve the InstallPlan..."
+  kubectl wait --for condition=InstallPlanPending --timeout=5m -n "${ns}" subs/"${sub}" || (echo "[ERROR](${cluster}) InstallPlan not found."; exit 1)
+  installPlan=$(kubectl get subscriptions.operators.coreos.com "${sub}" -n "${ns}" -o jsonpath='{.status.installPlanRef.name}')
+  if [ -n "${installPlan}" ]; then
+    kubectl patch installplan -n "${ns}" "${installPlan}" -p '{"spec":{"approved":true}}' --type merge
+  fi
+
+  echo "[INFO](${cluster}) Bundle ${bundle} installed"
+}
 
 ### Main ###
 
@@ -77,4 +158,3 @@ else
 fi
 
 run_if_defined post_deploy
-

--- a/scripts/shared/lib/deploy_bundle
+++ b/scripts/shared/lib/deploy_bundle
@@ -3,14 +3,9 @@
 . "${BASH_SOURCE%/*}"/source_only
 
 ### Constants ###
-
-# These variables are used elsewhere
-# shellcheck disable=SC2034
-readonly MARKETPLACE_NAMESPACE="olm"
-# shellcheck disable=SC2034
-readonly OPERATOR_NAME="submariner"
-# shellcheck disable=SC2034
-readonly INDEX_IMG=localhost:5000/submariner-operator-index:local
+readonly SUBM_GROUP="submariner-group"
+readonly SUBM_SUB="submariner-subscription"
+readonly SUBM_OPERATOR_NAME="submariner"
 
 # Variables
 
@@ -22,77 +17,20 @@ BROKER_K8S_CA=""
 
 function deploytool_prereqs() {
   [[ -z "${SUBM_NS}" ]] && (echo "[ERROR] Required environment variables SUBM_NS not loaded"; exit 3)
+  [[ -z "${SUBM_CS}" ]] && (echo "[ERROR] Required environment variables SUBM_CS not loaded"; exit 3)
+  [[ -z "${SUBM_INDEX_IMG}" ]] && (echo "[ERROR] Required environment variables SUBM_INDEX_IMG not loaded"; exit 3)
 
   # Create new namespace
-  run_subm_clusters create_submariner_namespace
+  run_subm_clusters "create_namespace ${SUBM_NS}"
 
   # Create the custom catalog source
-  run_subm_clusters create_catalog_source
+  run_subm_clusters "create_catalog_source ${SUBM_CS} ${SUBM_NS} ${SUBM_INDEX_IMG}"
+
+  # Create the operator group
+  run_subm_clusters "create_operator_group ${SUBM_GROUP} ${SUBM_NS}"
 
   # Install the submariner operator bundle
-  run_subm_clusters install_bundle
-}
-
-function create_submariner_namespace {
-  echo "[INFO](${cluster}) Create the namespace..."
-  kubectl create namespace "${SUBM_NS}" || :
-}
-
-function create_catalog_source() {
-  echo "[INFO](${cluster}) Create the catalog source..."
-
-  kubectl delete catalogsource/operatorhubio-catalog -n "${MARKETPLACE_NAMESPACE}" --wait --ignore-not-found
-  kubectl delete catalogsource/submariner-catalog-source -n "${MARKETPLACE_NAMESPACE}" --wait --ignore-not-found
-
-  # Create the CatalogSource
-  render_template "${RESOURCES_DIR}"/bundle/catalogSource.yaml | kubectl apply -f -
-
-  # Wait for the catalogSource Readiness
-  if ! (timeout 5m bash -c "until [[ $(kubectl --context="${cluster}" get catalogsource -n ${MARKETPLACE_NAMESPACE} submariner-catalog-source -o jsonpath='{.status.connectionState.lastObservedState}') -eq 'READY' ]]; do sleep 10; done"); then
-      echo "[ERROR] CatalogSource is not ready."
-      exit 1
-  fi
-
-  # Debug
-  kubectl -n ${MARKETPLACE_NAMESPACE} get catalogsource --ignore-not-found
-  kubectl -n ${MARKETPLACE_NAMESPACE} get pods --ignore-not-found
-  kubectl -n ${MARKETPLACE_NAMESPACE} get packagemanifests --ignore-not-found | grep 'Submariner Catalog Source' || true
-
-
-  # Create the OperatorGroup
-  render_template "${RESOURCES_DIR}"/bundle/operatorGroup.yaml | kubectl apply -f -
-
-  # Debug
-  kubectl get og -n "${SUBM_NS}" --ignore-not-found
-
-  echo "[INFO](${cluster}) Catalog source created"
-}
-
-function install_bundle() {
-  local installPlan
-
-  # Delete previous catalogSource and Subscription
-  kubectl delete sub/submariner-subscription -n "${SUBM_NS}" --wait --ignore-not-found
-
-  # Create the Subscription (Approval should be Manual not Automatic in order to pin the bundle version)
-  echo "[INFO](${cluster}) Install the bundle..."
-  render_template "${RESOURCES_DIR}"/bundle/subscription.yaml | kubectl apply -f -
-
-  # Manual Approve
-  echo "[INFO](${cluster}) Approve the installPlan..."
-  kubectl wait --for condition=InstallPlanPending --timeout=5m -n "${SUBM_NS}" subs/submariner-subscription || (echo "[ERROR](${cluster}) InstallPlan not found."; exit 1)
-  installPlan=$(kubectl get subscriptions.operators.coreos.com submariner-subscription -n "${SUBM_NS}" -o jsonpath='{.status.installPlanRef.name}')
-  if [ -n "${installPlan}" ]; then
-    kubectl patch installplan -n "${SUBM_NS}" "${installPlan}" -p '{"spec":{"approved":true}}' --type merge
-  fi
-
-  # Debug
-  kubectl get sub -n "${SUBM_NS}" --ignore-not-found
-  kubectl get installplan -n "${SUBM_NS}" --ignore-not-found
-  kubectl get csv -n "${SUBM_NS}" --ignore-not-found
-  kubectl get pods -n "${SUBM_NS}" --ignore-not-found
-
-  echo "[INFO](${cluster}) Bundle installed"
+  run_subm_clusters "install_bundle ${SUBM_SUB} ${SUBM_CS} ${SUBM_NS} ${SUBM_OPERATOR_NAME}"
 }
 
 function setup_broker() {
@@ -128,11 +66,11 @@ function setup_broker() {
   fi
 
   brokerClientSecret=$(kubectl -n "${BROKER_NAMESPACE}" get secrets -o json | jq -r -c '[.items[] | select(.metadata.annotations."kubernetes.io/service-account.name"=="'"${BROKER_CLIENT_SA}"'") | select(.data.token != null) | select(.data."ca.crt" != null)] | .[0]')
-  # shellcheck disable=SC2034
+  # shellcheck disable=SC2034 # this variable is used elsewhere
   BROKER_K8S_API_SERVER=$(kubectl get endpoints kubernetes -n default -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
-  # shellcheck disable=SC2034
+  # shellcheck disable=SC2034 # this variable is used elsewhere
   BROKER_K8S_API_SERVER_TOKEN=$(echo "${brokerClientSecret}" | jq -r '.data.token' | base64 --decode)
-  # shellcheck disable=SC2034
+  # shellcheck disable=SC2034 # this variable is used elsewhere
   BROKER_K8S_CA=$(echo "${brokerClientSecret}" | jq -r '.data."ca.crt"')
 
 }

--- a/scripts/shared/lib/deploy_ocm
+++ b/scripts/shared/lib/deploy_ocm
@@ -1,0 +1,166 @@
+# shellcheck shell=bash
+# shellcheck source=scripts/shared/lib/source_only
+. "${BASH_SOURCE%/*}"/source_only
+
+### Constants ###
+readonly OCM_NS="open-cluster-management"
+readonly OCM_AGENT_NS="open-cluster-management-agent"
+readonly HUB="cluster1"
+
+# Variables
+
+### Functions ###
+
+function deploytool_prereqs() {
+  # shellcheck disable=SC2153 # this variable is defined elsewhere
+  [[ -z "${SUBM_NS}" ]] && (echo "[ERROR] Required environment variables SUBM_NS not loaded"; exit 3)
+  # shellcheck disable=SC2153 # this variable is defined elsewhere
+  [[ -z "${SUBM_CS}" ]] && (echo "[ERROR] Required environment variables SUBM_CS not loaded"; exit 3)
+  # shellcheck disable=SC2153 # this variable is defined elsewhere
+  [[ -z "${SUBM_INDEX_IMG}" ]] && (echo "[ERROR] Required environment variables SUBM_INDEX_IMG not loaded"; exit 3)
+
+  # Create new namespace
+  with_context "${HUB}" "create_namespace ${OCM_NS}"
+  run_subm_clusters "create_namespace ${OCM_AGENT_NS}"
+  run_subm_clusters "create_namespace ${SUBM_NS}"
+
+  # Create the custom catalog source
+  run_subm_clusters "create_catalog_source ${SUBM_CS} ${SUBM_NS} ${SUBM_INDEX_IMG}"
+
+  # Install the cluster-manager on the hub
+  with_context "${HUB}" install_cluster_manager
+
+  # Install submariner-addon on the hub
+  with_context "${HUB}" install_submariner_addon
+
+  # Install the klusterlet on the managed clusters
+  run_subm_clusters "install_klusterlet"
+
+  # Import the managed Clusters
+  with_context "${HUB}" create_managed_clusters
+}
+
+function install_cluster_manager() {
+  local cluster_manager_dir
+
+  echo "[INFO](${cluster}) Deploy OCM cluster manager..."
+  # Clone the repo
+  [ -d /tmp/registration_operator ] && rm -Rf /tmp/registration_operator
+  git clone --depth 1 --single-branch --branch "${OCM_BASE_BRANCH}" https://github.com/open-cluster-management/registration-operator /tmp/registration_operator
+  cluster_manager_dir=/tmp/registration_operator/deploy/cluster-manager
+  # Deploy
+  kubectl apply -k ${cluster_manager_dir}/config/manifests
+  kubectl apply -k ${cluster_manager_dir}/config/samples
+}
+
+function install_klusterlet() {
+  local klusterlet_dir
+  local master_ip
+
+  # shellcheck disable=SC2034 # this variable is used elsewhere
+  master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}"-control-plane | head -n 1)
+  echo "[INFO](${cluster}) Deploy OCM klusterlet..."
+  # Clone the repo
+  if [ ! -d /tmp/registration_operator ]; then
+    git clone --depth 1 --single-branch --branch "${OCM_BASE_BRANCH}" https://github.com/open-cluster-management/registration-operator /tmp/registration_operator
+  fi
+  klusterlet_dir=/tmp/registration_operator/deploy/klusterlet
+  # Deploy
+  kubectl apply -k ${klusterlet_dir}/config/manifests
+  kubectl -n ${OCM_AGENT_NS} create secret generic bootstrap-hub-kubeconfig --from-file="kubeconfig=${KUBECONFIGS_DIR}/kind-config-${HUB}"
+  render_template "${RESOURCES_DIR}"/ocm/klusterlet.yaml | kubectl apply -f -
+  # Tag worker node with submariner.io/gateway=true
+  kubectl label nodes "${cluster}-worker" "submariner.io/gateway=true" --overwrite
+}
+
+function install_submariner_addon() {
+  local submariner_addon_dir
+  local broker_api_server
+
+  echo "[INFO](${cluster}) Deploy OCM submariner-addon..."
+  # Clone the repo
+  if [ -f "${DAPPER_SOURCE}"/deploy/config/manifests/bases/submariner-addon.clusterserviceversion.yaml ]; then
+    submariner_addon_dir="${DAPPER_SOURCE}"/deploy
+  else
+    [ -d /tmp/submariner-addon ] && rm -Rf /tmp/submariner-addon
+    git clone --depth 1 --single-branch --branch "${OCM_BASE_BRANCH}" https://github.com/open-cluster-management/submariner-addon /tmp/submariner-addon
+    submariner_addon_dir=/tmp/submariner-addon/deploy
+  fi
+  # Set submariner-addon imagePullPolicy to IfNotPresent
+  sed -i -- '/image: quay.io*/a\        imagePullPolicy: IfNotPresent' ${submariner_addon_dir}/config/operator/operator.yaml
+  # Add master apiserver to submariner-addon deployment
+  broker_api_server=$(kubectl get endpoints kubernetes -n default -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
+  yq eval -i '.spec.template.spec.containers[].env += {"name": "BROKER_API_SERVER", "value": "'"${broker_api_server}"'"}' \
+  ${submariner_addon_dir}/config/operator/operator.yaml
+  # Deploy
+  kubectl apply -k ${submariner_addon_dir}/config/manifests
+}
+
+function create_managed_clusters() {
+  local csr_name
+
+  # Loop the submariner clusters
+  for mc in "${clusters[@]}"; do
+    if [[ ${cluster_subm[$mc]} == "true" ]]; then
+      echo "[INFO](${cluster}) Accept the managed cluster ${mc} and approve its Certificate Signing Request (CSR)..."
+      # Wait for the managed cluster resource
+      if ! with_retries 120 kubectl get managedclusters.cluster.open-cluster-management.io "${mc}"; then
+        echo "[ERROR] Unable to find the managed cluster ${mc}."
+        exit 1
+      fi
+      # Accept the managed cluster
+      kubectl patch managedclusters.cluster.open-cluster-management.io "${mc}" \
+      --type merge --patch '{"spec":{"hubAcceptsClient":true}}'
+      # Approve the managed cluster CSR
+      csr_name=$(kubectl get csr | grep "${mc}" | grep "Pending" | awk '{print $1}')
+      kubectl certificate approve "${csr_name}"
+      # Wait for the managed cluster readiness
+      kubectl wait --for condition=ManagedClusterJoined --timeout=5m managedclusters.cluster.open-cluster-management.io "${mc}" \
+      || (echo "[ERROR](${cluster}) The managed cluster ${mc} is not ready."; exit 1)
+      # Add the managed cluster to the submariner clusterset
+      kubectl label managedclusters.cluster.open-cluster-management.io "${mc}" \
+      "cluster.open-cluster-management.io/clusterset=submariner" --overwrite
+    fi
+  done
+
+  echo "[INFO](${cluster}) Create the Managed Cluster Set ..."
+  render_template "${RESOURCES_DIR}"/ocm/managedClusterSet.yaml | kubectl apply -f -
+}
+
+function setup_broker() {
+  echo "[INFO](${cluster}) The broker setup is done by OCM."
+}
+
+function install_subm() {
+  # Loop the submariner clusters and set up the managed cluster addon
+  for mc in "${clusters[@]}"; do
+    if [[ ${cluster_subm[$mc]} == "true" ]]; then
+      echo "[INFO](${cluster}) Install submariner on ${mc}..."
+      # Create the Submariner Subscription config
+      render_template "${RESOURCES_DIR}"/ocm/submarinerConfig.yaml | kubectl apply -f -
+      # Create the Submariner addon to start the deployment
+      render_template "${RESOURCES_DIR}"/ocm/managedClusterAddOn.yaml | kubectl apply -f -
+      # Label the managed clusters and klusterletaddonconfigs to deploy submariner
+      kubectl label managedclusters.cluster.open-cluster-management.io "${mc}" "cluster.open-cluster-management.io/submariner-agent=true" --overwrite
+      echo "[INFO](${cluster}) Submariner installed on ${mc}"
+    fi
+  done
+  # Loop the submariner clusters and wait for the connection establishment
+  for mc in "${clusters[@]}"; do
+    if [[ ${cluster_subm[$mc]} == "true" ]]; then
+      with_retries 60 kubectl get manifestworks -n "${mc}" addon-submariner-deploy
+      with_retries 60 kubectl get manifestworks -n "${mc}" submariner-operator
+      kubectl wait --for=condition=Available --timeout=5m manifestworks -n "${mc}" addon-submariner-deploy
+      kubectl wait --for=condition=Available --timeout=5m manifestworks -n "${mc}" submariner-operator
+      with_retries 60 kubectl get managedclusteraddons -n "${mc}" submariner
+      kubectl wait --for=condition=Available --timeout=5m managedclusteraddons -n "${mc}" submariner && \
+      kubectl wait --for=condition=SubmarinerAgentDegraded=false --timeout=5m managedclusteraddons -n "${mc}" submariner && \
+      kubectl wait --for=condition=SubmarinerConnectionDegraded=false --timeout=5m managedclusteraddons -n "${mc}" submariner
+      echo "[INFO](${cluster}) Submariner installed on ${mc}"
+    fi
+  done
+}
+
+function install_subm_all_clusters() {
+  with_context "${HUB}" install_subm
+}

--- a/scripts/shared/resources/common/catalogSource.yaml
+++ b/scripts/shared/resources/common/catalogSource.yaml
@@ -2,12 +2,12 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: submariner-catalog-source
+  name: ${cs}
   namespace: ${MARKETPLACE_NAMESPACE}
 spec:
   sourceType: grpc
-  image: ${INDEX_IMG}
-  displayName: Submariner Catalog Source
+  image: ${iib}
+  displayName: ${cs}
   publisher: Submariner.io (Test)
   updateStrategy:
     registryPoll:

--- a/scripts/shared/resources/common/operatorGroup.yaml
+++ b/scripts/shared/resources/common/operatorGroup.yaml
@@ -2,8 +2,8 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: submariner-group
-  namespace: ${SUBM_NS}
+  name: ${og}
+  namespace: ${ns}
 spec:
   targetNamespaces:
-    - ${SUBM_NS}
+    - ${ns}

--- a/scripts/shared/resources/common/subscription.yaml
+++ b/scripts/shared/resources/common/subscription.yaml
@@ -2,10 +2,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: submariner-subscription
-  namespace: ${SUBM_NS}
+  name: ${sub}
+  namespace: ${ns}
 spec:
   installPlanApproval: Manual
-  name: ${OPERATOR_NAME}
-  source: submariner-catalog-source
+  name: ${bundle}
+  source: ${cs}
   sourceNamespace: ${MARKETPLACE_NAMESPACE}

--- a/scripts/shared/resources/ocm/klusterlet.yaml
+++ b/scripts/shared/resources/ocm/klusterlet.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operator.open-cluster-management.io/v1
+kind: Klusterlet
+metadata:
+  name: klusterlet
+spec:
+  registrationImagePullSpec: quay.io/open-cluster-management/registration
+  workImagePullSpec: quay.io/open-cluster-management/work
+  clusterName: ${cluster}
+  namespace: open-cluster-management-agent
+  externalServerURLs:
+    - url: https://${master_ip}

--- a/scripts/shared/resources/ocm/managedClusterAddOn.yaml
+++ b/scripts/shared/resources/ocm/managedClusterAddOn.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: ManagedClusterAddOn
+metadata:
+  name: submariner
+  namespace: ${mc}
+spec:
+  installNamespace: ${SUBM_NS}

--- a/scripts/shared/resources/ocm/managedClusterSet.yaml
+++ b/scripts/shared/resources/ocm/managedClusterSet.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: cluster.open-cluster-management.io/v1beta1
+kind: ManagedClusterSet
+metadata:
+  name: submariner

--- a/scripts/shared/resources/ocm/submarinerConfig.yaml
+++ b/scripts/shared/resources/ocm/submarinerConfig.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: submarineraddon.open-cluster-management.io/v1alpha1
+kind: SubmarinerConfig
+metadata:
+  name: submariner
+  namespace: ${mc}
+spec:
+  IPSecIKEPort: ${CE_IPSEC_IKEPORT}
+  IPSecNATTPort: ${CE_IPSEC_NATTPORT}
+  NATTEnable: false
+  cableDriver: libreswan
+  gatewayConfig:
+    gateways: 1
+  imagePullSpecs:
+    submarinerImagePullSpec: ${SUBM_IMAGE_REPO}/submariner-gateway:${SUBM_IMAGE_TAG}
+    submarinerRouteAgentImagePullSpec: ${SUBM_IMAGE_REPO}/submariner-route-agent:${SUBM_IMAGE_TAG}
+    lighthouseAgentImagePullSpec: ${SUBM_IMAGE_REPO}/lighthouse-agent:${SUBM_IMAGE_TAG}
+    lighthouseCoreDNSImagePullSpec: ${SUBM_IMAGE_REPO}/lighthouse-coredns:${SUBM_IMAGE_TAG}
+  subscriptionConfig:
+    source: ${SUBM_CS}
+    sourceNamespace: ${MARKETPLACE_NAMESPACE}


### PR DESCRIPTION
Test Submariner using OCM

* Rename the deploytool from olm to bundle
* Create common deploy functions
* Bump olm default version to v0.18.3
* Install `yq` in `shipyard-dapper-base image`
* Add ocm deploy tool
* The new deploy tool is now part of the CI

Closes #657 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
