### PR TITLE
Use Buildah to build and release images

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -1,0 +1,20 @@
+---
+name: Multi-arch builds
+
+on:
+  pull_request:
+
+jobs:
+  apply-suggestions-commits:
+    name: Check the multi-arch builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+      - name: Build the multi-arch images
+        run: make multiarch-images

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BASE_BRANCH ?= devel
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
-NON_DAPPER_GOALS += images
+MULTIARCH_IMAGES ?= nettest
+PLATFORMS ?= linux/amd64,linux/arm64
+NON_DAPPER_GOALS += images multiarch-images
 SHELLCHECK_ARGS := scripts/shared/lib/*
 FOCUS ?=
 SKIP ?=

--- a/Makefile.images
+++ b/Makefile.images
@@ -27,8 +27,14 @@ package/.image.%: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_imag
 # Default target to build images based on IMAGES variable
 images: $(foreach image,$(IMAGES),package/.image.$(image))
 
+# [multiarch-images] builds all multi-arch container images
+# Default target to build images based on the MULTIARCH_IMAGES variable
+# Default platforms based on the PLATFORMS variable
+multiarch-images: IMAGES_ARGS += --platform $(PLATFORMS)
+multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/.image.$(image))
+
 # [release-images] uploads the project's images to a public repository
-release-images:
+release-images: multiarch-images images
 	$(SCRIPTS_DIR)/release_images.sh $(IMAGES) $(RELEASE_ARGS)
 
-.PHONY: images release-images
+.PHONY: images multiarch-images release-images

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -90,10 +90,10 @@ export GO
 # Shipyard provided targets
 
 ##### CLEANING TARGETS #####
-.PHONY: clean clean-clusters clean-generated clean-buildx
+.PHONY: clean clean-clusters clean-generated
 
 # [clean] cleans everything (running clusters, generated files ...)
-clean: clean-clusters clean-generated clean-buildx
+clean: clean-clusters clean-generated
 
 # [clean-generated] removes files we generated
 clean-generated:
@@ -103,12 +103,6 @@ clean-generated:
 clean-clusters:
 	$(SCRIPTS_DIR)/cleanup.sh $(CLEANUP_ARGS)
 cleanup: clean-clusters
-
-# [clean-buildx] removes the buildx builder, if any
-clean-buildx:
-	docker buildx version > /dev/null 2>&1 && \
-	docker buildx use buildx_builder > /dev/null 2>&1 && \
-	docker buildx rm
 
 ##### DEPLOYMENT& TESTING TARGETS #####
 .PHONY: clusters preload-images deploy e2e upgrade-e2e deploy-latest

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -14,15 +14,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      env:
-        IMAGES_ARGS: --nocache ${{ inputs.image_args }}
-      run: |
-        echo "::group::Build new images"
-        make images
-        echo "::endgroup::"
-
-    - name: Release newly built images
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+    - name: Build and release images
       shell: bash
       env:
         QUAY_USERNAME: ${{ inputs.username }}

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -13,6 +13,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # Requirements:
 # Component        | Usage
 # -------------------------------------------------------------
+# buildah          | container image construction
 # curl             | download other tools
 # findutils        | make unit (find unit test dirs)
 # gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
@@ -28,7 +29,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # kubectl          | e2e tests (in kubernetes-client)
 # make             | OLM installation
 # markdownlint     | Markdown linting
-# moby-engine      | Dapper (Docker)
+# moby-engine      | Docker (for Dapper)
 # npm              | Required for installing markdownlint
 # qemu-user-static | Emulation (for multiarch builds)
 # ShellCheck       | shell script linting
@@ -39,7 +40,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
-                   gcc git-core curl moby-engine make golang kubernetes-client \
+                   gcc git-core curl buildah moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
                    qemu-user-static python3-pip && \
     npm install -g markdownlint-cli && \
@@ -55,7 +56,6 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.43.0 \
     HELM_VERSION=v3.7.1 \
     KIND_VERSION=v0.11.1 \
-    BUILDX_VERSION=v0.7.1 \
     GH_VERSION=2.2.0 \
     YQ_VERSION=4.14.1
 
@@ -66,9 +66,6 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
     GOFLAGS="" go get -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
-    mkdir -p ~/.docker/cli-plugins && \
-    curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \
-    chmod 755 ~/.docker/cli-plugins/docker-buildx && \
     curl -L https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${ARCH}.tar.gz | tar xzf - && \
     mv gh_${GH_VERSION}_linux_${ARCH}/bin/gh /go/bin/ && \
     rm -rf gh_${GH_VERSION}_linux_${ARCH} && \

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -2,15 +2,13 @@
 
 ## Process command line flags ##
 
-default_platform=linux/amd64
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' "${DEV_VERSION}" "Tag to set for the local image"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to use for the image"
 DEFINE_string 'image' '' "Image name to build" 'i'
 DEFINE_string 'dockerfile' '' "Dockerfile to build from" 'f'
 DEFINE_string 'buildargs' '' "Build arguments to pass to 'docker build'"
-DEFINE_boolean 'cache' true "Use cached layers from latest image"
-DEFINE_string 'platform' "${default_platform}" 'Platforms to target'
+DEFINE_string 'platform' '' 'Platforms to target'
 DEFINE_string 'hash' '' "File to write the hash to" 'h'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
@@ -22,7 +20,6 @@ dockerfile="${FLAGS_dockerfile}"
 buildargs="${FLAGS_buildargs}"
 platform="${FLAGS_platform}"
 hashfile="${FLAGS_hash}"
-[[ "${FLAGS_cache}" = "${FLAGS_TRUE}" ]] && cache=true || cache=false
 
 [[ -n "${image}" ]] || { echo "The image to build must be specified!"; exit 1; }
 [[ -n "${dockerfile}" ]] || { echo "The dockerfile to build from must be specified!"; exit 1; }
@@ -34,30 +31,41 @@ set -e
 local_image=${repo}/${image}:${tag}
 cache_image=${repo}/${image}:${CUTTING_EDGE}
 
-# When using cache pull latest image from the repo, so that it's layers may be reused.
-cache_flag=''
-if [[ "$cache" = true ]]; then
-    cache_flag="--cache-from ${cache_image}"
-    if [[ -z "$(docker image ls -q ${cache_image})" ]]; then
-        docker pull ${cache_image} || :
-    fi
-    for parent in $(grep FROM ${dockerfile} | cut -f2 -d' ' | grep -v scratch); do
-        cache_flag+=" --cache-from ${parent}"
-        docker pull ${parent} || :
-    done
-fi
+# We always use manifest builds
+buildah manifest rm "${image}" || :
+buildah manifest create "${image}" || :
 
-# Rebuild the image to update any changed layers and tag it back so it will be used.
-buildargs_flag="--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_BRANCH=${BASE_BRANCH}"
+buildargs_flag="--build-arg BASE_BRANCH=${BASE_BRANCH}"
 [[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} --build-arg ${buildargs}"
-if docker buildx version > /dev/null 2>&1; then
-    docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
-    docker buildx build --load -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" --platform ${platform} ${buildargs_flag} .
+
+# Default to linux/amd64 (for CI); Buildah platforms match Go OS/arch
+if command -v "${GO:-go}" >/dev/null; then
+    default_platform="$(${GO:-go} env GOOS)/$(${GO:-go} env GOARCH)"
 else
-    # Fall back to plain BuildKit
-    if [[ "${platform}" != "${default_platform}" ]]; then
-        echo "WARNING: buildx isn't available, cross-arch builds won't work as expected"
-    fi
-    DOCKER_BUILDKIT=1 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" ${buildargs_flag} .
+    echo Unable to determine default container image platform, assuming linux/amd64
+    default_platform=linux/amd64
 fi
-docker tag ${local_image} ${cache_image}
+[[ -n "$platform" ]] || platform="$default_platform"
+
+OIFS="$IFS"; IFS=,; platforms=($platform); IFS="$OIFS"
+for p in "${platforms[@]}"; do
+    # We need to manually specify TARGETPLATFORM
+    # See https://github.com/containers/buildah/issues/1368 (closed but not actually fixed)
+    buildah bud --tag "${local_image}" \
+                --manifest "${image}" \
+                --file "${dockerfile}" \
+                --iidfile "${hashfile}.${p/\//-}" \
+                --platform "${p}" \
+                ${buildargs_flag} \
+                --build-arg TARGETPLATFORM=${p} \
+                .
+    
+    # Make images matching the local platform available to Docker, and link their hashfile
+    if [ "$p" = "$default_platform" ]; then
+        ln -sf "${hashfile}.${p/\//-}" "${hashfile}"
+        buildah push ${local_image} docker-daemon:${local_image} || :
+        buildah push ${local_image} docker-daemon:${cache_image} || :
+    fi
+done
+
+buildah tag ${local_image} ${cache_image}

--- a/scripts/shared/release_images.sh
+++ b/scripts/shared/release_images.sh
@@ -23,15 +23,15 @@ source ${SCRIPTS_DIR}/lib/debug_functions
 
 function release_image() {
     local image=$1
+    local manifest=${image##*/}
 
     for target_tag in $VERSION $release_tag; do
         local target_image="${image}:${target_tag#v}"
-        docker tag ${image}:${DEV_VERSION} ${target_image}
-        docker push ${target_image}
+	    buildah manifest push --all ${manifest} docker://${target_image}
     done
 }
 
-echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
+echo "$QUAY_PASSWORD" | buildah login -u "$QUAY_USERNAME" --password-stdin quay.io
 for image in "$@"; do
     release_image ${repo}/${image}
 done


### PR DESCRIPTION
This replaces Docker buildx, inside the Dapper image for now.
Multi-arch builds are supported using manifests.

The default platform is now the runtime platform, rather than
"linux/amd64"; this should make it simpler to build local images for
local consumption on ARM systems in particular.

The containerd and selinux* packages are no longer installed, so we no
longer need to remove them. Explicitly installing nodejs means we can
also remove npm and python3-pip using dnf.

Multiarch images need to be explicitly declared as such, since some
images (e.g. shipyard-linting) can't be built on all arches.

Depends on https://github.com/submariner-io/submariner/pull/1676

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
