### PR TITLE
Set up the multi-active-gw branch

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -56,7 +56,7 @@ gitid="$(git symbolic-ref --short HEAD 2>/dev/null | tr / _ || :)"
 gitid="${gitid:-$(git show --format=%h -s)}"
 container="$(basename "$(pwd)"):${gitid}"
 docker build -t "${container}" -f "${file}" \
-       --build-arg "BASE_BRANCH=${BASE_BRANCH:-devel}" \
+       --build-arg "BASE_BRANCH=${BASE_BRANCH:-feature-multi-active-gw}" \
        --build-arg "PROJECT=${PROJECT}" \
        .
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -9,6 +9,6 @@ jobs:
     name: PR targets branch
     runs-on: ubuntu-latest
     steps:
-      - name: Check that the PR targets devel
-        if: ${{ github.base_ref != 'devel' }}
+      - name: Check that the PR targets multi-active-gw
+        if: ${{ github.base_ref != 'feature-multi-active-gw' }}
         run: exit 1

--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           # This is replaced to stable branch by auto release process
-          ref: devel
+          ref: feature-multi-active-gw
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           # This is replaced to stable branch by auto release process
-          ref: devel
+          ref: feature-multi-active-gw
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
         with:
           # This is replaced to stable branch by auto release process
-          ref: devel
+          ref: feature-multi-active-gw
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release Images
 on:
   push:
     branches:
-      - devel
+      - feature-multi-active-gw
       - release-*
 
 jobs:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # Auto-generated, do not edit; see CODEOWNERS.in
-* @Oats87 @skitt @sridhargaddam @tpantelis
-*.md @dfarrell07 @Oats87 @skitt @sridhargaddam @tpantelis
-/.github/workflows/ @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis
-/scripts/ @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis
-Dockerfile.dapper @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis
-Makefile* @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis
-package/ @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis
+* @anfredette @astoycos @Billy99 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+*.md @anfredette @astoycos @Billy99 @dfarrell07 @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+/.github/workflows/ @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+/scripts/ @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+Dockerfile.dapper @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+Makefile* @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis
+package/ @anfredette @astoycos @Billy99 @mkolesnik @nerdalert @Oats87 @skitt @sridhargaddam @tpantelis

--- a/CODEOWNERS.in
+++ b/CODEOWNERS.in
@@ -1,6 +1,13 @@
+# Core Submariner codeowners
 @dfarrell07 *.md
 @mkolesnik /.github/workflows/ /scripts/ Makefile* Dockerfile.dapper package/
 @Oats87 *
 @skitt *
 @sridhargaddam *
 @tpantelis *
+
+# Feature branch codeowners
+@anfredette *
+@astoycos *
+@Billy99 *
+@nerdalert *

--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -1,4 +1,4 @@
-FROM quay.io/submariner/shipyard-linting:devel
+FROM quay.io/submariner/shipyard-linting:feature-multi-active-gw
 
 ENV DAPPER_ENV="GITHUB_SHA MAKEFLAGS" \
     DAPPER_SOURCE=/opt/linting

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_BRANCH ?= devel
+BASE_BRANCH ?= feature-multi-active-gw
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 MULTIARCH_IMAGES ?= nettest

--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,5 +1,5 @@
 # Calculate versions; these can be overridden
-CUTTING_EDGE := devel
+CUTTING_EDGE := feature-multi-active-gw
 DEV_VERSION := dev
 override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short HEAD)
 VERSION ?= $(CALCULATED_VERSION)

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Dockerfile should build upon `quay.io/submariner/shipyard-dapper-base`.
 For example, this very basic file allows E2E testing:
 
 ```Dockerfile
-FROM quay.io/submariner/shipyard-dapper-base:devel
+FROM quay.io/submariner/shipyard-dapper-base:feature-multi-active-gw
 
 ENV DAPPER_SOURCE=/go/src/github.com/submariner-io/submariner DAPPER_DOCKER_SOCKET=true
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
@@ -51,7 +51,7 @@ To use Shipyard's target, simply include the [Makefile.inc](Makefile.inc) file i
 The simplest Makefile would look like this:
 
 ```Makefile
-BASE_BRANCH=devel
+BASE_BRANCH=feature-multi-active-gw
 PROJECT=shipyard
 export BASE_BRANCH
 export PROJECT

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -255,7 +255,7 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 			Containers: []v1.Container{
 				{
 					Name:  "tcp-check-listener",
-					Image: "quay.io/submariner/nettest:devel",
+					Image: "quay.io/submariner/nettest:feature-multi-active-gw",
 					// We send the string 50 times to put more pressure on the TCP connection and avoid limited
 					// resource environments from not sending at least some data before timeout.
 					Command: []string{
@@ -303,7 +303,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 			Containers: []v1.Container{
 				{
 					Name:  "tcp-check-connector",
-					Image: "quay.io/submariner/nettest:devel",
+					Image: "quay.io/submariner/nettest:feature-multi-active-gw",
 					// We send the string 50 times to put more pressure on the TCP connection and avoid limited
 					// resource environments from not sending at least some data before timeout.
 					Command: []string{
@@ -355,7 +355,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 			Containers: []v1.Container{
 				{
 					Name:            "nettest-client-pod",
-					Image:           "quay.io/submariner/nettest:devel",
+					Image:           "quay.io/submariner/nettest:feature-multi-active-gw",
 					ImagePullPolicy: v1.PullAlways,
 					Command: []string{
 						"sh", "-c", "for i in $(seq $CONN_TRIES);" +
@@ -399,7 +399,7 @@ func (np *NetworkPod) buildThroughputServerPod() {
 			Containers: []v1.Container{
 				{
 					Name:            "nettest-server-pod",
-					Image:           "quay.io/submariner/nettest:devel",
+					Image:           "quay.io/submariner/nettest:feature-multi-active-gw",
 					ImagePullPolicy: v1.PullAlways,
 					Command:         []string{"sh", "-c", "iperf3 -s -p $TARGET_PORT"},
 					Env: []v1.EnvVar{
@@ -435,7 +435,7 @@ func (np *NetworkPod) buildLatencyClientPod() {
 			Containers: []v1.Container{
 				{
 					Name:            "latency-client-pod",
-					Image:           "quay.io/submariner/nettest:devel",
+					Image:           "quay.io/submariner/nettest:feature-multi-active-gw",
 					ImagePullPolicy: v1.PullAlways,
 					Command: []string{
 						"sh",
@@ -474,7 +474,7 @@ func (np *NetworkPod) buildLatencyServerPod() {
 			Containers: []v1.Container{
 				{
 					Name:            "latency-server-pod",
-					Image:           "quay.io/submariner/nettest:devel",
+					Image:           "quay.io/submariner/nettest:feature-multi-active-gw",
 					ImagePullPolicy: v1.PullAlways,
 					Command:         []string{"netserver", "-D"},
 				},


### PR DESCRIPTION
This sets up CODEOWNERS so that the multi-active-gateway developers
can merge PRs to this branch independently.

It also updates the branch check to enforce use of the multi-active-gw
branch, and updates branch references and image references.

See <https://github.com/submariner-io/submariner/issues/1731> for
details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
