### PR TITLE
Tooling for creating deployments and running E2E with AWS and OCP

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -99,6 +99,16 @@ if [ -d "${HOME}/.docker" ]; then
     dockerargs="${dockerargs} -v ${HOME}/.docker:/root/.docker${suffix}"
 fi
 
+# Pass through ~/.aws/credentials so that the container can operate on AWS (if needed).
+if [ -r "${HOME}/.aws/credentials" ]; then
+    volume="${HOME}/.aws/credentials:/root/.aws/credentials"
+    if [ -z "${suffix}" ]; then
+        dockerargs="${dockerargs} -v ${volume}:ro"
+    else
+        dockerargs="${dockerargs} -v ${volume}${suffix},ro"
+    fi
+fi
+
 # seccomp is unconfined to avoid problems with clone3 in Fedora 35
 # See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
 # Remove "--security-opt seccomp=unconfined" once all supported container runtimes

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ include Makefile.versions
 # Shipyard-specific starts
 # We need to ensure images, including the Shipyard base image, are updated
 # before we start Dapper
-clean-clusters cleanup clusters deploy deploy-latest e2e golangci-lint post-mortem print-version scale unit upgrade-e2e: package/.image.shipyard-dapper-base
+clean-clusters cleanup cloud-prepare clusters deploy deploy-latest e2e golangci-lint post-mortem print-version scale unit upgrade-e2e: package/.image.shipyard-dapper-base
 deploy deploy-latest e2e upgrade-e2e: package/.image.nettest
 
 .DEFAULT_GOAL := lint

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,14 +2,14 @@
 USING = $(subst $(,), ,$(using))
 _using = ${USING}
 PRELOAD_IMAGES ?= submariner-gateway submariner-operator submariner-route-agent
-export PROVIDER ?= kind
 
 ### Tunable variables for affecting make commands ###
 # Affecting multiple commands
 DEBUG_PRINT ?= true
 PARALLEL ?= true
+PROVIDER ?= kind
 TIMEOUT ?= 5m
-export DEBUG_PRINT GLOBALNET PARALLEL PLUGIN SETTINGS TIMEOUT
+export DEBUG_PRINT GLOBALNET PARALLEL PLUGIN PROVIDER SETTINGS TIMEOUT
 
 # Specific to `clusters`
 K8S_VERSION ?= 1.24
@@ -103,6 +103,10 @@ endif
 
 ifneq (,$(filter ovn,$(_using)))
 PRELOAD_IMAGES += submariner-networkplugin-syncer
+endif
+
+ifneq (,$(filter aws-ocp,$(_using)))
+PROVIDER = aws-ocp
 endif
 
 GO ?= go

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -136,14 +136,18 @@ clean-buildx:
 	docker buildx rm
 
 ##### DEPLOYMENT& TESTING TARGETS #####
-.PHONY: clusters deploy e2e scale upgrade-e2e deploy-latest
+.PHONY: clusters cloud-prepare deploy e2e scale upgrade-e2e deploy-latest
 
 # [clusters] creates KIND clusters that can then be used to deploy Submariner
 clusters:
 	$(SCRIPTS_DIR)/$@.sh
 
+# [cloud-prepare] can be run on a POC/testing cloud environment to prepare it before deploying Submariner
+cloud-prepare:
+	$(SCRIPTS_DIR)/$@.sh
+
 # [deploy] deploys Submariner on KIND clusters
-deploy: clusters preload-images
+deploy: clusters cloud-prepare preload-images
 	$(SCRIPTS_DIR)/$@.sh
 
 # [e2e] executes the project's end to end testing on the deployed KIND clusters

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -107,6 +107,11 @@ endif
 
 ifneq (,$(filter aws-ocp,$(_using)))
 PROVIDER = aws-ocp
+IMAGE_TAG = subctl
+endif
+
+ifeq ($(PROVIDER),kind)
+deploy: preload-images
 endif
 
 GO ?= go
@@ -147,7 +152,7 @@ cloud-prepare:
 	$(SCRIPTS_DIR)/$@.sh
 
 # [deploy] deploys Submariner on KIND clusters
-deploy: clusters cloud-prepare preload-images
+deploy: clusters cloud-prepare
 	$(SCRIPTS_DIR)/$@.sh
 
 # [e2e] executes the project's end to end testing on the deployed KIND clusters

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -25,7 +25,8 @@ export CABLE_DRIVER DEPLOYTOOL IMAGE_TAG LIGHTHOUSE
 # Specific to `e2e`
 TESTDIR ?= test/e2e
 LAZY_DEPLOY ?= true
-export FOCUS LAZY_DEPLOY SKIP TESTDIR
+SUBCTL_VERIFICATIONS ?= connectivity
+export FOCUS LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TESTDIR
 
 # Specific to `reload-images`
 export RESTART ?= none
@@ -105,9 +106,18 @@ ifneq (,$(filter ovn,$(_using)))
 PRELOAD_IMAGES += submariner-networkplugin-syncer
 endif
 
+# Force running E2E with `subctl verify`
+ifneq (,$(filter subctl-verify,$(_using)))
+TESTDIR = non-existent-dir
+endif
+
 ifneq (,$(filter aws-ocp,$(_using)))
 PROVIDER = aws-ocp
 IMAGE_TAG = subctl
+endif
+
+ifeq ($(LIGHTHOUSE),true)
+SUBCTL_VERIFICATIONS = service-discovery
 endif
 
 ifeq ($(PROVIDER),kind)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -2,6 +2,7 @@
 USING = $(subst $(,), ,$(using))
 _using = ${USING}
 PRELOAD_IMAGES ?= submariner-gateway submariner-operator submariner-route-agent
+export PROVIDER ?= kind
 
 ### Tunable variables for affecting make commands ###
 # Affecting multiple commands

--- a/gh-actions/commit-size/action.yaml
+++ b/gh-actions/commit-size/action.yaml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: Make sure the size of each commit doesn't pass the desired size
       shell: bash
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-size-check') }}
       run: |
         set -e
         # Fetch 'origin' to get all commits for size checking

--- a/release-notes/force-subctl-verify
+++ b/release-notes/force-subctl-verify
@@ -1,0 +1,4 @@
+Support was added to force running `subctl verify` when testing end-to-end, ignoring any local tests.
+To use this feature, run `make e2e using=subctl-verify`.
+Verifications can be now specified using the `SUBCTL_VERIFICATIONS` flag, instead of relying on the default behavior.
+e.g.: `make e2e using=subctl-verify SUBCTL_VERIFICATIONS=connectivity,service-discovery`.

--- a/release-notes/support-aws-ocp
+++ b/release-notes/support-aws-ocp
@@ -1,0 +1,9 @@
+Support was added in shipyard to easily create test clusters using OCP on top of AWS.
+This allows developers and users to easily stand up a test/PoC environment with Submariner using AWS+OCP.
+The deployed environment will use the latest published Submariner images, it's currently not possible to use locally built images.
+
+The following commands are supported:
+* `make clusters using=aws-ocp`
+* `make deploy using=aws-ocp`
+* `make e2e using=aws-ocp`
+* `make cleanup using=aws-ocp`

