### PR TITLE
Ignore . when calculating container dependencies

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -15,7 +15,7 @@ FORCE_IMAGE: ;
 # We have to run it through a variable in order to expand any * that might be
 # in the COPY command; find is used to handle directories as dependencies
 # Files copied from another image are ignored
-docker_deps = $(shell files=($(1) $$(awk '/COPY/ { if (substr($$2, 1, 7) != "--from=") { for (i = 2; i < NF; i++) { print $$i } } }' $(1))) && find $${files[*]} -type f -o -type l)
+docker_deps = $(shell files=($(1) $$(awk '/COPY/ && substr($$2, 1, 7) != "--from=" && $$2 != "." { $$1 = $$NF = ""; print }' $(1))) && find $${files[*]} -type f -o -type l)
 
 # Patterned recipe to use to build any image from any Dockerfile
 # An empty file is used for make to figure out if dependencies changed or not


### PR DESCRIPTION
To allow building images using builder containers, and copying the
current directory, ignore "COPY .".

Clean up the AWK script slightly while we're at it.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
