### PR TITLE
Handle local builds in our Dapper infrastructure 

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -9,6 +9,22 @@ NON_DAPPER_GOALS += .dapper shell targets $(LINTING_GOALS)
 export MAKEFLAGS
 export PROJECT
 
+# Define LOCAL_BUILD to build directly on the host and not inside a Dapper container
+ifdef LOCAL_BUILD
+DAPPER_HOST_ARCH ?= $(shell go env GOHOSTARCH)
+SHIPYARD_DIR ?= ../shipyard
+SCRIPTS_DIR ?= $(SHIPYARD_DIR)/scripts/shared
+
+export DAPPER_HOST_ARCH
+export SHIPYARD_DIR
+export SCRIPTS_DIR
+
+RUN_IN_DAPPER :=
+
+.dapper:
+
+else
+
 .dapper:
 	@echo Downloading dapper
 	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/$(BASE_BRANCH)/$@
@@ -16,13 +32,15 @@ export PROJECT
 	@./.dapper -v
 
 SELINUX_CONTEXT := $(shell (selinuxenabled && echo -S z) 2>/dev/null)
-RUN_IN_DAPPER := ./.dapper $(DAPPER_ARGS) $(SELINUX_CONTEXT)
+RUN_IN_DAPPER = ./.dapper $(DAPPER_ARGS) $(SELINUX_CONTEXT) --
+
+endif
 
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
 $(filter-out .dapper prune-images shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper $(BASE_DAPPER)
 	-docker network create -d bridge kind
-	+$(RUN_IN_DAPPER) -- make --debug=b $@
+	+$(RUN_IN_DAPPER) make --debug=b $@
 
 # The original dockerfiles will live in Shipyard and be downloaded by consuming projects.
 $(BASE_DAPPER) $(LINTING_DAPPER):
@@ -30,8 +48,9 @@ $(BASE_DAPPER) $(LINTING_DAPPER):
 	@curl -sfLO https://raw.githubusercontent.com/submariner-io/shipyard/$(BASE_BRANCH)/$@
 
 # Run silently as the commands are pretty straightforward and `make` hasn't a lot to do
+$(LINTING_GOALS): DAPPER_ARGS := -f $(LINTING_DAPPER)
 $(LINTING_GOALS): .dapper $(LINTING_DAPPER)
-	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -- make $@
+	@$(RUN_IN_DAPPER) make $@
 
 # [prune-images] removes all Submariner-provided images and all untagged images
 # Use this to ensure you use current images
@@ -46,12 +65,14 @@ prune-images:
 	    fi \
 	done
 
+shell: DAPPER_ARGS := -s
 shell: .dapper $(BASE_DAPPER)
-	$(RUN_IN_DAPPER) -s
+	$(RUN_IN_DAPPER)
 
 # Run silently to just list the targets (hence we can't use the generic dapper wrapper recipe).
 # This only lists targets accessible inside dapper (which are 99% of targets we use)
+targets: DAPPER_ARGS := -f $(LINTING_DAPPER)
 targets: $(LINTING_DAPPER)
-	@$(RUN_IN_DAPPER) -f $(LINTING_DAPPER) -- eval "\$${SCRIPTS_DIR}/targets.sh"
+	@$(RUN_IN_DAPPER) eval "\$${SCRIPTS_DIR}/targets.sh"
 
 .PHONY: prune-images shell targets $(LINTING_GOALS)


### PR DESCRIPTION
This is based on
<submariner-io/submariner#1607> but adapted so
that it can be shared across all projects. When LOCAL_BUILD is
defined, assume that Shipyard is available in ../shipyard (relative to
the top directory of the current project), and instead of running
Dapper, run Dapper-hosted commands directly.

This relies on DAPPER_ARGS for Dapper arguments throughout, instead of
specifying Dapper arguments in the Dapper invocation itself; that way,
local builds can ignore DAPPER_ARGS entirely. This produces the
expected behaviour when choosing a base image: the command to run
inside the chosen base image is run directly. It changes "make shell"
however, but in a sensible way; Make determines that there is nothing
to do and returns to whatever called it, typically a shell in the
right environment.