### PR TITLE
Don't release multi-arch images if there are none

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -42,6 +42,8 @@ multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/$(image).tar)
 # [release-images] uploads the project's images to a public repository
 release-images:
 	$(SCRIPTS_DIR)/release_images.sh $(filter-out $(MULTIARCH_IMAGES),$(IMAGES)) $(RELEASE_ARGS)
+ifneq (,$(MULTIARCH_IMAGES))
 	$(SCRIPTS_DIR)/release_images.sh --oci package/ $(MULTIARCH_IMAGES) $(RELEASE_ARGS)
+endif
 
 .PHONY: images multiarch-images release-images


### PR DESCRIPTION
release-images always tries to release multi-arch images, even when
there aren't any; see
https://github.com/submariner-io/submariner-operator/runs/5831545335?check_suite_focus=true
for one instance. This doesn't break the release of existing images
but causes the job to report failure.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
