### PR TITLE
Rename `DEBUG` to `DEBUG_PRINT`

### DIFF
--- a/.github/workflows/clean-tests.yml
+++ b/.github/workflows/clean-tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  DEBUG: true
+  DEBUG_PRINT: true
 jobs:
   clean-clusters:
     name: Cluster Clean-up

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  DEBUG: true
+  DEBUG_PRINT: true
 jobs:
   check-multiarch:
     name: Check the multi-arch builds

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  DEBUG: true
+  DEBUG_PRINT: true
 jobs:
   clusters:
     name: Clusters

--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -39,7 +39,7 @@ RUN_IN_DAPPER = ./.dapper $(DAPPER_ARGS) $(SELINUX_CONTEXT) --
 
 endif
 
-ifeq (true,$(DEBUG))
+ifeq (true,$(DEBUG_PRINT))
 MAKE_DEBUG_FLAG = --debug=b
 endif
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -5,9 +5,9 @@ PRELOAD_IMAGES ?= submariner-gateway submariner-operator submariner-route-agent
 
 ### Tunable variables for affecting make commands ###
 # Affecting multiple commands
-DEBUG ?= true
+DEBUG_PRINT ?= true
 TIMEOUT ?= 5m
-export DEBUG GLOBALNET PLUGIN SETTINGS TIMEOUT
+export DEBUG_PRINT GLOBALNET PLUGIN SETTINGS TIMEOUT
 
 # Specific to `clusters`
 K8S_VERSION ?= 1.24

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -37,7 +37,7 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: echo "DEBUG=true" >> $GITHUB_ENV
+      run: echo "DEBUG_PRINT=true" >> $GITHUB_ENV
     - shell: bash
       run: |
         echo "::group::Reclaiming free space"

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: echo "DEBUG=true" >> $GITHUB_ENV
+      run: echo "DEBUG_PRINT=true" >> $GITHUB_ENV
     - name: Set up QEMU (to support building on non-native architectures)
       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
     - name: Set up buildx

--- a/gh-actions/upgrade-e2e/action.yaml
+++ b/gh-actions/upgrade-e2e/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: echo "DEBUG=true" >> $GITHUB_ENV
+      run: echo "DEBUG_PRINT=true" >> $GITHUB_ENV
     - shell: bash
       run: |
         echo "::group::Reclaiming free space"

--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -9,7 +9,7 @@ NO_COLOR=$(echo -e '\e[0m')
 
 function trap_commands() {
     # Function to print each bash command before it is executed
-    trap 'cmd="$BASH_COMMAND" &&
+    trap '[[ "${DEBUG_PRINT}" == true ]] && cmd="$BASH_COMMAND" &&
           ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local) ]] &&
           { [[ ! "$cmd" =~ \$\( ]] || cmd="${cmd@Q}"; } &&
           ctxt="${cluster:+[${cluster}]}" &&
@@ -19,6 +19,5 @@ function trap_commands() {
 
 ### Main ###
 
-[[ "${DEBUG_PRINT}" == 'true' ]] || return 0
 set -T
 trap_commands

--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -19,6 +19,6 @@ function trap_commands() {
 
 ### Main ###
 
-[[ "${DEBUG}" == 'true' ]] || return 0
+[[ "${DEBUG_PRINT}" == 'true' ]] || return 0
 set -T
 trap_commands


### PR DESCRIPTION
Turns out the `DEBUG` env variable is used by `kubectl` (and probably
some of K8s go libraries) to control debug printing of network
connections.

Renaming our variable to `DEBUG_PRINT` to avoid this noise.

Example prints:
```
I0809 13:29:36.492157    5475 log.go:195] (0xc0006ee000) (0xc0008d6140) Create stream
I0809 13:29:36.492225    5475 log.go:195] (0xc0006ee000) (0xc0008d6140) Stream added, broadcasting: 1
I0809 13:29:36.493575    5475 log.go:195] (0xc0006ee000) Reply frame received for 1
I0809 13:29:36.493595    5475 log.go:195] (0xc0006ee000) (0xc0008d61e0) Create stream
I0809 13:29:36.493603    5475 log.go:195] (0xc0006ee000) (0xc0008d61e0) Stream added, broadcasting: 3
I0809 13:29:36.494109    5475 log.go:195] (0xc0006ee000) Reply frame received for 3
...
```

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
