### PR TITLE
Tell go mod tidy we don't care about 1.16

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -239,13 +239,13 @@ unit: $(VENDOR_MODULES)
 vendor/modules.txt: go.mod
 	$(GO) mod download
 	$(GO) mod vendor
-	$(GO) mod tidy
+	$(GO) mod tidy -compat=1.17
 
 %/vendor/modules.txt: %/go.mod
 	cd $(patsubst %/vendor/,%,$(dir $@)) && \
 	$(GO) mod download && \
 	$(GO) mod vendor && \
-	$(GO) mod tidy
+	$(GO) mod tidy -compat=1.17
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners


### PR DESCRIPTION
Since we require 1.18 or later, we can ignore go.mod compatibility
with 1.16; this instructs "go mod tidy" explicitly, to avoid issues
with dependencies which are resolved differently between 1.16 and
1.17.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
