### PR TITLE
Ensure that failing unit tests stop the build

### DIFF
--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -54,8 +54,8 @@ for module in "${modules[@]}"; do
 
         echo "Running tests in ${packages[*]}"
         [ "${ARCH}" == "amd64" ] && race=-race
-        ${GO:-go} test -v ${race} -cover "${packages[@]}" -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@" || result=1
-    )
+        ${GO:-go} test -v ${race} -cover "${packages[@]}" -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@"
+    ) || result=1
 done
 
 exit $result


### PR DESCRIPTION
Commit e82a3e3e ("Fix unit test directory finding") resulted in go
test's exit status being ignored; the failure would set result=1, as
before, but only in a subshell, and that value was lost as soon as the
subshell exited.

Removing all post-processing of the immediate go test result ensures
that the subshell exits with the same exit status as go test; the
subshell's exit status can then be acted upon to update the result
variable.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
