### PR TITLE
Shrink base image

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -36,6 +36,11 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # yq                 | YAML processing (OCM deploy tool)
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
+# Removals and UPX are done after all installations, since image layers are diffs.
+# We remove:
+# - DNF cache
+# - Any unnecessary packages and executables
+# - Precompiled packages in go (see https://github.com/golang/go/issues/47257)
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils upx jq gitlint python3-setuptools \
@@ -46,6 +51,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     dnf -y clean all && \
     rm -f /usr/bin/{dockerd,lto-dump} \
           /usr/libexec/gcc/x86_64-redhat-linux/10/lto1 && \
+    find /usr/lib/golang -name '*.a' -newercc /proc -delete && \
     find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -11,40 +11,37 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
     SCRIPTS_DIR=${SHIPYARD_DIR}/scripts
 
 # Requirements:
-# Component        | Usage
+# Component          | Usage
 # -------------------------------------------------------------
-# curl             | download other tools
-# findutils        | make unit (find unit test dirs)
-# gcc              | needed by `go test -race` (https://github.com/golang/go/issues/27089)
-# gh               | backport, releases
-# ginkgo           | tests
-# git              | find the workspace root
-# gitlint          | Commit message linting
-# golang           | build
-# golangci-lint    | code linting
-# helm             | e2e tests
-# jq               | JSON processing (GitHub API)
-# kind             | e2e tests
-# kubectl          | e2e tests (in kubernetes-client)
-# make             | OLM installation
-# markdownlint     | Markdown linting
-# moby-engine      | Docker (for Dapper)
-# npm              | Required for installing markdownlint
-# qemu-user-static | Emulation (for multiarch builds)
-# ShellCheck       | shell script linting
-# skopeo           | container image manipulation
-# upx              | binary compression
-# yamllint         | YAML linting
-# yq               | YAML processing (OCM deploy tool)
+# curl               | download other tools
+# findutils          | make unit (find unit test dirs)
+# gcc                | needed by `go test -race` (https://github.com/golang/go/issues/27089)
+# gh                 | backport, releases
+# ginkgo             | tests
+# git                | find the workspace root
+# golang             | build
+# golangci-lint      | code linting
+# helm               | e2e tests
+# j2cli[yaml]        | Jinja2 template engine CLI (Used by OVN KIND setup)
+# jq                 | JSON processing (GitHub API)
+# kind               | e2e tests
+# kubectl            | e2e tests (in kubernetes-client)
+# make               | OLM installation
+# moby-engine        | Docker (for Dapper)
+# python3-pip        | Needed (temprorarily) to install j2cli, removed once done
+# python3-setuptools | Needed by j2cli
+# qemu-user-static   | Emulation (for multiarch builds)
+# skopeo             | container image manipulation
+# upx                | binary compression
+# yq                 | YAML processing (OCM deploy tool)
 
 # This layer's versioning is handled by dnf, and isn't expected to be rebuilt much except in CI
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq ShellCheck npm gitlint yamllint \
+                   findutils upx jq gitlint python3-setuptools \
                    qemu-user-static python3-pip skopeo && \
-    npm install -g markdownlint-cli && \
     pip install j2cli[yaml] --user && \
-    rpm -e --nodeps containerd npm python3-pip && \
+    rpm -e --nodeps containerd python3-pip && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \
     dnf -y clean all && \
     rm -f /usr/bin/{dockerd,lto-dump} \


### PR DESCRIPTION
A couple of commits to radically shrink the base shipyard image (**33% (upwards of 300MB) reduction** in the uncompressed size).

* Stop installing linting tools in base image
* Remove golang's pre-compiled packages

See individual commits for specific details.