### PR TITLE
Stop trying to set colour codes

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -41,7 +41,6 @@ source ${SCRIPTS_DIR}/lib/deploy_funcs
 ### Constants ###
 readonly CE_IPSEC_IKEPORT=500
 readonly CE_IPSEC_NATTPORT=4500
-readonly SUBM_COLORCODES=blue
 readonly SUBM_IMAGE_REPO=localhost:5000
 readonly SUBM_IMAGE_TAG=${image_tag:-local}
 readonly SUBM_CS="submariner-catalog-source"

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -69,7 +69,6 @@ function subctl_install_subm() {
                 ${subctlrepver} \
                 --nattport "${CE_IPSEC_NATTPORT}" \
                 --ikeport "${CE_IPSEC_IKEPORT}" \
-                --colorcodes "${SUBM_COLORCODES}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \
                 --natt=false \
                 --cable-driver "${cable_driver}" \

--- a/scripts/shared/resources/bundle/submariner.yaml
+++ b/scripts/shared/resources/bundle/submariner.yaml
@@ -9,7 +9,6 @@ spec:
   clusterCIDR: "${cluster_CIDRs[$cluster]}"
   globalCIDR: "${global_CIDRs[$cluster]}"
   clusterID: "${cluster}"
-  colorCodes: "${SUBM_COLORCODES}"
   debug: false
   natEnabled: false
   serviceDiscoveryEnabled: ${service_discovery}


### PR DESCRIPTION
The --colorcodes option is deprecated and is being removed.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
