### PR TITLE
Pass unit test arguments to go test

### DIFF
--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -26,7 +26,7 @@ for module in "${modules[@]}"; do
     if [ -n "${packages}" ]; then
 	echo "Running tests in ${packages}"
 	[ "${ARCH}" == "amd64" ] && race=-race
-	(cd $module && ${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml) || result=1
+	(cd $module && ${GO:-go} test -v ${race} -cover ${packages} -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@") || result=1
     fi
 done
 


### PR DESCRIPTION
This allows UNIT_TEST_ARGS to be used, e.g. UNIT_TEST_ARGS=-failfast.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
