### PR TITLE
Mount ~/.docker in its entirety

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -93,6 +93,12 @@ if docker 2>&1 | grep -q podman; then
   DAPPER_GID=0
 fi
 
+# Pass through ~/.docker so that the container can get any authentication tokens in ~/.docker/config.json
+# We can't mount config.json specifically because "docker login" attempts to rename it, which fails
+if [ -d "${HOME}/.docker" ]; then
+    dockerargs="${dockerargs} -v ${HOME}/.docker:/root/.docker${suffix}"
+fi
+
 # seccomp is unconfined to avoid problems with clone3 in Fedora 35
 # See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
 # Remove "--security-opt seccomp=unconfined" once all supported container runtimes
@@ -100,7 +106,6 @@ fi
 docker run -i --rm --security-opt seccomp=unconfined \
        $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" \
        -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" \
-       -v "${HOME}/.docker/config.json:/root/.docker/config.json${suffix}" \
        ${dockerargs} \
        ${DAPPER_RUN_ARGS} \
        "${container}" "$@"


### PR DESCRIPTION
Mounting ~/.docker/config.json specifically means that it can't be
renamed; and "docker login" tries to rename it, which fails. See
https://github.com/submariner-io/shipyard/runs/5361789965 for one
example.

Instead, this mounts ~/.docker, and only does so if ~/.docker actually
exists.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
