### PR TITLE
Rename coverprofile to already-ignored IDE pattern

### DIFF
--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -56,8 +56,8 @@ for module in "${modules[@]}"; do
         [ "${ARCH}" == "amd64" ] && race=-race
         # It's important that the `go test` command's exit status is reported from this () block.
         # Can't be one command (with -cover). Need detailed -coverprofile for Sonar and summary to console.
-        ${GO:-go} test -v ${race} -coverprofile unit_coverage.out "${packages[@]}" -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@" && \
-        go tool cover -func unit_coverage.out
+        ${GO:-go} test -v ${race} -coverprofile unit.coverprofile "${packages[@]}" -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@" && \
+        go tool cover -func unit.coverprofile
     ) || result=1
 done
 


### PR DESCRIPTION
It seems that a number of IDEs create *.coverprofile files.
This pattern is already in the relevant Submariner .gitignore files.
Instead of adding many ignores, name coverprofile to match that rule.

Relates-to: #868
Relates-to: stolostron/backlog#22706
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
