### PR TITLE
Add OVN-K Dir to safe directories

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -3,12 +3,13 @@ FROM quay.io/submariner/shipyard-dapper-base:${BASE_BRANCH}
 
 ARG PROJECT
 ENV DAPPER_ENV="QUAY_USERNAME QUAY_PASSWORD CLUSTERS_ARGS DEPLOY_ARGS CLEANUP_ARGS E2E_ARGS RELEASE_ARGS MAKEFLAGS FOCUS SKIP PLUGIN E2E_TESTDIR GITHUB_USER GITHUB_TOKEN USING" \
-    DAPPER_SOURCE=/go/src/github.com/submariner-io/${PROJECT} DAPPER_DOCKER_SOCKET=true
+    DAPPER_SOURCE=/go/src/github.com/submariner-io/${PROJECT} DAPPER_DOCKER_SOCKET=true OVN_DIR=${DAPPER_SOURCE}/ovn-kubernetes
 ENV DAPPER_OUTPUT=${DAPPER_SOURCE}/output
 
 WORKDIR ${DAPPER_SOURCE}
 
 RUN git config --global --add safe.directory ${DAPPER_SOURCE}
+RUN git config --global --add safe.directory ${OVN_DIR}
 
 ENTRYPOINT ["/opt/shipyard/scripts/entry"]
 CMD ["sh"]


### PR DESCRIPTION
Follow up to https://github.com/submariner-io/shipyard/pull/802

since we have to clone the ovn-k source in order
to ensure the kind deployment can start properly
we also need to add it as a git safe directory

For More information see -> https://coreos.slack.com/archives/C0134E73VH6/p1652895384711149 
