### PR TITLE
Check that the multiarch image builds work

### DIFF
--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  apply-suggestions-commits:
+  check-multiarch:
     name: Check the multi-arch builds
     runs-on: ubuntu-latest
     steps:
@@ -17,3 +17,5 @@ jobs:
         uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
       - name: Build the multi-arch images
         run: make multiarch-images
+      - name: Check that we actually build multi-arch images
+        run: bash -c '[ "$(echo package/*.tar)" != "package/*.tar" ]'


### PR DESCRIPTION
make multiarch-images can succeed without actually producing
multiarch-images; it warns about this but doesn't fail. This adds a
check that we actually produced multiarch images.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
