### PR TITLE
Automated backport of #714: Increase inotify settings in E2E/upgrade GHAs

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -56,6 +56,10 @@ runs:
         free -h
         echo "::endgroup::"
 
+    - name: Set up kernel, increase the inotify settings
+      shell: bash
+      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+
     - name: Install WireGuard specific modules
       shell: bash
       run: |

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -24,6 +24,10 @@ runs:
         free -h
         echo "::endgroup::"
 
+    - name: Set up kernel, increase the inotify settings
+      shell: bash
+      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+
     - shell: bash
       run: |
         make upgrade-e2e


### PR DESCRIPTION
Backport of #714 on release-0.11.

#714: Increase inotify settings in E2E/upgrade GHAs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.