### PR TITLE
Include cloud-prepare in `make prune-images`

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -57,7 +57,7 @@ $(LINTING_GOALS): .dapper $(LINTING_DAPPER)
 # Copied from Makefile to provide this everywhere (until we can share
 # non-Dapper goals across projects)
 prune-images:
-	docker images | grep -E '(admiral|coastguard|lighthouse|nettest|shipyard|submariner|<none>)' | while read image tag hash _; do \
+	docker images | grep -E '(admiral|cloud-prepare|coastguard|lighthouse|nettest|shipyard|submariner|<none>)' | while read image tag hash _; do \
 	    if [ "$$tag" != "<none>" ]; then \
 	        docker rmi $$image:$$tag; \
 	    else \


### PR DESCRIPTION
Delete cloud-prepare container images in the helper command meant to
delete all Submariner container images. Cloud prepare does produce
images (demo: `make shell`/`docker images`), so this fixes the ~bug of
the leftover images.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
