### PR TITLE
Clarify logged inotify warning

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -310,7 +310,9 @@ function deploy_cluster_capabilities() {
 
 function warn_inotify() {
     if [[ "$(cat /proc/sys/fs/inotify/max_user_instances)" -lt 512 ]]; then
-        echo "Please increase your inotify settings (currently $(cat /proc/sys/fs/inotify/max_user_watches) and $(cat /proc/sys/fs/inotify/max_user_instances)):"
+        echo "Your inotify settings are lower than our recommendation."
+        echo "This may cause failures in large deployments, but we don't know if it caused this failure."
+        echo "You may need to increase your inotify settings (currently $(cat /proc/sys/fs/inotify/max_user_watches) and $(cat /proc/sys/fs/inotify/max_user_instances)):"
         echo sudo sysctl fs.inotify.max_user_watches=524288
         echo sudo sysctl fs.inotify.max_user_instances=512
         echo 'See https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files'
@@ -344,6 +346,7 @@ declare_cidrs
 # Run in subshell to check response, otherwise `set -e` is not honored
 ( run_all_clusters with_retries 3 create_kind_cluster; ) &
 if ! wait $!; then
+    echo "Failed to create kind clusters."
     warn_inotify
     exit 1
 fi


### PR DESCRIPTION
As-is, this results in logs that seem to imply the automation knows this
is an issue with inotify settings. Make it clear that we're only saying
they are below a recommendation, not that we know they caused a failure.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
