### PR TITLE
Test all Shipyard consumers in consuming-lint|unit

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
+        project: ['admiral', 'cloud-prepare', 'coastguard', 'lighthouse', 'submariner', 'submariner-charts', 'submariner-operator']
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ['admiral', 'submariner', 'submariner-operator', 'lighthouse']
+        project: ['admiral', 'cloud-prepare', 'coastguard', 'lighthouse', 'submariner', 'submariner-charts', 'submariner-operator']
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f


### PR DESCRIPTION
Include all projects that consume Shipyard in the jobs that are meant to
run linting or unit tests against projects that consume Shipyard.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
