### PR TITLE
Remove directories when cleaning

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -110,9 +110,9 @@ export GO
 # [clean] cleans everything (running clusters, generated files ...)
 clean: clean-clusters clean-generated clean-buildx
 
-# [clean-generated] removes files we generated
+# [clean-generated] removes files we generated, by removing all files and directories ignored by git
 clean-generated:
-	git clean -X -f
+	git clean -X -f -d
 
 # [clean-clusters] removes running clusters
 clean-clusters:


### PR DESCRIPTION
Right now `make clean-generated` (which is also called when running
`make clean`) only removes files in the top level directory.
This can result in stale files and directories left behind, which lead
to incorrect behaviors.

Added `-d` for git to recursively remove files and directories.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
