### PR TITLE
Fix new markdownlint link error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Periodic](https://github.com/submariner-io/shipyard/workflows/Periodic/badge.svg)](https://github.com/submariner-io/shipyard/actions?query=workflow%3APeriodic)
 <!-- markdownlint-enable line-length -->
 
-The Shipyard project provides tooling for creating K8s clusters with [kind](K8s in Docker) and provides a Go framework for creating E2E
-tests.
+The Shipyard project provides tooling for creating K8s clusters with [kind] and provides a Go framework for creating E2E tests.
 
 ## Prerequisites
 


### PR DESCRIPTION
This seems to be a new error as of markdownlint-cli 0.32.0.

The missing-space [link](aside) is detected as a malformed link.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
