### PR TITLE
HACK: Fix subctl download script

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -135,7 +135,7 @@ declare_cidrs
 declare_kubeconfig
 
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
-bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash" ||
+bash -c "curl -Ls https://astoycos.github.io/get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash" ||
 bash -c "curl -Ls https://get.submariner.io | VERSION=devel DESTDIR=/go/bin bash"
 
 load_deploytool $deploytool


### PR DESCRIPTION
The subctl download script from get.submariner.io
didn't work for the feature branches, as a temporary
fix use astoycos.github.io/get.submariner.io instead of
get.submariner.io so that the correct RBAC is applied 
for the submariner gateway. 

Signed-off-by: Andrew Stoycos <astoycos@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
