### PR TITLE
make clean-clusters is deleting images that it probably shouldn't

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -69,6 +69,44 @@ function kind_fixup_config() {
     chmod a+r $KUBECONFIG
 }
 
+# In development environments where clusters are brought up and down
+# multiple times, several Docker images are repeatedly pulled and deleted,
+# leading to the Docker error:
+#   "toomanyrequests: You have reached your pull rate limit"
+# Preload the KIND image. Also tag it so the `docker system prune` during
+# cleanup won't remove it.
+function download_kind() {
+    if [[ -z "${k8s_version}" ]]; then
+        echo "k8s_version not set."
+        return
+    fi
+
+    # Example: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+    kind_image="kindest/node:v${k8s_version}"
+    # Example: kindest/node:v1.20.7
+    kind_image_tag="kindest/node:v$(echo ${k8s_version}|awk -F"@" '{print $1}')"
+    # Example: kindest/node:@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+    kind_image_sha="kindest/node@$(echo ${k8s_version}|awk -F"@" '{print $2}')"
+
+    # Check if image is already present, and if not, download it.
+    echo "Processing Image: $kind_image_tag ($kind_image)"
+    if [[ -n $(docker images -q "$kind_image_tag") ]] ; then
+        echo "Image $kind_image_tag already downloaded."
+        return
+    fi
+
+    echo "Image $kind_image_tag not found, downloading..."
+    if ! docker pull "$kind_image"; then
+        echo "**** 'docker pull $kind_image' failed. Manually run. ****"
+        return
+    fi
+
+    image_id=$(docker images -q "$kind_image_sha")
+    if ! docker tag "$image_id" "$kind_image_tag"; then
+        echo "'docker tag ${image_id} ${kind_image_tag}' failed."
+    fi
+}
+
 function create_kind_cluster() {
     export KUBECONFIG=${KUBECONFIGS_DIR}/kind-config-${cluster}
     rm -f "$KUBECONFIG"
@@ -271,6 +309,7 @@ function warn_inotify() {
 rm -rf ${KUBECONFIGS_DIR}
 mkdir -p ${KUBECONFIGS_DIR}
 
+download_kind
 load_settings
 run_local_registry
 declare_cidrs


### PR DESCRIPTION
Running make deploy and make clean-clusters multiple times from a server on
corporate network and started hitting the Docker pull rate issue:
  "toomanyrequests: You have reached your pull rate limit"

Preload KIND image so docker pull failure can be added to a output signalling
a manual pull required. Also tag the image so that it is not considered a
"dangling" image and deleted by "docker system prune" on "make clean-clusters".

Closes: #698

Signed-off-by: Billy McFall <22157057+Billy99@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
