### PR TITLE
Mount ~/.docker/config.json in Dapper containers

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -100,6 +100,7 @@ fi
 docker run -i --rm --security-opt seccomp=unconfined \
        $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" \
        -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" \
+       -v "${HOME}/.docker/config.json:/root/.docker/config.json${suffix}" \
        ${dockerargs} \
        ${DAPPER_RUN_ARGS} \
        "${container}" "$@"

--- a/.dapper
+++ b/.dapper
@@ -97,4 +97,9 @@ fi
 # See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
 # Remove "--security-opt seccomp=unconfined" once all supported container runtimes
 # handle clone3
-docker run -i --rm --security-opt seccomp=unconfined $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" ${dockerargs} ${DAPPER_RUN_ARGS} "${container}" "$@"
+docker run -i --rm --security-opt seccomp=unconfined \
+       $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" \
+       -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" \
+       ${dockerargs} \
+       ${DAPPER_RUN_ARGS} \
+       "${container}" "$@"


### PR DESCRIPTION
This passes through authentication tokens, e.g. for Docker Hub or
Quay. This avoids having to try "docker login" inside the running
containers.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
