### PR TITLE
Add JUnit report generation to "subctl verify"

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -91,5 +91,10 @@ func RunE2ETests(t *testing.T) bool {
 		config.DefaultReporterConfig.SlowSpecThreshold = 45.0
 	}
 
+	// Set junit report path and filename if required by user
+	// The default of the parameter is set to empty, so if not used
+	// creation of report will be skipped
+	config.DefaultReporterConfig.ReportFile = framework.TestContext.JunitReport
+
 	return ginkgo.RunSpecs(t, "Submariner E2E suite")
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -35,8 +35,7 @@ type TestContextType struct {
 	KubeContexts        contextArray
 	ClusterIDs          []string
 	NumNodesInCluster   map[ClusterIndex]int
-	ReportDir           string
-	ReportPrefix        string
+	JunitReport         string
 	SubmarinerNamespace string
 	ConnectionTimeout   uint
 	ConnectionAttempts  uint
@@ -65,10 +64,8 @@ func init() {
 	flag.StringVar(&TestContext.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to kubeconfig containing embedded authinfo.")
 	flag.Var(&TestContext.KubeContexts, "dp-context", "kubeconfig context for dataplane clusters (use several times).")
-	flag.StringVar(&TestContext.ReportPrefix, "report-prefix", "",
-		"Optional prefix for JUnit XML reports. Default is empty, which doesn't prepend anything to the default name.")
-	flag.StringVar(&TestContext.ReportDir, "report-dir", "",
-		"Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
+	flag.StringVar(&TestContext.JunitReport, "junit-report", "",
+		"Path to the directory and filename of the JUnit XML report. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner",
 		"Namespace in which the submariner components are deployed.")
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18,


### PR DESCRIPTION
The E2E tests should be able to generate report at the end of the
execution.
After the following ginkgo patch - [1], creation of the test directory
(if required) and generation of the report handled by ginkgo after the
input parameters such as directory and file name.

Replacing existing parameters which are no longer working after the
following patch - [2].

[1] - https://github.com/onsi/ginkgo/pull/601
[2] - https://github.com/submariner-io/shipyard/pull/216

Depends On: https://github.com/submariner-io/submariner-operator/pull/1961

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>