### PR TITLE
Revert "Drop all caching logic from image building"

### DIFF
--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -18,6 +18,8 @@ runs:
     - name: Build new images
       # This needs to be kept separate so that the release stage runs using the new Shipyard base image
       shell: bash
+      env:
+        USE_CACHE: false
       run: |
         echo "::group::Build new images"
         make images multiarch-images

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -4,6 +4,7 @@ set -e
 
 ### Variables ###
 
+[[ -n "${USE_CACHE}" ]] || USE_CACHE='true'
 [[ $# == 1 ]] || { echo "Exactly one image to build must be specified!"; exit 1; }
 [[ -n "${DOCKERFILE}" ]] || { echo "The DOCKERFILE to build from must be specified!"; exit 1; }
 [[ -n "${HASHFILE}" ]] || { echo "The HASHFILE to write the hash to must be specified!"; exit 1; }
@@ -21,6 +22,28 @@ source "${SCRIPTS_DIR}/lib/debug_functions"
 local_image="${REPO}/${1}:${DEV_VERSION}"
 cache_image="${REPO}/${1}:${CUTTING_EDGE}"
 
+# When using cache pull latest image from the repo, so that its layers may be reused.
+declare -a cache_flags
+if [[ "${USE_CACHE}" = true ]]; then
+    cache_flags+=(--cache-from "${cache_image}")
+    if [[ -z "$(docker image ls -q "${cache_image}")" ]]; then
+        docker pull "${cache_image}" || :
+    fi
+    # The shellcheck linting tool recommends piping to a while read loop, but that doesn't work for us
+    # because the while loop ends up in a subshell
+    # shellcheck disable=SC2013
+    for parent in $(awk '/FROM/ {
+                             for (i = 2; i <= NF; i++) {
+                                 if ($i == "AS") next;
+                                 if (!($i ~ /^--platform/ || $i ~ /scratch/))
+                                     print gensub("\\${BASE_BRANCH}", ENVIRON["BASE_BRANCH"], "g", $i)
+                             }
+                         }' "${DOCKERFILE}"); do
+        cache_flags+=(--cache-from "${parent}")
+        docker pull "${parent}" || :
+    done
+fi
+
 output_flag=--load
 [[ -z "${OCIFILE}" ]] || output_flag="--output=type=oci,dest=${OCIFILE}"
 
@@ -37,13 +60,13 @@ fi
 buildargs_flags=(--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg "BASE_BRANCH=${BASE_BRANCH}")
 if [[ "${PLATFORM}" != "${default_platform}" ]] && docker buildx version > /dev/null 2>&1; then
     docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
-    docker buildx build "${output_flag}" -t "${local_image}" -f "${DOCKERFILE}" --iidfile "${HASHFILE}" --platform "${PLATFORM}" "${buildargs_flags[@]}" .
+    docker buildx build "${output_flag}" -t "${local_image}" "${cache_flags[@]}" -f "${DOCKERFILE}" --iidfile "${HASHFILE}" --platform "${PLATFORM}" "${buildargs_flags[@]}" .
 else
     # Fall back to plain BuildKit
     if [[ "${PLATFORM}" != "${default_platform}" ]]; then
         echo "WARNING: buildx isn't available, cross-arch builds won't work as expected"
     fi
-    DOCKER_BUILDKIT=1 docker build -t "${local_image}" -f "${DOCKERFILE}" --iidfile "${HASHFILE}" "${buildargs_flags[@]}" .
+    DOCKER_BUILDKIT=1 docker build -t "${local_image}" "${cache_flags[@]}" -f "${DOCKERFILE}" --iidfile "${HASHFILE}" "${buildargs_flags[@]}" .
 fi
 
 # We can only tag the image in non-OCI mode


### PR DESCRIPTION
This reverts commit a685e56cc17df03dbab79dad4da56118e2503a43.

It seems that cache was useful to speed up CI jobs after all, reverting
the change.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
