### PR TITLE
Various fixes & refactors for debug printing for Shipyard

### DIFF
--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -7,14 +7,20 @@ NO_COLOR=$(echo -e '\e[0m')
 
 ### Functions ###
 
+# Function to print each bash command before it is executed.
+# Only outputs when $DEBUG_PRINT is set, to control printing precisely.
+# Skips common command (printing, control structures, etc).
+# Skips parsing `$()` as it causes the internal command to be executed twice.
+# Skips parsing `=(` as it causes an error for eval.
+# Skips printing function name twice (caveat - if we ever do a recursion, we won't see it).
 function trap_commands() {
-    # Function to print each bash command before it is executed
-    trap '[[ "${DEBUG_PRINT}" == true ]] && cmd="$BASH_COMMAND" &&
-          ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local) ]] &&
-          { [[ ! "$cmd" =~ \$\( ]] || cmd="${cmd@Q}"; } &&
-          ctxt="${cluster:+[${cluster}]}" &&
-          cmd=`eval echo "[$(date +%R:%S.%3N)] [${PWD##*/}]\$ $ctxt $cmd" 2>/dev/null` &&
-          echo "${CYAN_COLOR}$cmd${NO_COLOR}" >&2; true' DEBUG
+    trap '[[ "${DEBUG_PRINT}" == true ]] &&
+          declare -g cmd="$BASH_COMMAND" cur_func="${FUNCNAME[0]}" &&
+          ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local|printf) ]] &&
+          { [[ "$cmd" =~ =\$?\( ]] && cmd="${cmd@Q}" || cmd=$(eval echo "$cmd"); } &&
+          [[ -n "$cmd" && "${cmd%% *}" != "$cur_func" ]] &&
+          ctxt="[$(date +%R:%S.%3N)] [${PWD##*/}]${cluster:+ [${cluster}]}" &&
+          echo "${CYAN_COLOR}${ctxt}\$ ${cmd}${NO_COLOR}" >&2; true' DEBUG
 }
 
 ### Main ###

