### PR TITLE
Automated backport of #847: Label e2e test namespace as privileged

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -201,7 +201,10 @@ func (f *Framework) BeforeEach() {
 		By(fmt.Sprintf("Creating namespace objects with basename %q", f.BaseName))
 
 		namespaceLabels := map[string]string{
-			"e2e-framework": f.BaseName,
+			"e2e-framework":                      f.BaseName,
+			"pod-security.kubernetes.io/enforce": "privileged",
+			"pod-security.kubernetes.io/audit":   "privileged",
+			"pod-security.kubernetes.io/warn":    "privileged",
 		}
 
 		for idx, clientSet := range KubeClients {


### PR DESCRIPTION
Backport of #847 on release-0.12.

#847: Label e2e test namespace as privileged

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.