### PR TITLE
Make golangci-lint a no-op if unconfigured

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -165,8 +165,12 @@ VENDOR_MODULES := $(shell find . -name vendor -prune -o -name go.mod -printf "%h
 
 # [golangci-lint] validates Go code in the project
 golangci-lint: $(VENDOR_MODULES)
+ifneq (,$(shell find . -name '*.go'))
 	golangci-lint linters
 	golangci-lint run --timeout 10m
+else
+	@echo 'There are no Go files to lint.'
+endif
 
 # [packagedoc-lint] checks that the package docs don’t include the SPDX header
 packagedoc-lint:


### PR DESCRIPTION
golangci-lint only make sense in projects with Go files; attempting to
run it on projects without any Go content causes errors. This turns
"make golangci-lint" into a no-op if there are no Go files to process.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
