### PR TITLE
Helm: retrieve the created secrets by name

### DIFF
--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -26,8 +26,8 @@ function setup_broker() {
     fi
 
     submariner_broker_url=$(kubectl -n default get endpoints kubernetes -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
-    submariner_broker_ca=$(kubectl -n "${BROKER_NAMESPACE}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_CLIENT_SA}')].data['ca\.crt']}")
-    submariner_broker_token=$(kubectl -n "${BROKER_NAMESPACE}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='${BROKER_CLIENT_SA}')].data.token}"|base64 --decode)
+    submariner_broker_ca=$(kubectl -n "${BROKER_NAMESPACE}" get secrets "${BROKER_CLIENT_SA}-token" -o jsonpath="{.data['ca\.crt']}")
+    submariner_broker_token=$(kubectl -n "${BROKER_NAMESPACE}" get secrets "${BROKER_CLIENT_SA}-token" -o jsonpath="{.data.token}"|base64 --decode)
 }
 
 function helm_install_subm() {

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -18,7 +18,7 @@ function setup_broker() {
     else
         echo "Installing submariner broker..."
         # shellcheck disable=SC2086 # Split on purpose
-        helm install --devel "${BROKER_NAMESPACE}" \
+        helm install --debug --devel "${BROKER_NAMESPACE}" \
              "${HELM_REPO_LOCATION}"/submariner-k8s-broker \
              --create-namespace \
              --kube-context "${cluster}" \
@@ -41,7 +41,7 @@ function helm_install_subm() {
 
     echo "Installing Submariner..."
     # shellcheck disable=SC2086 # Split on purpose
-    helm --kube-context "${cluster}" install --devel submariner-operator \
+    helm --kube-context "${cluster}" install --debug --devel submariner-operator \
         "${HELM_REPO_LOCATION}"/submariner-operator \
         --create-namespace \
         --namespace "${SUBM_NS}" \

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -18,7 +18,7 @@ function setup_broker() {
     else
         echo "Installing submariner broker..."
         # shellcheck disable=SC2086 # Split on purpose
-        helm install "${BROKER_NAMESPACE}" \
+        helm install --devel "${BROKER_NAMESPACE}" \
              "${HELM_REPO_LOCATION}"/submariner-k8s-broker \
              --create-namespace \
              --kube-context "${cluster}" \
@@ -41,7 +41,7 @@ function helm_install_subm() {
 
     echo "Installing Submariner..."
     # shellcheck disable=SC2086 # Split on purpose
-    helm --kube-context "${cluster}" install submariner-operator \
+    helm --kube-context "${cluster}" install --devel submariner-operator \
         "${HELM_REPO_LOCATION}"/submariner-operator \
         --create-namespace \
         --namespace "${SUBM_NS}" \


### PR DESCRIPTION
To support Kubernetes 1.24, our Helm charts create secrets with a
fixed name; use that to retrieve the secrets instead of looking for
all annotated secrets (for Kubernetes < 1.24 there end up being two of
those).

Depends on https://github.com/submariner-io/submariner-charts/pull/237
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
