### PR TITLE
Make weave deploy more robust

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -215,9 +215,19 @@ function deploy_weave_cni(){
 
     echo "${WEAVE_YAML}" | kubectl apply -f -
     echo "Waiting for weave-net pods to be ready..."
+    with_retries 5 ensure_weave_pods
     kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout="${timeout}"
     echo "Waiting for core-dns deployment to be ready..."
     kubectl -n kube-system rollout status deploy/coredns --timeout="${timeout}"
+}
+
+function ensure_weave_pods() {
+    if kubectl get pods -l name=weave-net -n kube-system | grep weave-net; then
+       return 0
+    fi
+
+    sleep 3
+    return 1
 }
 
 function deploy_ovn_cni(){


### PR DESCRIPTION
Sometimes we try to await the weave pods before any of them are ready.
This fails due to [1], so in the meantime implementing this workaround
makes deploying with weave much more robust (and stops wasting time
trying to redeploy).

[1]: https://github.com/kubernetes/kubectl/issues/1516

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
