### PR TITLE
Update K8s in E2E, EOL 1.19 and add 1.23

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,7 +19,7 @@ jobs:
         project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
         deploytool: ['operator', 'helm']
         cabledriver: ['libreswan']
-        k8s_version: ['1.19']
+        k8s_version: ['1.23']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -31,8 +31,6 @@ jobs:
           # Test the same set of cable driver combinations as the consuming projects do in their CI
           - project: submariner
             cabledriver: wireguard
-            deploytool: operator
-            k8s_version: '1.19'
           # Test multiple K8s versions only in submariner-operator, balancing coverage and jobs
           - project: submariner-operator
             k8s_version: '1.20'
@@ -40,8 +38,6 @@ jobs:
             k8s_version: '1.21'
           - project: submariner-operator
             k8s_version: '1.22'
-          - project: submariner-operator
-            k8s_version: '1.23'
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -5,7 +5,7 @@ inputs:
   k8s_version:
     description: 'Version of Kubernetes to use for clusters'
     required: false
-    default: '1.19'
+    default: '1.23'
   using:
     description: 'Various options to pass via using="..."'
     required: false


### PR DESCRIPTION
Update the versions of Kubernetes tested in the E2E CI. Add 1.23 as the
new default for most tests, remove 1.19 as it is now EOL.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
