### PR TITLE
Switch the default kind to 0.14

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -55,19 +55,19 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.46.2 \
     HELM_VERSION=v3.9.0 \
-    KIND_VERSION=v0.12.0 \
+    KIND_VERSION=v0.14.0 \
     BUILDX_VERSION=v0.8.2 \
     GH_VERSION=2.5.1 \
     YQ_VERSION=4.20.2
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
-# We temporarily install kind-0.12 and kind-0.14; kind-0.12 is the default, and kind-0.14 is used for K8s 1.24, until
+# We temporarily install kind-0.12 and kind-0.14; kind-0.14 is the default, and kind-0.12 is used for K8s before 1.24, until
 # all kind images are available with containerd 1.6.5 or later
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
-    curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
-    curl -Lo /go/bin/kind-0.14 "https://github.com/kubernetes-sigs/kind/releases/download/v0.14.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind-0.14 && \
+    curl -Lo /go/bin/kind-0.12 "https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind-0.12 && \
+    curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     GOFLAGS="" go install -v github.com/onsi/ginkgo/ginkgo@latest && \
     GOFLAGS="" go install -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \
     mkdir -p /usr/local/libexec/docker/cli-plugins && \

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -14,7 +14,7 @@ kind_k8s_versions[1.22]=1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c
 kind_k8s_versions[1.23]=1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
 # kind-0.14 hashes
 kind_k8s_versions[1.24]=1.24.2@sha256:a3220cefdf4f9be6681c871da35521eaaf59fadd7d509613a9e1881c5f74b587
-kind_binaries[1.24]='kind-0.14'
+kind_binaries[1.24]='kind'
 
 ## Process command line flags ##
 
@@ -33,7 +33,7 @@ eval set -- "${FLAGS_ARGV}"
 k8s_version="${FLAGS_k8s_version}"
 olm_version="${FLAGS_olm_version}"
 [[ -z "${k8s_version}" ]] && k8s_version="${DEFAULT_K8S_VERSION}"
-kind="${kind_binaries[$k8s_version]:-kind}"
+kind="${kind_binaries[$k8s_version]:-kind-0.12}"
 [[ -n "${kind_k8s_versions[$k8s_version]}" ]] && k8s_version="${kind_k8s_versions[$k8s_version]}"
 [[ "${FLAGS_olm}" = "${FLAGS_TRUE}" ]] && olm=true || olm=false
 [[ "${FLAGS_prometheus}" = "${FLAGS_TRUE}" ]] && prometheus=true || prometheus=false


### PR DESCRIPTION
This will allow OVN deployments to work with Kubernetes 1.24.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
