### PR TITLE
Pass the context when retrieving cluster resources

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -33,7 +33,10 @@ function post_analyze() {
     kubectl version || true
 
     print_section "* Overview of all resources in $cluster *"
-    kubectl api-resources --verbs=list -o name | xargs -n 1 kubectl get --show-kind -o wide --ignore-not-found
+    for resource in $(kubectl api-resources --verbs=list -o name); do
+        print_section "** Resource: $resource"
+        kubectl get --all-namespaces --show-kind -o wide --ignore-not-found "$resource"
+    done
 
     print_section "* Details of pods with statuses other than Running in $cluster *"
     for pod in $(kubectl get pods -A | tail -n +2 | grep -v Running | sed 's/  */;/g'); do


### PR DESCRIPTION
xargs doesn't know about the kubectl function, so when we retrieve the
resources we don't specify the context and end up with whatever the
default context is.

Command substitution with a for loop ensures that the function is used
and we retrieve the information from the context we expect.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
