### PR TITLE
Adjust PATH var in Dockerfile.shipyard-dapper-base

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -5,7 +5,7 @@ FROM fedora:36
 ARG UPX_LEVEL=-5
 ENV DAPPER_HOST_ARCH=amd64 SHIPYARD_DIR=/opt/shipyard SHELL=/bin/bash \
     DAPPER_RUN_ARGS="--net=kind"
-ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/root/.local/bin:/go/bin:/usr/local/go/bin:$PATH \
+ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.local/bin:/usr/local/go/bin:$PATH \
     GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${DAPPER_HOST_ARCH} \
     GOPATH=/go GO111MODULE=on GOFLAGS=-mod=vendor GOPROXY=https://proxy.golang.org \
     SCRIPTS_DIR=${SHIPYARD_DIR}/scripts


### PR DESCRIPTION
The upgrade job has been failing (see https://github.com/submariner-io/submariner/pull/1925#issuecomment-1186226654) due it using the previous/latest `subctl` release version installed in _/root/.local/bin_ instead of the current `subctl` installed in _/go/bin_ when it runs join with the locally built images. This is because of how the PATH var is defined in `Dockerfile.shipyard-dapper-base`, which was recently changed by [this commit](https://github.com/submariner-io/shipyard/pull/704/commits/72301efcf47a161b035e0f9927572167cbf524be).

Move _/go/bin_ ahead of _/root/.local/bin_ in the PATH.
