### PR TITLE
Run all linter make targets in `make lint` alias

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -177,7 +177,7 @@ packagedoc-lint:
 	done 2>/dev/null; \
 	exit $$result
 
-lint: gitlint golangci-lint markdownlint yamllint
+lint: gitlint golangci-lint markdownlint packagedoc-lint shellcheck yamllint
 
 # [markdownlint] validates Markdown files in the project
 markdownlint:


### PR DESCRIPTION
Run all linters that can be run via make in the `make lint` make target,
which is meant to be an alias to run all linters.

This will cause more linters to be run in Shipyard's consuming-lint
tests, but other CI will not change as they invoke linters directly.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
