### PR TITLE
Clarify backport script fail on fork name

### DIFF
--- a/scripts/shared/backport.sh
+++ b/scripts/shared/backport.sh
@@ -95,7 +95,12 @@ PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789
 declare -r PULLSUBJ
 
 echo "+++ Updating remotes..."
-git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
+if ! git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"; then
+  echo "Failed to run git remote update. You may need to manually provide the names of your remotes."
+  echo "export UPSTREAM_REMOTE=<remote name for upstream>"
+  echo "export FORK_REMOTE=<remote name for your fork>"
+  exit 1
+fi
 
 if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
   echo "!!! '${BRANCH}' not found. The second argument should be something like release-0.9."


### PR DESCRIPTION
When the name of a user's fork doesn't match their username on GitHub,
the backport script fails. If that happens, clarify in the output how to
fix it by setting a custom name for the fork.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
