### PR TITLE
Drop the bundle and OCM deployment tests

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         globalnet: ['', 'globalnet']
-        deploytool: ['operator', 'helm', 'bundle', 'ocm']
+        deploytool: ['operator', 'helm']
         lighthouse: ['']
         ovn: ['']
         include:
@@ -52,17 +52,7 @@ jobs:
             lighthouse: lighthouse
           - deploytool: helm
             lighthouse: lighthouse
-          - deploytool: bundle
-            lighthouse: lighthouse
-        exclude:
-          # OCM does not support globalnet at this moment
-          - deploytool: ocm
-            globalnet: globalnet
     steps:
-      - name: Set up kernel, increase the inotify settings
-        if: ${{ matrix.deploytool == 'bundle' || matrix.deploytool == 'ocm' }}
-        run: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512
-
       - name: Reclaim space on GHA host (if the job needs it)
         if: ${{ matrix.ovn != '' }}
         run: rm -rf /usr/share/dotnet


### PR DESCRIPTION
These are currently broken, and as discussed in today's development
meeting, should be dropped. They will be restored once bundle
construction is fixed (as part of the planned Operator SDK upgrade).

Fixes: #717
Signed-off-by: Stephen Kitt <skitt@redhat.com>
(cherry picked from commit bcc10c5a76691b131690a0ebae4e90320b9fe4d8)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
