### PR TITLE
Extract `get-subctl.sh` to easily fetch `subctl`

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -147,8 +147,7 @@ upgrade-e2e: deploy-latest deploy e2e
 # This uses make deploy, but forcefully ignores images so that images
 # are *not* rebuilt (we want to deploy the published images only)
 deploy-latest:
-	curl -L get.submariner.io | VERSION=latest bash
-	$(MAKE) -o images -o preload-images deploy SUBCTL=~/.local/bin/subctl IMAGE_TAG=subctl using=$(using)
+	$(MAKE) -o images -o preload-images deploy SUBCTL_VERSION=latest IMAGE_TAG=subctl using=$(using)
 
 ##### LINTING TARGETS #####
 .PHONY: gitlint golangci-lint markdownlint packagedoc-lint shellcheck yamllint

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -79,6 +79,9 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
     find /go/bin /usr/local/libexec/docker/cli-plugins -type f -executable -newercc /proc \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
     go clean -cache -modcache
 
+# Link get-subctl script so it can be easily run inside a shell
+RUN ln -s $SCRIPTS_DIR/get-subctl.sh /root/.local/bin/subctl
+
 # Copy kubecfg to always run on the shell
 COPY scripts/shared/lib/kubecfg /etc/profile.d/kubecfg.sh
 

--- a/release-notes/get-subctl
+++ b/release-notes/get-subctl
@@ -1,0 +1,2 @@
+Added a centralized script for getting `subctl`. It now impersonates `subctl` so that users who run `make shell` will have it downloaded the first time they try to use it.
+To influence the version being installed, the `SUBCTL_VERSION` variable can be set.

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -137,8 +137,7 @@ declare_cidrs
 declare_kubeconfig
 
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
-bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash" ||
-bash -c "curl -Ls https://get.submariner.io | VERSION=devel DESTDIR=/go/bin bash"
+"${SCRIPTS_DIR}/get-subctl.sh"
 
 load_deploytool "${DEPLOYTOOL}"
 deploytool_prereqs

--- a/scripts/shared/get-subctl.sh
+++ b/scripts/shared/get-subctl.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+# In case we're pretending to be `subctl`
+if [[ "${0##*/}" = subctl ]] && [[ -L "$0" ]]; then
+    run_subctl=true
+
+    # Delete ourselves to ensure we don't run into issues with the new subctl
+    rm -f "$0"
+fi
+
+# Default to devel if we don't know what base branch were on
+curl -Ls --retry 3 https://get.submariner.io | VERSION="${SUBCTL_VERSION:-${BASE_BRANCH:-devel}}" bash
+
+# If we're pretending to be subctl, run subctl with any given arguments
+[[ -z "${run_subctl}" ]] || subctl "$@"

--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -65,7 +65,7 @@ function post_analyze() {
 ### Main ###
 
 declare_kubeconfig
-bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash"
+"${SCRIPTS_DIR}/get-subctl.sh"
 for cluster in $(kind get clusters); do
     post_analyze
 done


### PR DESCRIPTION
This will be useful both for scripts and for `make shell` users who need
to quickly get subctl for various operations

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
