### PR TITLE
Disable seccomp confinement for now

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -85,4 +85,8 @@ fi
 
 [ -t 1 ] && dockerargs="${dockerargs} -t"
 
-docker run -i --rm $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$(id -u)" -e "DAPPER_GID=$(id -g)" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"
+# seccomp is unconfined to avoid problems with clone3 in Fedora 35
+# See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
+# Remove "--security-opt seccomp=unconfined" once all supported container runtimes
+# handle clone3
+docker run -i --rm --security-opt seccomp=unconfined $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$(id -u)" -e "DAPPER_GID=$(id -g)" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -55,7 +55,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.43.0 \
     HELM_VERSION=v3.7.1 \
     KIND_VERSION=v0.11.1 \
-    BUILDX_VERSION=v0.7.0 \
+    BUILDX_VERSION=v0.7.1 \
     GH_VERSION=2.2.0 \
     YQ_VERSION=4.14.1
 


### PR DESCRIPTION
glibc 2.34 started using clone3(), which causes failures with confined
container runtimes which don't handle it correctly (in most cases,
they return EPERM because the syscall is blocked; returning ENOSYS
instead causes glibc to fall back to clone() which is handled
correctly).

Disabling seccomp confinement fixes this for now. Once we're confident
that all our users have recent enough runtimes, we can re-enable it.

The buildx bump to 0.7.1 is related; 0.7.1 includes a fix for this in
the builder images.

Fixes: https://github.com/submariner-io/submariner/issues/1595
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
