### PR TITLE
Automated backport of #802: Mark the source directory as safe

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,5 +8,7 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]

--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -6,5 +6,7 @@ ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
+RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]


### PR DESCRIPTION
Backport of #802 on release-0.12.

#802: Mark the source directory as safe

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.