### PR TITLE
Use kind 0.14 to test Kubernetes 1.24

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -61,10 +61,13 @@ ENV LINT_VERSION=v1.46.0 \
     YQ_VERSION=4.20.2
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
+# We temporarily install kind-0.12 and kind-0.14; kind-0.12 is the default, and kind-0.14 is used for K8s 1.24, until
+# all kind images are available with containerd 1.6.5 or later
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
-    curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
+    curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
+    curl -Lo /go/bin/kind-0.14 "https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind-0.14 && \
     GOFLAGS="" go install -v github.com/onsi/ginkgo/ginkgo@latest && \
     GOFLAGS="" go install -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
     mkdir -p /usr/local/libexec/docker/cli-plugins && \

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -3,7 +3,8 @@
 ## Kubernetes version mapping, as supported by kind ##
 # See the release notes of the kind version in use
 DEFAULT_K8S_VERSION=1.23
-declare -A kind_k8s_versions
+declare -A kind_k8s_versions kind_kind_binaries
+# kind-0.12 hashes
 kind_k8s_versions[1.17]=1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5
 kind_k8s_versions[1.18]=1.18.20@sha256:e3dca5e16116d11363e31639640042a9b1bd2c90f85717a7fc66be34089a8169
 kind_k8s_versions[1.19]=1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467
@@ -11,6 +12,22 @@ kind_k8s_versions[1.20]=1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db58153
 kind_k8s_versions[1.21]=1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
 kind_k8s_versions[1.22]=1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
 kind_k8s_versions[1.23]=1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
+# kind-0.14 hashes
+#kind_k8s_versions[1.18]=1.18.20@sha256:738cdc23ed4be6cc0b7ea277a2ebcc454c8373d7d8fb991a7fcdbd126188e6d7
+#kind_k8s_versions[1.19]=1.19.16@sha256:d9c819e8668de8d5030708e484a9fdff44d95ec4675d136ef0a0a584e587f65c
+#kind_k8s_versions[1.20]=1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248
+#kind_k8s_versions[1.21]=1.21.12@sha256:f316b33dd88f8196379f38feb80545ef3ed44d9197dca1bfd48bcb1583210207
+#kind_k8s_versions[1.22]=1.22.9@sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
+#kind_k8s_versions[1.23]=1.23.6@sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae
+kind_k8s_versions[1.24]=1.24.2@sha256:a3220cefdf4f9be6681c871da35521eaaf59fadd7d509613a9e1881c5f74b587
+kind_kind_binaries[1.17]='kind'
+kind_kind_binaries[1.18]='kind'
+kind_kind_binaries[1.19]='kind'
+kind_kind_binaries[1.20]='kind'
+kind_kind_binaries[1.21]='kind'
+kind_kind_binaries[1.22]='kind'
+kind_kind_binaries[1.23]='kind'
+kind_kind_binaries[1.24]='kind-0.14'
 
 ## Process command line flags ##
 
@@ -29,6 +46,7 @@ eval set -- "${FLAGS_ARGV}"
 k8s_version="${FLAGS_k8s_version}"
 olm_version="${FLAGS_olm_version}"
 [[ -z "${k8s_version}" ]] && k8s_version="${DEFAULT_K8S_VERSION}"
+kind="${kind_kind_binaries[$k8s_version]}"
 [[ -n "${kind_k8s_versions[$k8s_version]}" ]] && k8s_version="${kind_k8s_versions[$k8s_version]}"
 [[ "${FLAGS_olm}" = "${FLAGS_TRUE}" ]] && olm=true || olm=false
 [[ "${FLAGS_prometheus}" = "${FLAGS_TRUE}" ]] && prometheus=true || prometheus=false
@@ -37,7 +55,7 @@ olm_version="${FLAGS_olm_version}"
 settings="${FLAGS_settings}"
 timeout="${FLAGS_timeout}"
 
-echo "Running with: k8s_version=${k8s_version}, olm_version=${olm_version}, olm=${olm}, globalnet=${globalnet}, prometheus=${prometheus}, registry_inmemory=${registry_inmemory}, settings=${settings}, timeout=${timeout}"
+echo "Running with: kind=${kind}, k8s_version=${k8s_version}, olm_version=${olm_version}, olm=${olm}, globalnet=${globalnet}, prometheus=${prometheus}, registry_inmemory=${registry_inmemory}, settings=${settings}, timeout=${timeout}"
 
 set -em
 
@@ -118,9 +136,9 @@ function create_kind_cluster() {
     export KUBECONFIG=${KUBECONFIGS_DIR}/kind-config-${cluster}
     rm -f "$KUBECONFIG"
 
-    if kind get clusters | grep -q "^${cluster}$"; then
+    if ${kind} get clusters | grep -q "^${cluster}$"; then
         echo "KIND cluster already exists, skipping its creation..."
-        kind export kubeconfig --name="${cluster}"
+        ${kind} export kubeconfig --name="${cluster}"
         kind_fixup_config
         return
     fi
@@ -137,16 +155,16 @@ function create_kind_cluster() {
         image_flag="--image=kindest/node:v${k8s_version}"
     fi
 
-    kind version
+    ${kind} version
     cat "${RESOURCES_DIR}/${cluster}-config.yaml"
-    kind create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
+    ${kind} create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
     kind_fixup_config
 
     ( deploy_cluster_capabilities; ) &
     if ! wait $! ; then
         echo "Failed to deploy cluster capabilities, removing the cluster"
         kubectl cluster-info dump 1>&2
-        kind delete cluster --name="${cluster}"
+        ${kind} delete cluster --name="${cluster}"
         return 1
     fi
 }
@@ -249,14 +267,14 @@ function deploy_kind_ovn(){
     ( ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"; ) &
     if ! wait $! ; then
         echo "Failed to install kind with OVN"
-        kind delete cluster --name="${cluster}"
+        ${kind} delete cluster --name="${cluster}"
         return 1
     fi
 
     ( deploy_cluster_capabilities; ) &
     if ! wait $! ; then
         echo "Failed to deploy cluster capabilities, removing the cluster"
-        kind delete cluster --name="${cluster}"
+        ${kind} delete cluster --name="${cluster}"
         return 1
     fi
 }


### PR DESCRIPTION
kind 0.13 and 0.14 add support for Kubernetes 1.24, but the non-1.24
Kubernetes images used with these versions currently embed containerd
1.6.4, which breaks Weave (see
https://github.com/weaveworks/weave/issues/3942 for details).

To allow testing Kubernetes 1.24, install kind 0.14, while preserving
kind 0.12; both binaries are now named explicitly with their version
number (kind-0.12 and kind-0.14). When Kubernetes 1.24 is requested,
deploy it with kind 0.14, otherwise rely on 0.12.

See https://github.com/kubernetes-sigs/kind/releases/tag/v0.13.0 and
https://github.com/kubernetes-sigs/kind/releases/tag/v0.14.0 for
details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
