### PR TITLE
Stop augmenting versions for `deploy-latest`

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -147,7 +147,7 @@ upgrade-e2e: deploy-latest deploy e2e
 # are *not* rebuilt (we want to deploy the published images only)
 deploy-latest:
 	curl -L get.submariner.io | VERSION=latest bash
-	$(MAKE) -o images -o preload-images deploy SUBCTL=~/.local/bin/subctl DEV_VERSION=latest CUTTING_EDGE=latest VERSION=latest DEPLOY_ARGS="$(DEPLOY_ARGS) --image_tag=subctl" using=$(using)
+	$(MAKE) -o images -o preload-images deploy SUBCTL=~/.local/bin/subctl DEPLOY_ARGS="$(DEPLOY_ARGS) --image_tag=subctl" using=$(using)
 
 ##### LINTING TARGETS #####
 .PHONY: gitlint golangci-lint markdownlint packagedoc-lint shellcheck yamllint

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -75,7 +75,7 @@ function test_connection() {
 
 function connectivity_tests() {
     target_cluster="$1"
-    DEV_VERSION="${BASE_BRANCH}" import_image quay.io/submariner/nettest
+    import_image quay.io/submariner/nettest
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -75,6 +75,9 @@ function subctl_install_subm() {
                 ${deploytool_submariner_args} \
                 ${cidr_args} \
                 "${OUTPUT_DIR}"/broker-info.subm
+
+    # Print installed versions for manual validation of CI
+    "${SUBCTL}" show versions --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster"
 }
 
 function install_subm_all_clusters() {


### PR DESCRIPTION
Since this target gets the latest `subctl`, and uses `SUBCTL` flag to
skip overriding versions on deployment, the actual versions that will
deploy are the ones dictated by that `subctl`.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
