### PR TITLE
Bump to Fedora 36

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,5 +8,7 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM fedora:36
 
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.
@@ -65,8 +65,8 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
-    GOFLAGS="" go get -v github.com/onsi/ginkgo/ginkgo && \
-    GOFLAGS="" go get -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
+    GOFLAGS="" go install -v github.com/onsi/ginkgo/ginkgo@latest && \
+    GOFLAGS="" go install -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
     mkdir -p ~/.docker/cli-plugins && \
     curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o ~/.docker/cli-plugins/docker-buildx && \
     chmod 755 ~/.docker/cli-plugins/docker-buildx && \


### PR DESCRIPTION
Fedora 36 isn't quite released yet, but it provides Go 1.18, and we
need Go 1.17 for current Kubernetes dependencies (see
https://github.com/submariner-io/lighthouse/pull/658 for example).

(Fedora 35 has Go 1.16.)

Depends on #776
Depends on #802 
Depends on #803
Depends on https://github.com/submariner-io/submariner-operator/pull/2016

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
