### PR TITLE
Automated backport of #874: Fix new markdownlint link error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 [![Periodic](https://github.com/submariner-io/shipyard/workflows/Periodic/badge.svg)](https://github.com/submariner-io/shipyard/actions?query=workflow%3APeriodic)
 <!-- markdownlint-enable line-length -->
 
-The Shipyard project provides tooling for creating K8s clusters with [kind](K8s in Docker) and provides a Go framework for creating E2E
-tests.
+The Shipyard project provides tooling for creating K8s clusters with [kind] and provides a Go framework for creating E2E tests.
 
 ## Prerequisites
 


### PR DESCRIPTION
Backport of #874 on release-0.12.

#874: Fix new markdownlint link error in README

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.