--- a/scripts/shared/cloud-prepare.sh
+++ b/scripts/shared/cloud-prepare.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -em -o pipefail
+
+source "${SCRIPTS_DIR}/lib/debug_functions"
+source "${SCRIPTS_DIR}/lib/utils"
+
+readonly GATEWAY_LABEL='submariner.io/gateway=true'
+
+### Functions ###
+
+function cloud_prepare() {
+    [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
+    ! check_gateway_exists || return 0
+
+    case "${PROVIDER}" in
+    kind|aws-ocp)
+        "prepare_${PROVIDER//-/_}"
+        ;;
+    *)
+        echo "Unknown PROVIDER ${PROVIDER@Q}."
+        return 1
+    esac
+}
+
+function check_gateway_exists() {
+    [[ $(kubectl get nodes -l "${GATEWAY_LABEL}" --no-headers | wc -l) -gt 0 ]]
+}
+
+function prepare_kind() {
+    read -r -a nodes <<< "${cluster_nodes[$cluster]}"
+    kubectl label node "${cluster}-${nodes[-1]}" "${GATEWAY_LABEL}" --overwrite
+}
+
+function prepare_aws_ocp() {
+    subctl cloud prepare aws --kubecontext "${cluster}" --ocp-metadata "${OUTPUT_DIR}/aws-ocp-${cluster}/"
+    with_retries 60 sleep_on_fail 5s check_gateway_exists
+}
+
+### Main ###
+
+load_settings
+declare_kubeconfig
+[[ "${PROVIDER}" == "kind" ]] || "${SCRIPTS_DIR}/get-subctl.sh"
+
+# Run in subshell to check response, otherwise `set -e` is not honored
+( run_all_clusters cloud_prepare; ) &
+if ! wait $!; then
+    echo "Failed to prepare cloud"
+    exit 1
+fi
+

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -42,7 +42,6 @@ function deploy_cluster_capabilities() {
 
 ### Main ###
 
-rm -rf "${KUBECONFIGS_DIR}"
 mkdir -p "${KUBECONFIGS_DIR}"
 
 load_settings
@@ -55,7 +54,7 @@ provider_prepare
 ( run_all_clusters with_retries 3 provider_create_cluster; ) &
 if ! wait $!; then
     echo "Failed to create clusters using ${PROVIDER@Q}."
-    provider_failed
+    run_if_defined provider_failed
     exit 1
 fi
 

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -1,268 +1,12 @@
 #!/usr/bin/env bash
 
-set -em
-
-## Kubernetes version mapping, as supported by kind ##
-# See the release notes of the kind version in use
-declare -A kind_k8s_versions kind_binaries
-# kind-0.12 hashes
-kind_k8s_versions[1.17]=1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5
-kind_k8s_versions[1.18]=1.18.20@sha256:e3dca5e16116d11363e31639640042a9b1bd2c90f85717a7fc66be34089a8169
-kind_k8s_versions[1.19]=1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467
-kind_k8s_versions[1.20]=1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
-kind_k8s_versions[1.21]=1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
-kind_k8s_versions[1.22]=1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
-kind_k8s_versions[1.23]=1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
-# kind-0.14 hashes
-kind_k8s_versions[1.24]=1.24.2@sha256:a3220cefdf4f9be6681c871da35521eaaf59fadd7d509613a9e1881c5f74b587
-kind_binaries[1.24]='kind'
-
-kind="${kind_binaries[$K8S_VERSION]:-kind-0.12}"
-[[ -n "${kind_k8s_versions[$K8S_VERSION]}" ]] && K8S_VERSION="${kind_k8s_versions[$K8S_VERSION]}"
+set -em -o pipefail
 
 source "${SCRIPTS_DIR}/lib/utils"
-print_env GLOBALNET K8S_VERSION OLM OLM_VERSION PARALLEL PROMETHEUS SETTINGS TIMEOUT
+print_env GLOBALNET K8S_VERSION OLM OLM_VERSION PARALLEL PROMETHEUS PROVIDER SETTINGS TIMEOUT
 source "${SCRIPTS_DIR}/lib/debug_functions"
 
 ### Functions ###
-
-function generate_cluster_yaml() {
-    # These are used by render_template
-    local pod_cidr service_cidr dns_domain disable_cni
-    # shellcheck disable=SC2034
-    pod_cidr="${cluster_CIDRs[${cluster}]}"
-    # shellcheck disable=SC2034
-    service_cidr="${service_CIDRs[${cluster}]}"
-    # shellcheck disable=SC2034
-    dns_domain="${cluster}.local"
-    disable_cni="false"
-    # shellcheck disable=SC2034
-    [[ -z "${cluster_cni[$cluster]}" ]] || disable_cni="true"
-
-    local nodes
-    for node in ${cluster_nodes[${cluster}]}; do nodes="${nodes}"$'\n'"- role: $node"; done
-
-    render_template "${RESOURCES_DIR}/kind-cluster-config.yaml" > "${RESOURCES_DIR}/${cluster}-config.yaml"
-}
-
-function kind_fixup_config() {
-    local master_ip
-    master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}-control-plane" | head -n 1)
-    sed -i -- "s/server: .*/server: https:\/\/$master_ip:6443/g" "$KUBECONFIG"
-    sed -i -- "s/user: kind-.*/user: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/name: kind-.*/name: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/cluster: kind-.*/cluster: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/current-context: .*/current-context: ${cluster}/g" "$KUBECONFIG"
-    chmod a+r "$KUBECONFIG"
-}
-
-# In development environments where clusters are brought up and down
-# multiple times, several Docker images are repeatedly pulled and deleted,
-# leading to the Docker error:
-#   "toomanyrequests: You have reached your pull rate limit"
-# Preload the KIND image. Also tag it so the `docker system prune` during
-# cleanup won't remove it.
-function download_kind() {
-    if [[ -z "${K8S_VERSION}" ]]; then
-        echo "K8S_VERSION not set."
-        return
-    fi
-
-    # Example: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-    kind_image="kindest/node:v${K8S_VERSION}"
-    # Example: kindest/node:v1.20.7
-    kind_image_tag="kindest/node:v$(echo ${K8S_VERSION}|awk -F"@" '{print $1}')"
-    # Example: kindest/node:@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-    kind_image_sha="kindest/node@$(echo ${K8S_VERSION}|awk -F"@" '{print $2}')"
-
-    # Check if image is already present, and if not, download it.
-    echo "Processing Image: $kind_image_tag ($kind_image)"
-    if [[ -n $(docker images -q "$kind_image_tag") ]] ; then
-        echo "Image $kind_image_tag already downloaded."
-        return
-    fi
-
-    echo "Image $kind_image_tag not found, downloading..."
-    if ! docker pull "$kind_image"; then
-        echo "**** 'docker pull $kind_image' failed. Manually run. ****"
-        return
-    fi
-
-    image_id=$(docker images -q "$kind_image_sha")
-    if ! docker tag "$image_id" "$kind_image_tag"; then
-        echo "'docker tag ${image_id} ${kind_image_tag}' failed."
-    fi
-}
-
-function create_kind_cluster() {
-    export KUBECONFIG=${KUBECONFIGS_DIR}/kind-config-${cluster}
-    rm -f "$KUBECONFIG"
-
-    if "${kind}" get clusters | grep -q "^${cluster}$"; then
-        echo "KIND cluster already exists, skipping its creation..."
-        "${kind}" export kubeconfig --name="${cluster}"
-        kind_fixup_config
-        return
-    fi
-
-    echo "Creating KIND cluster..."
-    if [[ "${cluster_cni[$cluster]}" == "ovn" ]]; then
-        deploy_kind_ovn
-        return
-    fi
-
-    generate_cluster_yaml
-    local image_flag=''
-    [[ -z "${K8S_VERSION}" ]] || image_flag="--image=kindest/node:v${K8S_VERSION}"
-
-    "${kind}" version
-    cat "${RESOURCES_DIR}/${cluster}-config.yaml"
-    "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
-    kind_fixup_config
-
-    ( deploy_cluster_capabilities; ) &
-    if ! wait $! ; then
-        echo "Failed to deploy cluster capabilities, removing the cluster"
-        kubectl cluster-info dump 1>&2
-        "${kind}" delete cluster --name="${cluster}"
-        return 1
-    fi
-}
-
-function deploy_cni() {
-    [[ -n "${cluster_cni[$cluster]}" ]] || return 0
-
-    eval "deploy_${cluster_cni[$cluster]}_cni"
-}
-
-function deploy_weave_cni(){
-    echo "Applying weave network..."
-
-    WEAVE_YAML=$(curl -sL "https://cloud.weave.works/k8s/net?k8s-version=v$K8S_VERSION&env.IPALLOC_RANGE=${cluster_CIDRs[${cluster}]}" | sed 's!ghcr.io/weaveworks/launcher!weaveworks!')
-
-    # Search the YAML for images that need to be downloaded
-    readarray -t IMAGE_LIST < <(echo "${WEAVE_YAML}" | yq e '.items[].spec.template.spec.containers[].image, .items[].spec.template.spec.initContainers[].image' -)
-    echo "IMAGE_LIST=${IMAGE_LIST[*]}"
-    for image in "${IMAGE_LIST[@]}"
-    do
-        IMAGE_FAILURE=false
-
-        # Check if image is already present, and if not, download it.
-        echo "Processing Image: $image"
-        if [ -z "$(docker images -q "$image")" ] ; then
-            echo "Image $image not found, downloading..."
-            if ! docker pull "$image"; then
-                echo "**** 'docker pull $image' failed. Manually run. ****"
-                IMAGE_FAILURE=true
-            fi
-        else
-            echo "Image $image already downloaded."
-        fi
-
-        if [ "${IMAGE_FAILURE}" == false ] ; then
-            LCL_REG_IMAGE_NAME="${image/weaveworks/localhost:5000}"
-            # Copy image to local registry if not there
-            if [ -z "$(docker images -q "${LCL_REG_IMAGE_NAME}")" ] ; then
-                echo "Image ${LCL_REG_IMAGE_NAME} not found, tagging and pushing ..."
-                if ! docker tag "$image" "${LCL_REG_IMAGE_NAME}"; then
-                    echo "'docker tag $image ${LCL_REG_IMAGE_NAME}' failed."
-                    IMAGE_FAILURE=true
-                else
-                    if ! docker push "${LCL_REG_IMAGE_NAME}"; then
-                        echo "'docker push ${LCL_REG_IMAGE_NAME}' failed."
-                        IMAGE_FAILURE=true
-                    fi
-                fi
-            else
-                echo "Image ${LCL_REG_IMAGE_NAME} already present."
-            fi
-        fi
-
-        if [ "${IMAGE_FAILURE}" == false ] ; then
-            # Update the YAML by replacing upstream image name with the local registry image name
-            WEAVE_YAML=$(echo "${WEAVE_YAML}" | \
-                    image=${image} \
-                    LCL_REG_IMAGE_NAME=${LCL_REG_IMAGE_NAME} \
-                    yq e 'with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.containers[].image | select(. == strenv(image));
-                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single") |
-                          with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.initContainers[].image | select(. == strenv(image));
-                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single")
-                    ' - )
-        fi
-    done
-
-    echo "${WEAVE_YAML}" | kubectl apply -f -
-    echo "Waiting for weave-net pods to be ready..."
-    with_retries 5 ensure_weave_pods
-    kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout="${TIMEOUT}"
-    echo "Waiting for core-dns deployment to be ready..."
-    kubectl -n kube-system rollout status deploy/coredns --timeout="${TIMEOUT}"
-}
-
-function ensure_weave_pods() {
-    if kubectl get pods -l name=weave-net -n kube-system | grep weave-net; then
-       return 0
-    fi
-
-    sleep 3
-    return 1
-}
-
-function deploy_ovn_cni(){
-    echo "OVN CNI deployed."
-}
-
-function deploy_kind_ovn(){
-    local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master"
-    export K8s_VERSION="${K8S_VERSION}"
-    export NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
-    export SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
-    export KIND_CLUSTER_NAME="${cluster}"
-
-    export OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
-    docker pull "${OVN_SRC_IMAGE}"
-    docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
-    docker push "${OVN_IMAGE}"
-
-    ( ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"; ) &
-    if ! wait $! ; then
-        echo "Failed to install kind with OVN"
-        "${kind}" delete cluster --name="${cluster}"
-        return 1
-    fi
-
-    ( deploy_cluster_capabilities; ) &
-    if ! wait $! ; then
-        echo "Failed to deploy cluster capabilities, removing the cluster"
-        "${kind}" delete cluster --name="${cluster}"
-        return 1
-    fi
-}
-
-function run_local_registry() {
-    # Run a local registry to avoid loading images manually to kind
-    if registry_running; then
-        echo "Local registry $KIND_REGISTRY already running."
-        return 0
-    fi
-
-    echo "Deploying local registry $KIND_REGISTRY to serve images centrally."
-    local volume_dir="/var/lib/registry"
-    local volume_flag="/dev/shm/${KIND_REGISTRY}:${volume_dir}"
-    selinuxenabled && volume_flag="${volume_flag}:z" 2>/dev/null
-    docker run -d -v "${volume_flag}" -p 127.0.0.1:5000:5000 --restart=always --name "$KIND_REGISTRY" registry:2
-    docker network connect kind "$KIND_REGISTRY" || true
-
-    # If the local volume mount directory is empty, probably due to a host reboot,
-    # then try to push any images with "localhost:5000".
-    if [[ -z "$(docker exec -e tmp_dir=${volume_dir} $KIND_REGISTRY /bin/sh -c 'ls -A ${tmp_dir} 2>/dev/null')" ]]; then
-        echo "Push images to local registry: $KIND_REGISTRY"
-        readarray -t local_image_list < <(docker images | awk -F' ' '/localhost:5000/ {print $1":"$2}')
-        for image in "${local_image_list[@]}"; do
-            docker push "${image}" || echo "Failed to push ${image@Q} to registry."
-        done
-    fi
-}
 
 function deploy_olm() {
     echo "Applying OLM CRDs..."
@@ -292,45 +36,8 @@ function deploy_prometheus() {
 }
 
 function deploy_cluster_capabilities() {
-    deploy_cni
     [[ "${OLM}" != "true" ]] || deploy_olm
     [[ "${PROMETHEUS}" != "true" ]] || deploy_prometheus
-}
-
-function warn_inotify() {
-    if [[ "$(cat /proc/sys/fs/inotify/max_user_instances)" -lt 512 ]]; then
-        echo "Your inotify settings are lower than our recommendation."
-        echo "This may cause failures in large deployments, but we don't know if it caused this failure."
-        echo "You may need to increase your inotify settings (currently $(cat /proc/sys/fs/inotify/max_user_watches) and $(cat /proc/sys/fs/inotify/max_user_instances)):"
-        echo sudo sysctl fs.inotify.max_user_watches=524288
-        echo sudo sysctl fs.inotify.max_user_instances=512
-        echo 'See https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files'
-    fi
-}
-
-# If any of the clusters use OVN-K as the CNI then clone the
-# ovn-kubernetes repo from master in order to access the required
-# kind scripts, and manifest generation templates.
-function download_ovnk() {
-    if [[ ${cluster_cni[*]} != *"ovn"* ]]; then
-        return
-    fi
-
-    echo "Cloning ovn-kubernetes from source"
-    mkdir -p ovn-kubernetes
-    # We only need the contrib directory, use a sparse checkout
-    cd ovn-kubernetes
-    git init
-    git config core.sparseCheckout true
-    echo contrib/ > .git/info/sparse-checkout
-    echo dist/ >> .git/info/sparse-checkout
-    if git remote add -f origin https://github.com/ovn-org/ovn-kubernetes.git
-    then
-        git pull origin master
-    else
-        git fetch && git reset --hard origin/master
-    fi
-    cd ..
 }
 
 ### Main ###
@@ -338,18 +45,20 @@ function download_ovnk() {
 rm -rf "${KUBECONFIGS_DIR}"
 mkdir -p "${KUBECONFIGS_DIR}"
 
-download_kind
 load_settings
-download_ovnk
-run_local_registry
 declare_cidrs
 
+load_library clusters PROVIDER
+provider_prepare
+
 # Run in subshell to check response, otherwise `set -e` is not honored
-( run_all_clusters with_retries 3 create_kind_cluster; ) &
+( run_all_clusters with_retries 3 provider_create_cluster; ) &
 if ! wait $!; then
-    echo "Failed to create kind clusters."
-    warn_inotify
+    echo "Failed to create clusters using ${PROVIDER@Q}."
+    provider_failed
     exit 1
 fi
 
+declare_kubeconfig
+run_all_clusters deploy_cluster_capabilities
 print_clusters_message

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -126,8 +126,6 @@ deploytool_prereqs
 
 run_if_defined pre_deploy
 
-run_subm_clusters prepare_cluster
-
 with_context "$broker" setup_broker
 install_subm_all_clusters
 

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -121,7 +121,7 @@ declare_kubeconfig
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
 "${SCRIPTS_DIR}/get-subctl.sh"
 
-load_deploytool
+load_library deploy DEPLOYTOOL
 deploytool_prereqs
 
 run_if_defined pre_deploy

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -17,14 +17,12 @@ source "${SCRIPTS_DIR}/lib/deploy_funcs"
 readonly CE_IPSEC_IKEPORT=500
 # shellcheck disable=SC2034
 readonly CE_IPSEC_NATTPORT=4500
-# shellcheck disable=SC2034
-readonly SUBM_IMAGE_REPO=localhost:5000
-# shellcheck disable=SC2034
-readonly SUBM_IMAGE_TAG="${IMAGE_TAG}"
+SUBM_IMAGE_REPO=localhost:5000
+SUBM_IMAGE_TAG="${IMAGE_TAG}"
 # shellcheck disable=SC2034
 readonly SUBM_CS="submariner-catalog-source"
 # shellcheck disable=SC2034
-readonly SUBM_INDEX_IMG=localhost:5000/submariner-operator-index:local
+readonly SUBM_INDEX_IMG="${SUBM_IMAGE_REPO}/submariner-operator-index:${SUBM_IMAGE_TAG}"
 # shellcheck disable=SC2034
 readonly BROKER_NAMESPACE="submariner-k8s-broker"
 # shellcheck disable=SC2034
@@ -139,3 +137,7 @@ else
 fi
 
 run_if_defined post_deploy
+
+# Print installed versions for manual validation of CI
+subctl show versions
+print_clusters_message

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -8,7 +8,7 @@ ginkgo_args=()
 [[ -n "${SKIP}" ]] && ginkgo_args+=("-ginkgo.skip=${SKIP}")
 
 source "${SCRIPTS_DIR}/lib/utils"
-print_env FOCUS GLOBALNET LAZY_DEPLOY SKIP TESTDIR
+print_env FOCUS GLOBALNET LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TESTDIR
 source "${SCRIPTS_DIR}/lib/debug_functions"
 
 ### Functions ###
@@ -41,7 +41,7 @@ function test_with_e2e_tests {
 }
 
 function test_with_subctl {
-    subctl verify --only connectivity --kubecontexts "$(generate_kubecontexts)"
+    subctl verify --only "${SUBCTL_VERIFICATIONS}" --kubecontexts "$(generate_kubecontexts)"
 }
 
 function count_nodes() {

--- a/scripts/shared/lib/cleanup_aws_ocp
+++ b/scripts/shared/lib/cleanup_aws_ocp
@@ -1,0 +1,17 @@
+. "${SCRIPTS_DIR}/lib/ocp_utils"
+
+### Functions ###
+
+function provider_initialize() {
+    readarray -t clusters < <(find "${OUTPUT_DIR}" -type f -name metadata.json -exec sh -c "basename \$(dirname {})" \;)
+    [[ "${#clusters[@]}" -gt 0 ]] || { echo "No AWS clusters found." && return 0; }
+    ensure_openshift_install
+}
+
+function provider_delete_cluster() {
+    openshift-install destroy cluster --dir="${OUTPUT_DIR}/${cluster}"
+}
+
+function provider_finalize() {
+    \rm -rf "${OUTPUT_DIR}"/aws-ocp-* "${KUBECONFIGS_DIR}"/aws-ocp-*
+}

--- a/scripts/shared/lib/cleanup_aws_ocp
+++ b/scripts/shared/lib/cleanup_aws_ocp
@@ -9,7 +9,7 @@ function provider_initialize() {
 }
 
 function provider_delete_cluster() {
-    openshift-install destroy cluster --dir="${OUTPUT_DIR}/${cluster}"
+    "${OCP_INSTALLER}" destroy cluster --dir="${OUTPUT_DIR}/${cluster}"
 }
 
 function provider_finalize() {

--- a/scripts/shared/lib/cleanup_kind
+++ b/scripts/shared/lib/cleanup_kind
@@ -1,0 +1,20 @@
+
+### Functions ###
+
+function provider_initialize() {
+    readarray -t clusters < <(kind get clusters)
+}
+
+function provider_delete_cluster() {
+    kind delete cluster --name="${cluster}"
+}
+
+function provider_finalize {
+    if registry_running; then
+        echo "Stopping local KIND registry..."
+        docker stop "$KIND_REGISTRY"
+    fi
+
+    docker system prune --volumes -f
+    rm -f "${KUBECONFIGS_DIR}"/kind-config-*
+}

--- a/scripts/shared/lib/clusters_aws_ocp
+++ b/scripts/shared/lib/clusters_aws_ocp
@@ -1,3 +1,4 @@
+. "${SCRIPTS_DIR}/lib/ocp_utils"
 
 ### Variables ###
 
@@ -6,7 +7,7 @@ declare -g install_template="${OUTPUT_DIR}/aws-ocp-template"
 ### Functions ###
 
 function provider_prepare() {
-    curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz | tar -xzf - -C /usr/local/bin/ openshift-install
+    ensure_openshift_install
 
     if [[ -d "${install_template}" ]]; then
         echo "Reusing existing template for AWS install."

--- a/scripts/shared/lib/clusters_aws_ocp
+++ b/scripts/shared/lib/clusters_aws_ocp
@@ -1,0 +1,62 @@
+
+### Variables ###
+
+declare -g install_template="${OUTPUT_DIR}/aws-ocp-template"
+
+### Functions ###
+
+function provider_prepare() {
+    curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz | tar -xzf - -C /usr/local/bin/ openshift-install
+
+    if [[ -d "${install_template}" ]]; then
+        echo "Reusing existing template for AWS install."
+        echo "If you'd like to reinstall, please run 'make clean' and try again."
+        return 0
+    fi
+
+    rm -rf "${install_template}"
+    echo "Creating an initial configuration template for AWS."
+    echo "Please fill out all the necessary details."
+    echo "Note: The cluster name will be suffixed (eg with '-cluster1'), please fill out just the prefix."
+    openshift-install create install-config --dir "${install_template}"
+}
+
+function provider_create_cluster() {
+    export KUBECONFIG="${KUBECONFIGS_DIR}/aws-ocp-${cluster}"
+
+    if kubectl cluster-info > /dev/null 2>&1; then
+        echo "AWS cluster already exists, skipping its creation..."
+        return 0
+    fi
+
+    rm -f "$KUBECONFIG"
+
+    echo "Creating AWS cluster..."
+
+    local install_dir="${install_template/template/${cluster}}"
+    local install_config="${install_dir}/install-config.yaml"
+    local control_replicas compute_replicas
+    control_replicas=$(echo "${cluster_nodes[${cluster}]}" | tr ' ' '\n' | grep -wc 'control-plane')
+    compute_replicas=$(echo "${cluster_nodes[${cluster}]}" | tr ' ' '\n' | grep -wc 'worker')
+
+    # OCP needs at least 1 compute node to work properly
+    [[ "${compute_replicas}" != "0" ]] || compute_replicas = 1
+
+    rm -rf "${install_dir}"
+    cp -r "${install_template}" "${install_dir}"
+    yq -i ".metadata.name += \"-${cluster}\"" "${install_config}"
+    yq -i ".networking.clusterNetwork[0].cidr = \"${cluster_CIDRs[${cluster}]}\"" "${install_config}"
+    yq -i ".networking.serviceNetwork[0] = \"${service_CIDRs[${cluster}]}\"" "${install_config}"
+    yq -i ".controlPlane.replicas = ${control_replicas}" "${install_config}"
+    yq -i ".compute[0].replicas = ${compute_replicas}" "${install_config}"
+
+    if ! openshift-install create cluster --dir "${install_dir}"; then
+        echo "Failed to create AWS cluster, removing the cluster"
+        openshift-install destroy cluster --dir "${install_dir}"
+        return 1
+    fi
+
+    local kubeconfig="${install_dir}/auth/kubeconfig"
+    yq -i "(.. | select(. == \"admin\")) = \"${cluster}\"" "${kubeconfig}"
+    cp "${kubeconfig}" "${KUBECONFIG}"
+}

--- a/scripts/shared/lib/clusters_aws_ocp
+++ b/scripts/shared/lib/clusters_aws_ocp
@@ -19,7 +19,7 @@ function provider_prepare() {
     echo "Creating an initial configuration template for AWS."
     echo "Please fill out all the necessary details."
     echo "Note: The cluster name will be suffixed (eg with '-cluster1'), please fill out just the prefix."
-    openshift-install create install-config --dir "${install_template}"
+    "${OCP_INSTALLER}" create install-config --dir "${install_template}"
 }
 
 function provider_create_cluster() {
@@ -51,9 +51,9 @@ function provider_create_cluster() {
     yq -i ".controlPlane.replicas = ${control_replicas}" "${install_config}"
     yq -i ".compute[0].replicas = ${compute_replicas}" "${install_config}"
 
-    if ! openshift-install create cluster --dir "${install_dir}"; then
+    if ! "${OCP_INSTALLER}" create cluster --dir "${install_dir}"; then
         echo "Failed to create AWS cluster, removing the cluster"
-        openshift-install destroy cluster --dir "${install_dir}"
+        "${OCP_INSTALLER}" destroy cluster --dir "${install_dir}"
         return 1
     fi
 

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -1,0 +1,291 @@
+### Variables ###
+
+## Kubernetes version mapping, as supported by kind ##
+# See the release notes of the kind version in use
+declare -gA kind_k8s_versions kind_binaries
+# kind-0.12 hashes
+kind_k8s_versions[1.17]=1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5
+kind_k8s_versions[1.18]=1.18.20@sha256:e3dca5e16116d11363e31639640042a9b1bd2c90f85717a7fc66be34089a8169
+kind_k8s_versions[1.19]=1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467
+kind_k8s_versions[1.20]=1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
+kind_k8s_versions[1.21]=1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
+kind_k8s_versions[1.22]=1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
+kind_k8s_versions[1.23]=1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
+# kind-0.14 hashes
+kind_k8s_versions[1.24]=1.24.2@sha256:a3220cefdf4f9be6681c871da35521eaaf59fadd7d509613a9e1881c5f74b587
+kind_binaries[1.24]='kind'
+
+### Functions ###
+
+function generate_cluster_yaml() {
+    # These are used by render_template
+    local pod_cidr service_cidr dns_domain disable_cni
+    # shellcheck disable=SC2034
+    pod_cidr="${cluster_CIDRs[${cluster}]}"
+    # shellcheck disable=SC2034
+    service_cidr="${service_CIDRs[${cluster}]}"
+    # shellcheck disable=SC2034
+    dns_domain="${cluster}.local"
+    disable_cni="false"
+    # shellcheck disable=SC2034
+    [[ -z "${cluster_cni[$cluster]}" ]] || disable_cni="true"
+
+    local nodes
+    for node in ${cluster_nodes[${cluster}]}; do nodes="${nodes}"$'\n'"- role: $node"; done
+
+    render_template "${RESOURCES_DIR}/kind-cluster-config.yaml" > "${RESOURCES_DIR}/${cluster}-config.yaml"
+}
+
+function kind_fixup_config() {
+    local master_ip
+    master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}-control-plane" | head -n 1)
+    sed -i -- "s/server: .*/server: https:\/\/$master_ip:6443/g" "$KUBECONFIG"
+    sed -i -- "s/user: kind-.*/user: ${cluster}/g" "$KUBECONFIG"
+    sed -i -- "s/name: kind-.*/name: ${cluster}/g" "$KUBECONFIG"
+    sed -i -- "s/cluster: kind-.*/cluster: ${cluster}/g" "$KUBECONFIG"
+    sed -i -- "s/current-context: .*/current-context: ${cluster}/g" "$KUBECONFIG"
+    chmod a+r "$KUBECONFIG"
+}
+
+# In development environments where clusters are brought up and down
+# multiple times, several Docker images are repeatedly pulled and deleted,
+# leading to the Docker error:
+#   "toomanyrequests: You have reached your pull rate limit"
+# Preload the KIND image. Also tag it so the `docker system prune` during
+# cleanup won't remove it.
+function download_kind() {
+    if [[ -z "${K8S_VERSION}" ]]; then
+        echo "K8S_VERSION not set."
+        return
+    fi
+
+    # Example: kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+    kind_image="kindest/node:v${K8S_VERSION}"
+    # Example: kindest/node:v1.20.7
+    kind_image_tag="kindest/node:v$(echo ${K8S_VERSION}|awk -F"@" '{print $1}')"
+    # Example: kindest/node:@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
+    kind_image_sha="kindest/node@$(echo ${K8S_VERSION}|awk -F"@" '{print $2}')"
+
+    # Check if image is already present, and if not, download it.
+    echo "Processing Image: $kind_image_tag ($kind_image)"
+    if [[ -n $(docker images -q "$kind_image_tag") ]] ; then
+        echo "Image $kind_image_tag already downloaded."
+        return
+    fi
+
+    echo "Image $kind_image_tag not found, downloading..."
+    if ! docker pull "$kind_image"; then
+        echo "**** 'docker pull $kind_image' failed. Manually run. ****"
+        return
+    fi
+
+    image_id=$(docker images -q "$kind_image_sha")
+    if ! docker tag "$image_id" "$kind_image_tag"; then
+        echo "'docker tag ${image_id} ${kind_image_tag}' failed."
+    fi
+}
+
+function provider_create_cluster() {
+    export KUBECONFIG=${KUBECONFIGS_DIR}/kind-config-${cluster}
+    rm -f "$KUBECONFIG"
+
+    if "${kind}" get clusters | grep -q "^${cluster}$"; then
+        echo "KIND cluster already exists, skipping its creation..."
+        "${kind}" export kubeconfig --name="${cluster}"
+        kind_fixup_config
+        return
+    fi
+
+    echo "Creating KIND cluster..."
+    if [[ "${cluster_cni[$cluster]}" == "ovn" ]]; then
+        deploy_kind_ovn
+        return
+    fi
+
+    generate_cluster_yaml
+    local image_flag=''
+    [[ -z "${K8S_VERSION}" ]] || image_flag="--image=kindest/node:v${K8S_VERSION}"
+
+    "${kind}" version
+    cat "${RESOURCES_DIR}/${cluster}-config.yaml"
+    "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
+    kind_fixup_config
+
+    ( deploy_cni; ) &
+    if ! wait $! ; then
+        echo "Failed to deploy CNI, removing the cluster"
+        kubectl cluster-info dump 1>&2
+        "${kind}" delete cluster --name="${cluster}"
+        return 1
+    fi
+}
+
+function deploy_cni() {
+    [[ -n "${cluster_cni[$cluster]}" ]] || return 0
+
+    eval "deploy_${cluster_cni[$cluster]}_cni"
+}
+
+function deploy_weave_cni(){
+    echo "Applying weave network..."
+
+    WEAVE_YAML=$(curl -sL "https://cloud.weave.works/k8s/net?k8s-version=v$K8S_VERSION&env.IPALLOC_RANGE=${cluster_CIDRs[${cluster}]}" | sed 's!ghcr.io/weaveworks/launcher!weaveworks!')
+
+    # Search the YAML for images that need to be downloaded
+    readarray -t IMAGE_LIST < <(echo "${WEAVE_YAML}" | yq e '.items[].spec.template.spec.containers[].image, .items[].spec.template.spec.initContainers[].image' -)
+    echo "IMAGE_LIST=${IMAGE_LIST[*]}"
+    for image in "${IMAGE_LIST[@]}"
+    do
+        IMAGE_FAILURE=false
+
+        # Check if image is already present, and if not, download it.
+        echo "Processing Image: $image"
+        if [ -z "$(docker images -q "$image")" ] ; then
+            echo "Image $image not found, downloading..."
+            if ! docker pull "$image"; then
+                echo "**** 'docker pull $image' failed. Manually run. ****"
+                IMAGE_FAILURE=true
+            fi
+        else
+            echo "Image $image already downloaded."
+        fi
+
+        if [ "${IMAGE_FAILURE}" == false ] ; then
+            LCL_REG_IMAGE_NAME="${image/weaveworks/localhost:5000}"
+            # Copy image to local registry if not there
+            if [ -z "$(docker images -q "${LCL_REG_IMAGE_NAME}")" ] ; then
+                echo "Image ${LCL_REG_IMAGE_NAME} not found, tagging and pushing ..."
+                if ! docker tag "$image" "${LCL_REG_IMAGE_NAME}"; then
+                    echo "'docker tag $image ${LCL_REG_IMAGE_NAME}' failed."
+                    IMAGE_FAILURE=true
+                else
+                    if ! docker push "${LCL_REG_IMAGE_NAME}"; then
+                        echo "'docker push ${LCL_REG_IMAGE_NAME}' failed."
+                        IMAGE_FAILURE=true
+                    fi
+                fi
+            else
+                echo "Image ${LCL_REG_IMAGE_NAME} already present."
+            fi
+        fi
+
+        if [ "${IMAGE_FAILURE}" == false ] ; then
+            # Update the YAML by replacing upstream image name with the local registry image name
+            WEAVE_YAML=$(echo "${WEAVE_YAML}" | \
+                    image=${image} \
+                    LCL_REG_IMAGE_NAME=${LCL_REG_IMAGE_NAME} \
+                    yq e 'with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.containers[].image | select(. == strenv(image));
+                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single") |
+                          with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.initContainers[].image | select(. == strenv(image));
+                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single")
+                    ' - )
+        fi
+    done
+
+    echo "${WEAVE_YAML}" | kubectl apply -f -
+    echo "Waiting for weave-net pods to be ready..."
+    with_retries 5 ensure_weave_pods
+    kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout="${TIMEOUT}"
+    echo "Waiting for core-dns deployment to be ready..."
+    kubectl -n kube-system rollout status deploy/coredns --timeout="${TIMEOUT}"
+}
+
+function ensure_weave_pods() {
+    if kubectl get pods -l name=weave-net -n kube-system | grep weave-net; then
+       return 0
+    fi
+
+    sleep 3
+    return 1
+}
+
+function deploy_ovn_cni(){
+    echo "OVN CNI deployed."
+}
+
+function deploy_kind_ovn(){
+    local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master"
+    export K8s_VERSION="${K8S_VERSION}"
+    export NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
+    export SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
+    export KIND_CLUSTER_NAME="${cluster}"
+
+    export OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
+    docker pull "${OVN_SRC_IMAGE}"
+    docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
+    docker push "${OVN_IMAGE}"
+
+    ( ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"; ) &
+    if ! wait $! ; then
+        echo "Failed to install kind with OVN"
+        "${kind}" delete cluster --name="${cluster}"
+        return 1
+    fi
+}
+
+function run_local_registry() {
+    # Run a local registry to avoid loading images manually to kind
+    if registry_running; then
+        echo "Local registry $KIND_REGISTRY already running."
+        return 0
+    fi
+
+    echo "Deploying local registry $KIND_REGISTRY to serve images centrally."
+    local volume_dir="/var/lib/registry"
+    local volume_flag="/dev/shm/${KIND_REGISTRY}:${volume_dir}"
+    selinuxenabled && volume_flag="${volume_flag}:z" 2>/dev/null
+    docker run -d -v "${volume_flag}" -p 127.0.0.1:5000:5000 --restart=always --name "$KIND_REGISTRY" registry:2
+    docker network connect kind "$KIND_REGISTRY" || true
+
+    # If the local volume mount directory is empty, probably due to a host reboot,
+    # then try to push any images with "localhost:5000".
+    if [[ -z "$(docker exec -e tmp_dir=${volume_dir} $KIND_REGISTRY /bin/sh -c 'ls -A ${tmp_dir} 2>/dev/null')" ]]; then
+        echo "Push images to local registry: $KIND_REGISTRY"
+        readarray -t local_image_list < <(docker images | awk -F' ' '/localhost:5000/ {print $1":"$2}')
+        for image in "${local_image_list[@]}"; do
+            docker push "${image}" || echo "Failed to push ${image@Q} to registry."
+        done
+    fi
+}
+
+function provider_failed() {
+    if [[ "$(cat /proc/sys/fs/inotify/max_user_instances)" -lt 512 ]]; then
+        echo "Your inotify settings are lower than our recommendation."
+        echo "This may cause failures in large deployments, but we don't know if it caused this failure."
+        echo "You may need to increase your inotify settings (currently $(cat /proc/sys/fs/inotify/max_user_watches) and $(cat /proc/sys/fs/inotify/max_user_instances)):"
+        echo sudo sysctl fs.inotify.max_user_watches=524288
+        echo sudo sysctl fs.inotify.max_user_instances=512
+        echo 'See https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files'
+    fi
+}
+
+# If any of the clusters use OVN-K as the CNI then clone the
+# ovn-kubernetes repo from master in order to access the required
+# kind scripts, and manifest generation templates.
+function download_ovnk() {
+    echo "Cloning ovn-kubernetes from source"
+    mkdir -p ovn-kubernetes
+    # We only need the contrib directory, use a sparse checkout
+    cd ovn-kubernetes
+    git init
+    git config core.sparseCheckout true
+    echo contrib/ > .git/info/sparse-checkout
+    echo dist/ >> .git/info/sparse-checkout
+    if git remote add -f origin https://github.com/ovn-org/ovn-kubernetes.git
+    then
+        git pull origin master
+    else
+        git fetch && git reset --hard origin/master
+    fi
+    cd ..
+}
+
+function provider_prepare() {
+    [[ -z "${K8S_VERSION}" ]] && K8S_VERSION="${DEFAULT_K8S_VERSION}"
+    kind="${kind_binaries[$K8S_VERSION]:-kind-0.12}"
+    [[ -n "${kind_k8s_versions[$K8S_VERSION]}" ]] && K8S_VERSION="${kind_k8s_versions[$K8S_VERSION]}"
+
+    download_kind
+    [[ "${cluster_cni[*]}" != *"ovn"* ]] || download_ovnk
+    run_local_registry
+}

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -39,12 +39,9 @@ function generate_cluster_yaml() {
 function kind_fixup_config() {
     local master_ip
     master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}-control-plane" | head -n 1)
-    sed -i -- "s/server: .*/server: https:\/\/$master_ip:6443/g" "$KUBECONFIG"
-    sed -i -- "s/user: kind-.*/user: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/name: kind-.*/name: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/cluster: kind-.*/cluster: ${cluster}/g" "$KUBECONFIG"
-    sed -i -- "s/current-context: .*/current-context: ${cluster}/g" "$KUBECONFIG"
-    chmod a+r "$KUBECONFIG"
+    yq -i ".clusters[0].cluster.server = \"https://${master_ip}:6443\"" "${KUBECONFIG}"
+    yq -i "(.. | select(. == \"kind-${cluster}\")) = \"${cluster}\"" "${KUBECONFIG}"
+    chmod a+r "${KUBECONFIG}"
 }
 
 # In development environments where clusters are brought up and down

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -105,12 +105,6 @@ function verify_gw_status() {
     return 1
 }
 
-function prepare_cluster() {
-    [[ ${cluster_subm[$cluster]} = "true" ]] || return 0
-    read -r -a nodes <<< "${cluster_nodes[$cluster]}"
-    kubectl label node "${cluster}-${nodes[-1]}" "submariner.io/gateway=true" --overwrite
-}
-
 function deploy_resource() {
     local resource_file=$1
     local resource_name

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -125,17 +125,6 @@ function remove_resource() {
     kubectl delete -f "$resource_file"
 }
 
-function load_deploytool() {
-    local deploy_lib=${SCRIPTS_DIR}/lib/deploy_${DEPLOYTOOL}
-    if [[ ! -f $deploy_lib ]]; then
-        echo "Unknown deploy method: ${DEPLOYTOOL}"
-        exit 1
-    fi
-
-    echo "Will deploy submariner using ${DEPLOYTOOL}"
-    . "$deploy_lib"
-}
-
 function find_submariner_namespace() {
     local namespace
     namespace="$(kubectl get pods --all-namespaces | awk '/submariner/{ print $1 }' | grep -v broker | head -n 1)"

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -75,7 +75,14 @@ function test_connection() {
 
 function connectivity_tests() {
     target_cluster="$1"
-    import_image quay.io/submariner/nettest
+    if [[ "${SUBM_IMAGE_TAG}" == 'subctl' ]]; then
+        local SUBM_IMAGE_TAG="${BASE_BRANCH}"
+        # This is used in the resource template YAML
+        # shellcheck disable=SC2034
+        local SUBM_IMAGE_REPO="${REPO}"
+    fi
+
+    [[ "${PROVIDER}" != 'kind' ]] || import_image "${REPO}/nettest"
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 
@@ -109,14 +116,14 @@ function deploy_resource() {
     local resource_file=$1
     local resource_name
     resource_name=$(basename "$resource_file" ".yaml")
-    kubectl apply -f "${resource_file}"
+    render_template "${resource_file}" | kubectl apply -f -
     echo "Waiting for ${resource_name} pods to be ready."
     kubectl rollout status "deploy/${resource_name}" --timeout="${TIMEOUT}"
 }
 
 function remove_resource() {
     local resource_file=$1
-    kubectl delete -f "$resource_file"
+    render_template "${resource_file}" | kubectl delete -f -
 }
 
 function find_submariner_namespace() {

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -61,11 +61,11 @@ function helm_install_subm() {
         --set serviceAccounts.lighthouseAgent.create="${LIGHTHOUSE}" \
         --set serviceAccounts.lighthouseCoreDns.create="${LIGHTHOUSE}" \
         --set submariner.natEnabled="false" \
-        --set operator.image.repository="localhost:5000/submariner-operator" \
-        --set operator.image.tag="local" \
+        --set operator.image.repository="${SUBM_IMAGE_REPO}/submariner-operator" \
+        --set operator.image.tag="${SUBM_IMAGE_TAG}" \
         --set operator.image.pullPolicy="IfNotPresent" \
-        --set submariner.images.repository="localhost:5000" \
-        --set submariner.images.tag="local" \
+        --set submariner.images.repository="${SUBM_IMAGE_REPO}" \
+        --set submariner.images.tag="${SUBM_IMAGE_TAG}" \
         --set brokercrds.create="${crd_create}"
 }
 

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -37,7 +37,7 @@ function setup_broker() {
     (
         cd "${OUTPUT_DIR}" && \
         "${SUBCTL}" deploy-broker \
-               --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
+               --kubecontext "${cluster}" \
                ${subctlrepver} \
                ${gn} \
                ${sd}
@@ -63,7 +63,7 @@ function subctl_install_subm() {
     fi
 
     # shellcheck disable=SC2086 # Split on purpose
-    "${SUBCTL}" join --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster" \
+    "${SUBCTL}" join --kubecontext "${cluster}" \
                 --clusterid "${cluster}" \
                 ${subctlrepver} \
                 --nattport "${CE_IPSEC_NATTPORT}" \
@@ -72,9 +72,6 @@ function subctl_install_subm() {
                 --cable-driver "${CABLE_DRIVER}" \
                 ${cidr_args} \
                 "${OUTPUT_DIR}"/broker-info.subm
-
-    # Print installed versions for manual validation of CI
-    "${SUBCTL}" show versions --kubeconfig "${KUBECONFIGS_DIR}/kind-config-$cluster"
 }
 
 function install_subm_all_clusters() {

--- a/scripts/shared/lib/ocp_utils
+++ b/scripts/shared/lib/ocp_utils
@@ -1,0 +1,5 @@
+function ensure_openshift_install() {
+    command -v openshift-install > /dev/null && return 0
+    curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz \
+        | tar -xzf - -C /usr/local/bin/ openshift-install
+}

--- a/scripts/shared/lib/ocp_utils
+++ b/scripts/shared/lib/ocp_utils
@@ -1,5 +1,19 @@
+declare -gr OCP_INSTALLER="${HOME}/.local/bin/openshift-install"
+declare -gA k8s_ocp_version
+k8s_ocp_version[1.20]=latest-4.7
+k8s_ocp_version[1.21]=latest-4.8
+k8s_ocp_version[1.22]=latest-4.9
+k8s_ocp_version[1.23]=latest-4.10
+k8s_ocp_version[1.24]=latest-4.11
+
 function ensure_openshift_install() {
-    command -v openshift-install > /dev/null && return 0
-    curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz \
-        | tar -xzf - -C /usr/local/bin/ openshift-install
+    local ocpi_version="${k8s_ocp_version[$K8S_VERSION]}"
+
+    # Check if we already have the version installed, and if so skip re-downloading it
+    ! grep -qw "${ocpi_version#*-}" <("${OCP_INSTALLER}" version 2>/dev/null) || return 0
+
+    # Download the installer when we don't have it installed, or what we have isn't the requested version
+    mkdir -p "${OCP_INSTALLER%/*}"
+    curl -Ls "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${ocpi_version}/openshift-install-linux.tar.gz" \
+        | tar -xzf - -C "${OCP_INSTALLER%/*}" "${OCP_INSTALLER##*/}"
 }

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -49,6 +49,18 @@ function with_retries() {
     exit 1
 }
 
+function sleep_on_fail() {
+    local duration=$1
+
+    if "${@:2}"; then
+        return 0
+    fi
+
+    echo "Failed to '${*:2}', sleeping for ${duration}."
+    sleep "${duration}"
+    return 1
+}
+
 # Run a command with the given cluster as the context, which will be unset once finished
 # 1st argument is the context which will be set to $cluster global variable.
 # 2nd argument is the command to execute.

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -222,3 +222,20 @@ function print_env() {
        printf '%s=%q\n' "$var" "$value"
    done
 }
+
+# Load a library to provide a pluggable command.
+# 1st parameter is the command e.g. `clusters`, `deploy`, etc
+# 2nd parameter is the name of the variable that determines the library variant
+function load_library() {
+    local cmnd="$1"
+    local lib_var="$2"
+    declare -n library="${lib_var}"
+
+    [[ -n "${library}" ]] || { echo "No ${lib_var} specified, please specify a ${lib_var}."; exit 1; }
+
+    local lib_file="${SCRIPTS_DIR}/lib/${cmnd}_${library//-/_}"
+    [[ -f "$lib_file" ]] || { echo "Unknown ${lib_var} ${library@Q}"; exit 1; }
+
+    echo "Will use ${library@Q} for ${cmnd}"
+    . "$lib_file"
+}

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -127,8 +127,8 @@ function add_cluster_cidrs() {
         global_CIDRs[$idx]="242.254.${1}.0/24"
     fi
 
-    cluster_CIDRs[$idx]="10.${val}.0.0/16"
-    service_CIDRs[$idx]="100.${val}.0.0/16"
+    cluster_CIDRs[$idx]="10.$((val+128)).0.0/16"
+    service_CIDRs[$idx]="100.$((val+64)).0.0/16"
 }
 
 function declare_cidrs() {

--- a/scripts/shared/resources/netshoot.yaml
+++ b/scripts/shared/resources/netshoot.yaml
@@ -15,9 +15,9 @@ spec:
     spec:
       containers:
         - name: netshoot
-          image: localhost:5000/nettest:local
+          image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           command:
             - sleep
-            - "3600"
+            - 1h
       restartPolicy: Always

--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: nginx-demo
-          image: localhost:5000/nettest:local
+          image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
           command: ["/app/simpleserver"]
           ports:
             - containerPort: 8080


### PR DESCRIPTION
This PR adds a host of features to Shipyard to allow quickly deploying clusters using OCP on AWS.

Please see individual commits for details.

Highlights:
* Support was added in shipyard to easily create test clusters using OCP on top of AWS.
  This allows developers and users to easily stand up a test/PoC environment with Submariner using AWS+OCP.
  The deployed environment will use the latest Submariner images, it's currently not possible to use locally built images.

  * `make clusters using=aws-ocp`
  * `make deploy using=aws-ocp`
  * `make e2e using=aws-ocp`
  * `make cleanup using=aws-ocp`

* Support was added to force running `subctl verify` when testing end-to-end, regardless of any local tests.
  To utilize this feature, run `make e2e using=subctl-verify`.
  Specific verifications can be now specified using the `SUBCTL_VERIFICATIONS` flag,
  e.g.: `make e2e using=subctl-verify SUBCTL_VERIFICATIONS='connectivity,service-discovery'`.

Partially resolves #912