### PR TITLE
Automated backport of #880: Run the upgrade job on devel only

### DIFF
--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -3,6 +3,7 @@ name: Upgrade
 
 on:
   pull_request:
+    branches: [devel]
 
 jobs:
   upgrade-e2e:


### PR DESCRIPTION
Backport of #880 on release-0.12.

#880: Run the upgrade job on devel only

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.

Depends on #883