### PR TITLE
Increase inotify settings in E2E/upgrade GHAs

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -56,6 +56,10 @@ runs:
         free -h
         echo "::endgroup::"
 
+    - name: Set up kernel, increase the inotify settings
+      shell: bash
+      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+
     - name: Install WireGuard specific modules
       shell: bash
       run: |

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -24,6 +24,10 @@ runs:
         free -h
         echo "::endgroup::"
 
+    - name: Set up kernel, increase the inotify settings
+      shell: bash
+      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+
     - shell: bash
       run: |
         make upgrade-e2e


### PR DESCRIPTION
Instead of just warning about these settings being too low, increase
them for all E2E and E2E upgrade jobs by setting them in the shared
GitHub actions. This should fix the failures in Lighthouse jobs we've
been seeing, for example on submariner-io/lighthouse#673.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
