### PR TITLE
Make sure to pull `devel` nettest image

### DIFF
--- a/test/e2e/framework/deployments.go
+++ b/test/e2e/framework/deployments.go
@@ -66,7 +66,7 @@ func (f *Framework) NewNetShootDeployment(cluster ClusterIndex) *corev1.PodList 
 					Containers: []corev1.Container{
 						{
 							Name:            "netshoot",
-							Image:           "quay.io/submariner/nettest",
+							Image:           "quay.io/submariner/nettest:devel",
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"sleep", "600",
@@ -106,7 +106,7 @@ func (f *Framework) NewNginxDeployment(cluster ClusterIndex) *corev1.PodList {
 					Containers: []corev1.Container{
 						{
 							Name:            "nginx-demo",
-							Image:           "quay.io/submariner/nettest",
+							Image:           "quay.io/submariner/nettest:devel",
 							ImagePullPolicy: corev1.PullAlways,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
The tests are pulling `latest` which is actually tagged but is very
old and unmaintained.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
