### PR TITLE
Provide the correct uid/gid in rootless containers

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -85,8 +85,16 @@ fi
 
 [ -t 1 ] && dockerargs="${dockerargs} -t"
 
+DAPPER_UID=$(id -u)
+DAPPER_GID=$(id -g)
+# If docker is provided by Podman, assume rootless and tell the container to use root internally
+if docker 2>&1 | grep -q podman; then
+  DAPPER_UID=0
+  DAPPER_GID=0
+fi
+
 # seccomp is unconfined to avoid problems with clone3 in Fedora 35
 # See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
 # Remove "--security-opt seccomp=unconfined" once all supported container runtimes
 # handle clone3
-docker run -i --rm --security-opt seccomp=unconfined $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$(id -u)" -e "DAPPER_GID=$(id -g)" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"
+docker run -i --rm --security-opt seccomp=unconfined $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"


### PR DESCRIPTION
In rootless containers, the final chown messes permissions up because
the external uid/gid don't have the same meaning inside the
container. The appropriate uid/gid pair in this scenario is 0/0, which
is mapped back to the external uid/gid running the container.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
