### PR TITLE
Use openshifttest/nginx-alpine for rootless E2E

### DIFF
--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/testing-farm/nginx:latest
+          image: quay.io/openshifttest/nginx-alpine:latest
           ports:
-            - containerPort: 80
+            - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -29,7 +29,7 @@ spec:
   type: ClusterIP
   ports:
     - protocol: TCP
-      port: 80
+      port: 8080
   selector:
     app: nginx-demo
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/testing-farm/nginx:latest",
+							Image:           "quay.io/openshifttest/nginx-alpine:latest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
To fix support for running E2E tests using an nginx web server container
in OpenShift, which only allows running rootless containers.

The quay.io/bitnami/nginx image we used for a long time was rootless but
has been removed. The quay.io/testing-farm/nginx mirror of the official
nginx containers on DockerHub is not rootless. The official rootless
container nginxinc/nginx-unprivileged is on DockerHub but has no mirror
to Quay. The agnhost K8s CI tool's netexec or nettest commands might be
useful, but would require more retooling.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
