### PR TITLE
Update Prometheus resources for K8s 1.22+

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -46,12 +46,14 @@ jobs:
         deploytool: ['operator', 'helm']
         lighthouse: ['']
         ovn: ['']
+        prometheus: ['']
         include:
           - ovn: ovn
           - deploytool: operator
             lighthouse: lighthouse
           - deploytool: helm
             lighthouse: lighthouse
+          - prometheus: prometheus
     steps:
       - name: Reclaim space on GHA host (if the job needs it)
         if: ${{ matrix.ovn != '' }}
@@ -68,7 +70,9 @@ jobs:
       - name: Deploy clusters and Submariner
         env:
           TIMEOUT: 1m
-        run: make deploy using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.lighthouse }} ${{ matrix.ovn }}"
+        run: make deploy using="${{ matrix.globalnet }} \
+          ${{ matrix.deploytool }} ${{ matrix.lighthouse }} \
+          ${{ matrix.ovn }} ${{ matrix.prometheus }}"
 
       - name: Post mortem
         if: failure()

--- a/scripts/shared/resources/prometheus/clusterrole.yaml
+++ b/scripts/shared/resources/prometheus/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus

--- a/scripts/shared/resources/prometheus/clusterrolebinding.yaml
+++ b/scripts/shared/resources/prometheus/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus


### PR DESCRIPTION
ClusterRole and ClusterRoleBinding v1beta1 were removed in Kubernetes
1.22, update to v1 to allow testing on 1.22 and later.

This adds Prometheus to the Deploy matrix so we catch future breakages
sooner.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
