### PR TITLE
Check for fixup commits in PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,6 +23,14 @@ jobs:
           flags: 'i'
           error: 'Commits addressing code review feedback should typically be squashed into the commits under review'
 
+      - name: 'Verify no "fixup!" commits'
+        uses: tim-actions/commit-message-checker-with-regex@d6d9770051dd6460679d1cab1dcaa8cffc5c2bbd
+        with:
+          commits: ${{ steps.get-pr-commits.outputs.commits }}
+          pattern: '^(?!fixup!)'
+          flags: 'i'
+          error: 'Fixup commits should be squashed into the commits under review'
+
   commit-size:
     name: Commit Size
     runs-on: ubuntu-latest


### PR DESCRIPTION
Commits produced using "git commit --fix" are great for review, but
must be squashed before a PR is merged.

Signed-off-by: Stephen Kitt <skitt@redhat.com>