### PR TITLE
Automated backport of #781: Fix Nginx Image

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/bitnami/nginx:latest
+          image: quay.io/testing-farm/nginx:latest
           ports:
-            - containerPort: 8080
+            - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -30,7 +30,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 8080
   selector:
     app: nginx-demo
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/bitnami/nginx:latest",
+							Image:           "quay.io/testing-farm/nginx:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
Backport of #781 on release-0.12.

#781: Fix Nginx Image

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.