### PR TITLE
Disable VCS stamping in go compile

### DIFF
--- a/scripts/shared/compile.sh
+++ b/scripts/shared/compile.sh
@@ -34,6 +34,6 @@ if [ "$build_debug" = "false" ]; then
     ldflags="-s -w ${ldflags}"
 fi
 
-CGO_ENABLED=0 ${GO:-go} build -trimpath -ldflags "${ldflags}" -o $binary $source_file
+CGO_ENABLED=0 ${GO:-go} build -buildvcs=false -trimpath -ldflags "${ldflags}" -o $binary $source_file
 [[ "$build_upx" = "false" ]] || [[ "$build_debug" = "true" ]] || upx $binary
 


### PR DESCRIPTION
Local builds in Lighthouse (at least) fail with:

$ make deploy using=globalnet
...
[16:19:11.121] [lighthouse]$ CGO_ENABLED=0 go build -trimpath -ldflags
  -s -w  -o bin/lighthouse-agent ./pkg/agent
error obtaining VCS status: exit status 128
	Use -buildvcs=false to disable VCS stamping.
make: *** [Makefile:30: bin/lighthouse-agent] Error 1

We have go 1.18 in the dev container (after make shell in LH):

[root@5dd87becc9c2 lighthouse]# go version
go version go1.18 linux/amd64

But use go 1.17 in CI, which seems like the relevant difference issue.

kind v0.12.0 go1.17.8 linux/amd64

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
