### PR TITLE
add generic target to print a variable from make's environment

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -214,3 +214,5 @@ vendor/modules.txt: go.mod
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners
+
+print-%: ; @echo $* = $($*)


### PR DESCRIPTION
The `print-%` target would be more generally useful in Shipyard’s Makefile.inc

Moved from submariner-io/submariner#1607

Signed-off-by: Etai Lev Ran <etai@il.ibm.com>
