### PR TITLE
Release multi-arch images

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -41,6 +41,7 @@ multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/$(image).tar)
 
 # [release-images] uploads the project's images to a public repository
 release-images:
-	$(SCRIPTS_DIR)/release_images.sh $(IMAGES) $(RELEASE_ARGS)
+	$(SCRIPTS_DIR)/release_images.sh $(filter-out $(MULTIARCH_IMAGES),$(IMAGES)) $(RELEASE_ARGS)
+	$(SCRIPTS_DIR)/release_images.sh --oci package/ $(MULTIARCH_IMAGES) $(RELEASE_ARGS)
 
 .PHONY: images multiarch-images release-images

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -14,14 +14,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - shell: bash
+    - name: Set up QEMU (to support building on non-native architectures)
+      uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+    - name: Set up buildx
+      uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+    - name: Build new images
+      # This needs to be kept separate so that the release stage runs using the new Shipyard base image
+      shell: bash
       env:
         IMAGES_ARGS: --nocache ${{ inputs.image_args }}
       run: |
         echo "::group::Build new images"
-        make images
+        make images multiarch-images
         echo "::endgroup::"
-
     - name: Release newly built images
       shell: bash
       env:

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -32,6 +32,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 # npm              | Required for installing markdownlint
 # qemu-user-static | Emulation (for multiarch builds)
 # ShellCheck       | shell script linting
+# skopeo           | container image manipulation
 # subctl *         | Submariner's deploy tool (operator)
 # upx              | binary compression
 # yamllint         | YAML linting
@@ -41,7 +42,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/usr/loc
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq ShellCheck npm gitlint yamllint \
-                   qemu-user-static python3-pip && \
+                   qemu-user-static python3-pip skopeo && \
     npm install -g markdownlint-cli && \
     pip install j2cli[yaml] --user && \
     rpm -e --nodeps containerd npm python3-pip && \

--- a/scripts/shared/release_images.sh
+++ b/scripts/shared/release_images.sh
@@ -5,12 +5,14 @@
 source ${SCRIPTS_DIR}/lib/shflags
 DEFINE_string 'tag' "${CUTTING_EDGE}" "Additional tag(s) to use for the image (prefix 'v' will be stripped)"
 DEFINE_string 'repo' 'quay.io/submariner' "Quay.io repo to deploy to"
-FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] image [image ...]"
+DEFINE_string 'oci' '' 'Directory containing OCI images (for multi-arch pushes)'
+FLAGS_HELP="USAGE: $0 [--tag v1.2.3] [--repo quay.io/myrepo] [--oci package] image [image ...]"
 FLAGS "$@" || exit $?
 eval set -- "${FLAGS_ARGV}"
 
 release_tag="${FLAGS_tag}"
 repo="${FLAGS_repo}"
+oci="${FLAGS_oci}"
 
 if [[ $# == 0 ]]; then
     echo "At least one image to release must be specified!"
@@ -26,13 +28,18 @@ function release_image() {
 
     for target_tag in $VERSION $release_tag; do
         local target_image="${image}:${target_tag#v}"
-        docker tag ${image}:${DEV_VERSION} ${target_image}
-        docker push ${target_image}
+        if [[ -z "${oci}" ]]; then
+            # Single-arch
+            skopeo copy docker-daemon:${repo}/${image}:${DEV_VERSION} docker://${repo}/${target_image}
+        else
+            skopeo copy --all oci-archive:${oci}/${image}.tar docker://${repo}/${target_image}
+        fi
     done
 }
 
-echo "$QUAY_PASSWORD" | docker login quay.io -u "$QUAY_USERNAME" --password-stdin
-for image in "$@"; do
-    release_image ${repo}/${image}
+echo "$QUAY_PASSWORD" | skopeo login quay.io -u "$QUAY_USERNAME" --password-stdin
+
+for image; do
+    release_image ${image}
 done
 


### PR DESCRIPTION
This involves using Skopeo since buildx can't push multi-arch images
except as part of a build.

Depends on #721

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
