### PR TITLE
Drop the requirement for GCC

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -15,7 +15,6 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # -------------------------------------------------------------
 # curl             | download other tools
 # findutils        | make unit (find unit test dirs)
-# gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
 # gh               | backport, releases
 # ginkgo           | tests
 # git              | find the workspace root
@@ -38,7 +37,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   gcc git-core curl moby-engine make golang kubernetes-client \
+                   git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
                    qemu-user-static python3-pip && \
     npm install -g markdownlint-cli && \

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -25,7 +25,7 @@ for module in "${modules[@]}"; do
 
     if [ -n "${packages}" ]; then
 	echo "Running tests in ${packages}"
-	[ "${ARCH}" == "amd64" ] && race=-race
+	[ "${ARCH}" == "amd64" ] && race="-race -vet=off"
 	(cd $module && ${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml) || result=1
     fi
 done


### PR DESCRIPTION
By disabling "go vet" we can remove the requirement for GCC when
testing with race detection.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
