### PR TITLE
Add K8s 1.24 operator consumer E2E, EoL K8s 1.21

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -19,7 +19,7 @@ jobs:
         project: ['admiral', 'lighthouse', 'subctl', 'submariner', 'submariner-operator']
         deploytool: ['operator', 'helm']
         cabledriver: ['libreswan']
-        k8s_version: ['1.23']
+        k8s_version: ['1.24']
         exclude:
           # Admiral E2E doesn't respect deploy-tool params, as it uses clusters without Submariner
           - project: admiral
@@ -33,9 +33,9 @@ jobs:
             cabledriver: wireguard
           # Test multiple K8s versions only in submariner-operator, balancing coverage and jobs
           - project: submariner-operator
-            k8s_version: '1.21'
-          - project: submariner-operator
             k8s_version: '1.22'
+          - project: submariner-operator
+            k8s_version: '1.23'
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b


### PR DESCRIPTION
Use Kubernetes 1.24 for the consuming E2E that varies K8s versions.

Remove Kubernetes 1.21 because it's end of life.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
