### PR TITLE
Build multi-arch images with buildx

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -1,0 +1,19 @@
+---
+name: Multi-arch builds
+
+on:
+  pull_request:
+
+jobs:
+  apply-suggestions-commits:
+    name: Check the multi-arch builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - name: Set up QEMU (to support building on non-native architectures)
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+      - name: Build the multi-arch images
+        run: make multiarch-images

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 BASE_BRANCH ?= devel
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
-NON_DAPPER_GOALS += images
+MULTIARCH_IMAGES ?= nettest
+PLATFORMS ?= linux/amd64,linux/arm64
+NON_DAPPER_GOALS += images multiarch-images
 SHELLCHECK_ARGS := scripts/shared/lib/*
 FOCUS ?=
 SKIP ?=

--- a/Makefile.images
+++ b/Makefile.images
@@ -23,12 +23,24 @@ docker_deps = $(shell files=($(1) $$(awk '/COPY/ && substr($$2, 1, 7) != "--from
 package/.image.%: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_image_rebuild,$$*)
 	$(SCRIPTS_DIR)/build_image.sh -i $(lastword $(subst ., ,$@)) -f $< -h $@ $(IMAGES_ARGS)
 
+# Build an OCI tarball from a Dockerfile
+.SECONDEXPANSION:
+package/%.tar: $$(call docker_deps,package/Dockerfile.$$*) $$(call force_image_rebuid,$$*)
+	image=$(firstword $(subst ., ,$(@F))) && \
+	$(SCRIPTS_DIR)/build_image.sh -i $$image -f $< --oci $@ -h package/.image.$$image $(IMAGES_ARGS)
+
 # [images] builds all the container images for the project
 # Default target to build images based on IMAGES variable
 images: $(foreach image,$(IMAGES),package/.image.$(image))
+
+# [multiarch-images] builds all multi-arch container images
+# Default target to build images based on the MULTIARCH_IMAGES variable
+# Default platforms based on the PLATFORMS variable
+multiarch-images: override IMAGES_ARGS += --platform $(PLATFORMS)
+multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/$(image).tar)
 
 # [release-images] uploads the project's images to a public repository
 release-images:
 	$(SCRIPTS_DIR)/release_images.sh $(IMAGES) $(RELEASE_ARGS)
 
-.PHONY: images release-images
+.PHONY: images multiarch-images release-images

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -28,7 +28,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # kubectl          | e2e tests (in kubernetes-client)
 # make             | OLM installation
 # markdownlint     | Markdown linting
-# moby-engine      | Dapper (Docker)
+# moby-engine      | Docker (for Dapper)
 # npm              | Required for installing markdownlint
 # qemu-user-static | Emulation (for multiarch builds)
 # ShellCheck       | shell script linting

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -2,7 +2,6 @@
 
 ## Process command line flags ##
 
-default_platform=linux/amd64
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' "${DEV_VERSION}" "Tag to set for the local image"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to use for the image"
@@ -10,8 +9,9 @@ DEFINE_string 'image' '' "Image name to build" 'i'
 DEFINE_string 'dockerfile' '' "Dockerfile to build from" 'f'
 DEFINE_string 'buildargs' '' "Build arguments to pass to 'docker build'"
 DEFINE_boolean 'cache' true "Use cached layers from latest image"
-DEFINE_string 'platform' "${default_platform}" 'Platforms to target'
+DEFINE_string 'platform' '' 'Platforms to target'
 DEFINE_string 'hash' '' "File to write the hash to" 'h'
+DEFINE_string 'oci' '' 'File to write an OCI tarball to instead of an image in the local registry'
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
@@ -22,11 +22,16 @@ dockerfile="${FLAGS_dockerfile}"
 buildargs="${FLAGS_buildargs}"
 platform="${FLAGS_platform}"
 hashfile="${FLAGS_hash}"
+ocifile="${FLAGS_oci}"
 [[ "${FLAGS_cache}" = "${FLAGS_TRUE}" ]] && cache=true || cache=false
 
 [[ -n "${image}" ]] || { echo "The image to build must be specified!"; exit 1; }
 [[ -n "${dockerfile}" ]] || { echo "The dockerfile to build from must be specified!"; exit 1; }
 [[ -n "${hashfile}" ]] || { echo "The file to write the hash to must be specified!"; exit 1; }
+if [[ "${platform}" =~ , && -z "${ocifile}" ]]; then
+    echo Multi-arch builds require OCI output, please specify --oci
+    exit 1
+fi
 
 source ${SCRIPTS_DIR}/lib/debug_functions
 set -e
@@ -34,7 +39,7 @@ set -e
 local_image=${repo}/${image}:${tag}
 cache_image=${repo}/${image}:${CUTTING_EDGE}
 
-# When using cache pull latest image from the repo, so that it's layers may be reused.
+# When using cache pull latest image from the repo, so that its layers may be reused.
 cache_flag=''
 if [[ "$cache" = true ]]; then
     cache_flag="--cache-from ${cache_image}"
@@ -56,12 +61,24 @@ if [[ "$cache" = true ]]; then
     done
 fi
 
+output_flag=--load
+[[ -z "${ocifile}" ]] || output_flag="--output=type=oci,dest=${ocifile}"
+
+# Default to linux/amd64 (for CI); platforms match Go OS/arch
+if command -v "${GO:-go}" >/dev/null; then
+    default_platform="$(${GO:-go} env GOOS)/$(${GO:-go} env GOARCH)"
+else
+    echo Unable to determine default container image platform, assuming linux/amd64
+    default_platform=linux/amd64
+fi
+[[ -n "$platform" ]] || platform="$default_platform"
+
 # Rebuild the image to update any changed layers and tag it back so it will be used.
 buildargs_flag="--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_BRANCH=${BASE_BRANCH}"
 [[ -z "${buildargs}" ]] || buildargs_flag="${buildargs_flag} --build-arg ${buildargs}"
 if docker buildx version > /dev/null 2>&1; then
     docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
-    docker buildx build --load -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" --platform ${platform} ${buildargs_flag} .
+    docker buildx build ${output_flag} -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" --platform ${platform} ${buildargs_flag} .
 else
     # Fall back to plain BuildKit
     if [[ "${platform}" != "${default_platform}" ]]; then
@@ -69,4 +86,6 @@ else
     fi
     DOCKER_BUILDKIT=1 docker build -t ${local_image} ${cache_flag} -f ${dockerfile} --iidfile "${hashfile}" ${buildargs_flag} .
 fi
-docker tag ${local_image} ${cache_image}
+
+# We can only tag the image in non-OCI mode
+[[ -n "${ocifile}" ]] || docker tag ${local_image} ${cache_image}


### PR DESCRIPTION
The default platform is now the runtime platform, rather than
"linux/amd64"; this should make it simpler to build local images for
local consumption on ARM systems in particular.

Multiarch images need to be explicitly declared as such, since some
images (e.g. shipyard-linting) can't be built on all arches.

This currently relies on emulating each target architecture, using
QEMU. Some builds will be able to use cross-compilation only instead,
that will come later.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
