### PR TITLE
Bump Helm to 3.9.0

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -54,7 +54,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 ENV LINT_VERSION=v1.46.0 \
-    HELM_VERSION=v3.8.0 \
+    HELM_VERSION=v3.9.0 \
     KIND_VERSION=v0.12.0 \
     BUILDX_VERSION=v0.8.2 \
     GH_VERSION=2.5.1 \


### PR DESCRIPTION
This adds support for Kubernetes 1.24. See
https://github.com/helm/helm/releases/tag/v3.9.0 for details.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
