### PR TITLE
Fix a typo in release-images

### DIFF
--- a/Makefile.images
+++ b/Makefile.images
@@ -41,7 +41,7 @@ multiarch-images: $(foreach image,$(MULTIARCH_IMAGES),package/$(image).tar)
 
 # [release-images] uploads the project's images to a public repository
 release-images:
-ifneq (,$(filter-out ($MULTIARCH_IMAGES),$(IMAGES)))
+ifneq (,$(filter-out $(MULTIARCH_IMAGES),$(IMAGES)))
 	$(SCRIPTS_DIR)/release_images.sh $(filter-out $(MULTIARCH_IMAGES),$(IMAGES)) $(RELEASE_ARGS)
 endif
 ifneq (,$(MULTIARCH_IMAGES))


### PR DESCRIPTION
$(MULTIARCH_IMAGES) instead of ($MULTIARCH_IMAGES). Fixes commit
bdbd31fdbd ("Skip releasing images if there are none").

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
