### PR TITLE
Switch nginx container image bitnami->jitesoft

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/bitnami/nginx:latest
+          image: quay.io/jitesoft/nginx:latest
           ports:
             - containerPort: 8080
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/bitnami/nginx:latest",
+							Image:           "quay.io/jitesoft/nginx:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
The bitnami container is failing to pull. The org's name on Quay seems
to have changed, maybe as a part of bigger changes at Bitnami.

This seems to be the now-defunct image:

quay.io/repository/56401deb-7290-4d8b-8731-baf6d8b5d27d/nginx

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
