### PR TITLE
Add K8s->kind version map for 1.23

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -10,6 +10,7 @@ kind_k8s_versions[1.19]=1.19.11
 kind_k8s_versions[1.20]=1.20.7
 kind_k8s_versions[1.21]=1.21.1
 kind_k8s_versions[1.22]=1.22.0
+kind_k8s_versions[1.23]=1.23.0
 
 ## Process command line flags ##
 


### PR DESCRIPTION
See the kind 0.11.1 releaes notes for the version source:

https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1

Relates-to: submariner-io/submariner-website#624

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
