### PR TITLE
Fix shellcheck complaints about SC1091

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -179,7 +179,7 @@ markdownlint:
 
 # [shellcheck] validates your shell files
 shellcheck:
-	shellcheck $(SHELLCHECK_ARGS)
+	shellcheck -x -P $${SCRIPTS_DIR} $(SHELLCHECK_ARGS)
 
 # [yamllint] validates YAML files in the project
 yamllint:


### PR DESCRIPTION
Added flags to shellcheck to make sure the `$SCRIPTS_DIR` is available
to shellcheck so it won't complain about not being able to load these
files.
The flags are added to Shipyard to support any consuming project,
instead of having each project define them.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
