### PR TITLE
Mark the source directory as safe

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,5 +8,7 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]

--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -6,5 +6,7 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]


### PR DESCRIPTION
See
https://github.blog/2022-04-12-git-security-vulnerability-announced/
for context. git now refuses to handle repositories which don't belong
to the current user by default; such repositories need to be
explicitly marked as safe, in the global configuration for the current
user.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
