### PR TITLE
Fix gateway nodes naming fetch

### DIFF
--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -21,6 +21,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,8 @@ var gatewayGVR = &schema.GroupVersionResource{
 
 func (f *Framework) AwaitGatewayWithStatus(cluster ClusterIndex, name, status string) *unstructured.Unstructured {
 	gwClient := gatewayClient(cluster)
+	// Set short name without a suffix as exists in the Gateway resource
+	name = strings.Split(name, ".")[0]
 	obj := AwaitUntil(fmt.Sprintf("await Gateway on %q with status %q", name, status),
 		func() (interface{}, error) {
 			resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
@@ -104,6 +107,8 @@ func (f *Framework) AwaitGatewayRemoved(cluster ClusterIndex, name string) {
 
 func (f *Framework) AwaitGatewayFullyConnected(cluster ClusterIndex, name string) *unstructured.Unstructured {
 	gwClient := gatewayClient(cluster)
+	// Set short name without a suffix as exists in the Gateway resource
+	name = strings.Split(name, ".")[0]
 	obj := AwaitUntil(fmt.Sprintf("await Gateway on %q with status active and connections UP", name),
 		func() (interface{}, error) {
 			resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})


### PR DESCRIPTION
Fix redundancy testGatewayPodRestartScenario test for OCP cluster.

The gateway resource contains a name of the node which servers as a
gateway.
In OCP clusters, the nodes names may contain a suffix related to the
platform is runs on.
For example, aws platform node:
ip-10-0-25-94.us-west-1.compute.internal

The gateway resource node name contains just the first part of the name:
ip-10-0-25-94

And that leads to the failure of the test, since no gateway matching is
done and the test tells that gateway node does not exist.

Split the node name by a dot and taking the prefix.
If node name does not contains the suffix, the test will continue
without errors.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
