### PR TITLE
Gather and restore GW nodes state

### DIFF
--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -211,3 +211,20 @@ func gatewayNames(gateways []unstructured.Unstructured) []string {
 
 	return names
 }
+
+// RestoreClustersGatewaysState sets the state of the gateway nodes in all clusters
+// to it's initial state from ClustersGatewaysState global var
+// The initial state gathered by the GatherClustersGatewaysState function.
+func (f *Framework) RestoreClustersGatewaysState() {
+	By("Restore the GW nodes to the initial state")
+
+	if len(ClustersGatewaysState) == 0 {
+		By("Skip gateways restore as no previous state is available")
+	}
+
+	for cluster := range ClustersGatewaysState {
+		for _, gnode := range ClustersGatewaysState[cluster] {
+			f.SetGatewayLabelOnNode(ClusterIndex(cluster), gnode, true)
+		}
+	}
+}

--- a/test/e2e/framework/ginkgo_framework.go
+++ b/test/e2e/framework/ginkgo_framework.go
@@ -27,7 +27,7 @@ func NewFramework(baseName string) *Framework {
 	ginkgo.BeforeEach(f.BeforeEach)
 	ginkgo.AfterEach(f.AfterEach)
 
-	AddCleanupAction(f.GatewayCleanup)
+	AddCleanupAction(f.RestoreClustersGatewaysState)
 
 	return f
 }


### PR DESCRIPTION
Add functions that will gather the state of the gateway nodes on all
clusters and restore it when required.
Will be used in redundancy tests.

- The "GatherClustersGatewaysState" function will execute during
  "BeforeSuite" execution and store the GW state globally.
- The "RestoreClustersGatewaysState" will be called by redundancy tests
  and will restore the state of GW nodes to the initial state.

The change will replace a static definition of GW state during restore.