### PR TITLE
Reinstall .shflags if it's empty

### DIFF
--- a/scripts/shared/lib/shflags
+++ b/scripts/shared/lib/shflags
@@ -4,13 +4,14 @@
 
 ensure_shflags() {
     if [ -f /usr/share/shflags/shflags ]; then
-	. /usr/share/shflags/shflags
-	return
+      . /usr/share/shflags/shflags
+      return
     fi
 
-    if [ ! -f .shflags ]; then
+    if [ ! -s .shflags ]; then
         echo "Downloading shflags ${SHFLAGS_VERSION}"
         if ! curl -L "https://raw.githubusercontent.com/kward/shflags/${SHFLAGS_VERSION}/src/shflags" > .shflags; then
+            rm -f .shflags
             echo "$0 needs shflags in /usr/share/shflags/shflags or locally as .shflags." 1>&2
             echo "It was unable to download it; please install it and try again." 1>&2
             exit 1


### PR DESCRIPTION
We currently download and install .shflags if it's missing from the root
of a repo that uses Shipyard. This will cause us to additionally
reinstall .shflags if the file exists but is empty and clean up
.shflags if an attempt to update it fails.

If .shflags is empty, almost all Shipyard commands fail with cryptic
errors about failing to be able to source vars.

The .shflags file does actually end up empty if something is wrong with
container networking on a dev's computer. The very first steps of all
Shipyard shared scripts include sourcing the lib that first makes these
shell features available, so it's basically the first network usage from
our shared dev env. If networking ever fails, .shflags will be
overwritten and made empty, and without this change it will keep causing
failures even after networking is fixed.

Container networking can fail while still being able to run containers.
My docker daemon sometimes fails the following test after running for a
long time. I've been seeing this bug for most of the life of Submariner,
across two laptops.

docker run --rm alpine sh -c 'wget -q -O- https://docs.docker.com \
  | grep "<title"'

Container networking starts working again after `sudo systemctl restart
docker` or restarting my computer.

Also switch some tabs to spaces for consistency. Raised #731 to track
adding linting to prevent mixed tabs/spaces in shell scripts.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