--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -19,7 +19,7 @@ function trap_commands() {
           ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local|printf) ]] &&
           { [[ "$cmd" =~ =\$?\( ]] && cmd="${cmd@Q}" || cmd=$(eval echo "$cmd"); } &&
           [[ -n "$cmd" && "${cmd%% *}" != "$cur_func" ]] &&
-          ctxt="[$(date +%R:%S.%3N)] [${PWD##*/}]${cluster:+ [${cluster}]}" &&
+          ctxt="[$(date +%R:%S.%3N)] [dir=${PWD##*/}${cluster:+; cl=${cluster}}${cur_func:+; fn=${cur_func}}]" &&
           echo "${CYAN_COLOR}${ctxt}\$ ${cmd}${NO_COLOR}" >&2; true' DEBUG
 }
 

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -55,6 +55,7 @@ function with_retries() {
     local cmnd=$2
 
     iteration=1; while ((iteration <= retries)); do
+        >&2 echo "Attempt ${iteration}/${retries} to run '${*:2}'"
         (
             DEBUG_PRINT=${ORIG_DEBUG_PRINT}
             $cmnd "${@:3}"

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -39,6 +39,7 @@ function expect_env() {
 
 # Render a template file
 function render_template() {
+    local DEBUG_PRINT=false
     eval "echo \"$(cat "$1")\""
 }
 
@@ -157,6 +158,7 @@ function add_cluster_cidrs() {
 }
 
 function declare_cidrs() {
+    local DEBUG_PRINT=false
     # shellcheck disable=SC2034 # these variables are used elsewhere
     declare -gA cluster_CIDRs service_CIDRs global_CIDRs
     local cluster i=1
@@ -172,6 +174,7 @@ function declare_kubeconfig() {
 }
 
 function print_clusters_message() {
+    local DEBUG_PRINT=false
     cat << EOM
 Your virtual cluster(s) are deployed and working properly and can be accessed with:
 
@@ -193,6 +196,7 @@ function run_if_defined() {
 }
 
 function load_settings() {
+    local DEBUG_PRINT=false
     expect_env SETTINGS "Deployment settings file"
     declare -ga clusters
     declare -gA cluster_cni cluster_nodes cluster_subm
@@ -235,11 +239,12 @@ function _yq() {
 }
 
 function print_env() {
-   echo "Running with environment variables:"
-   for var; do
-       declare -n value="$var"
-       printf '%s=%q\n' "$var" "$value"
-   done
+    local DEBUG_PRINT=false
+    echo "Running with environment variables:"
+    for var; do
+        declare -n value="$var"
+        printf '%s=%q\n' "$var" "$value"
+    done
 }
 
 # Load a library to provide a pluggable command.

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -100,12 +100,12 @@ function run_consecutive() {
 # 2nd argument is the command to execute, which will have the $cluster variable set.
 # 3rd argument and so forth get passed to the command.
 function run_parallel() {
-    local cmnd=$2
+    local cluster
     declare -A pids
-    for cluster in $(eval echo "$1"); do
+    for cluster in $1; do
         (
            set -o pipefail
-           $cmnd "${@:3}" |& sed "/\[${cluster}]/!s/^/[${cluster}] /"
+           "${@:2}" |& sed "/\[${cluster}]/!s/^/[${cluster}] /"
         ) &
         pids["${cluster}"]=$!
     done
@@ -126,7 +126,7 @@ function run_all_clusters() {
 
 # Run the given command (with any arguments) in parallel on the clusters that install submariner.
 function run_subm_clusters() {
-    declare -a subm_clusters
+    local cluster subm_clusters=()
     for cluster in "${clusters[@]}"; do
         [[ "${cluster_subm[${cluster}]}" != "true" ]] || subm_clusters+=( "${cluster}" )
     done
@@ -159,8 +159,8 @@ function add_cluster_cidrs() {
 function declare_cidrs() {
     # shellcheck disable=SC2034 # these variables are used elsewhere
     declare -gA cluster_CIDRs service_CIDRs global_CIDRs
+    local cluster i=1
 
-    i=1
     for cluster in "${clusters[@]}"; do
         add_cluster_cidrs "$i" "$cluster"
         i=$(("$i"+1))
@@ -213,6 +213,7 @@ function _yq() {
 }
 
 function load_settings_from_yaml() {
+    local cluster
     declare -ga clusters
     declare -gA cluster_cni cluster_nodes cluster_subm
 

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -113,7 +113,7 @@ function run_parallel() {
         (
            set -o pipefail
            DEBUG_PRINT=${ORIG_DEBUG_PRINT}
-           "${@:2}" |& sed "/\[${cluster}]/!s/^/[${cluster}] /"
+           "${@:2}" |& sed "/cl=${cluster}/!s/^/[${cluster}] /"
         ) &
         pids["${cluster}"]=$!
     done

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -10,6 +10,7 @@ readonly RESOURCES_DIR=${SCRIPTS_DIR}/resources
 readonly OUTPUT_DIR=${DAPPER_OUTPUT}
 readonly KUBECONFIGS_DIR=${DAPPER_OUTPUT}/kubeconfigs
 readonly SUBM_NS=submariner-operator
+readonly ORIG_DEBUG_PRINT=$DEBUG_PRINT
 
 ### Functions ###
 
@@ -49,11 +50,15 @@ function render_template() {
 # 3rd argument and so forth get passed to the command.
 # The current iteration is made available in the iteration variable.
 function with_retries() {
+    local DEBUG_PRINT=false
     local retries=$1
     local cmnd=$2
 
     iteration=1; while ((iteration <= retries)); do
-        ( $cmnd "${@:3}"; ) &
+        (
+            DEBUG_PRINT=${ORIG_DEBUG_PRINT}
+            $cmnd "${@:3}"
+        ) &
         if wait $!; then
             return 0
         fi
@@ -101,11 +106,13 @@ function run_consecutive() {
 # 2nd argument is the command to execute, which will have the $cluster variable set.
 # 3rd argument and so forth get passed to the command.
 function run_parallel() {
+    local DEBUG_PRINT=false
     local cluster
     declare -A pids
     for cluster in $1; do
         (
            set -o pipefail
+           DEBUG_PRINT=${ORIG_DEBUG_PRINT}
            "${@:2}" |& sed "/\[${cluster}]/!s/^/[${cluster}] /"
         ) &
         pids["${cluster}"]=$!
@@ -127,6 +134,7 @@ function run_all_clusters() {
 
 # Run the given command (with any arguments) in parallel on the clusters that install submariner.
 function run_subm_clusters() {
+    local DEBUG_PRINT=false
     local cluster subm_clusters=()
     for cluster in "${clusters[@]}"; do
         [[ "${cluster_subm[${cluster}]}" != "true" ]] || subm_clusters+=( "${cluster}" )

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -194,26 +194,6 @@ function run_if_defined() {
 
 function load_settings() {
     expect_env SETTINGS "Deployment settings file"
-
-    load_settings_from_yaml
-    cat << EOM
-Cluster settings::
-  broker - ${broker@Q}
-  clusters - ${clusters[*]@Q}
-  cni - $(typeset -p cluster_cni | cut -f 2- -d=)
-  nodes per cluster - $(typeset -p cluster_nodes | cut -f 2- -d=)
-  install submariner - $(typeset -p cluster_subm | cut -f 2- -d=)
-EOM
-}
-
-function _yq() {
-    local output
-    output=$(yq e "$*" "${SETTINGS}")
-    [[ "${output}" == "null" ]] || echo "${output}"
-}
-
-function load_settings_from_yaml() {
-    local cluster
     declare -ga clusters
     declare -gA cluster_cni cluster_nodes cluster_subm
 
@@ -230,12 +210,28 @@ function load_settings_from_yaml() {
     fi
 
     # Determine per cluster settings, default to global if not defined
+    local cluster
     for cluster in "${clusters[@]}"; do
         cluster_cni["${cluster}"]=$(_yq ".clusters.${cluster}.cni // .cni")
         cluster_nodes["${cluster}"]=$(_yq ".clusters.${cluster}.nodes // .nodes")
         cluster_subm["${cluster}"]=$(_yq ".clusters.${cluster}.submariner")
         cluster_subm["${cluster}"]=$(_yq ".submariner")
     done
+
+    cat << EOM
+Cluster settings::
+  broker - ${broker@Q}
+  clusters - ${clusters[*]@Q}
+  cni - $(typeset -p cluster_cni | cut -f 2- -d=)
+  nodes per cluster - $(typeset -p cluster_nodes | cut -f 2- -d=)
+  install submariner - $(typeset -p cluster_subm | cut -f 2- -d=)
+EOM
+}
+
+function _yq() {
+    local output
+    output=$(yq e "$*" "${SETTINGS}")
+    [[ "${output}" == "null" ]] || echo "${output}"
 }
 
 function print_env() {


### PR DESCRIPTION
This is an assortment of various fixes and associated refactors for debug printing.
Please see individual commits for details.

Highlights:
* Stop setting/printing cluster context when not in such a context
* Skip printing debug info in some `utils` functions
* Skip function double print
* Print func name as part of debug context
* Print attempt message in `with_retries`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
