### PR TITLE
Add `simpleserver` for testing

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -24,5 +24,6 @@ RUN apk add --no-cache \
 	tcpdump
 
 COPY --from=0 /usr/local/bin/net* /usr/local/bin/
+COPY scripts/nettest/* /app/
 
 CMD ["/bin/bash","-l"]

--- a/scripts/nettest/simpleserver
+++ b/scripts/nettest/simpleserver
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+while true
+do
+    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | nc -l -p 8080
+done

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -75,7 +75,7 @@ function test_connection() {
 
 function connectivity_tests() {
     target_cluster="$1"
-    import_image quay.io/submariner/nettest
+    DEV_VERSION="${BASE_BRANCH}" import_image quay.io/submariner/nettest
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 

--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,9 +15,10 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: quay.io/testing-farm/nginx:latest
+          image: localhost:5000/nettest:local
+          command: ["/app/simpleserver"]
           ports:
-            - containerPort: 80
+            - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -30,6 +31,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
+      targetPort: 8080
   selector:
     app: nginx-demo
 ---

--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -106,14 +106,16 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/testing-farm/nginx:latest",
+							Image:           "quay.io/submariner/nettest",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: port,
 								},
 							},
-							Command: []string{},
+							Command: []string{
+								"/app/simpleserver",
+							},
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyAlways,


### PR DESCRIPTION
Instead of relying on an external webserver, we can use `nc` in a simple
wrapper script to serve a simple endpoint for our tests.

This should avoid future breakage since we're shipping it in our own
image, and it's a very simple image with simple requirements (rootless).

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
