### PR TITLE
Fix Nginx Image

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/bitnami/nginx:latest
+          image: quay.io/testing-farm/nginx:latest
           ports:
-            - containerPort: 8080
+            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -30,7 +30,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
   selector:
     app: nginx-demo
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/bitnami/nginx:latest",
+							Image:           "quay.io/testing-farm/nginx:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
quay.io/bitnami/nginx:latest was removed use
quay.io/testing-farm/nginx instead since it is
just a quay.io mirror of the official docker
image.

We verified the SHAs of the containers here match
the official ones

https://quay.io/repository/testing-farm/nginx/manifest/sha256:61face6bf030edce7ef6d7dd66fe452298d6f5f7ce032afdd01683ef02b2b841

https://hub.docker.com/layers/nginx/library/nginx/latest/images/sha256-61face6bf030edce7ef6d7dd66fe452298d6f5f7ce032afdd01683ef02b2b841

Also https://gitlab.com/testing-farm/docs/root seems
to be CopyWrited/Owned by Redhat.

The new image exposes port 80 instead of 8080,
so update the `nginx-demo` service+deployment
to also reflect this.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
