### PR TITLE
Automated backport of #718: Refactor inotify E2E GHA step to be more standard

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -56,9 +56,11 @@ runs:
         free -h
         echo "::endgroup::"
 
-    - name: Set up kernel, increase the inotify settings
-      shell: bash
-      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+    - shell: bash
+      run: |
+        echo "::group::Increase inotify settings"
+        sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+        echo "::endgroup::"
 
     - name: Install WireGuard specific modules
       shell: bash

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -24,9 +24,11 @@ runs:
         free -h
         echo "::endgroup::"
 
-    - name: Set up kernel, increase the inotify settings
-      shell: bash
-      run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+    - shell: bash
+      run: |
+        echo "::group::Increase inotify settings"
+        sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
+        echo "::endgroup::"
 
     - shell: bash
       run: |


### PR DESCRIPTION
Backport of #718 on release-0.11.

#718: Refactor inotify E2E GHA step to be more standard

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.