### PR TITLE
Support multi arch compile inside `compile.sh`

### DIFF
--- a/scripts/shared/compile.sh
+++ b/scripts/shared/compile.sh
@@ -27,8 +27,21 @@ source "${SCRIPTS_DIR}/lib/utils"
 print_env BUILD_DEBUG BUILD_UPX LDFLAGS
 source "${SCRIPTS_DIR}/lib/debug_functions"
 
+### Functions ###
+
+# Determine GOARCH based on the last component of the target directory, if any
+function determine_goarch() {
+    GOARCH="$(dirname "${binary}")"
+    [[ "${GOARCH}" != '.' ]] || { unset GOARCH && return 0; }
+
+    # Convert from Docker arch to Go arch
+    GOARCH="${GOARCH/arm\/v7/arm}"
+    export GOARCH="${GOARCH##*/}"
+}
+
 ## Main ##
 
+[[ -n "${GOARCH}" ]] || determine_goarch
 mkdir -p "${binary%/*}"
 
 echo "Building ${binary@Q} (LDFLAGS: ${LDFLAGS@Q})"


### PR DESCRIPTION
Instead of relying on callers of the script to properly set the
`GOARCH`, detect it inside the script.

Callers can still set `GOARCH` if they choose to.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
