### PR TITLE
Extract `exit_error` and `expect_env` functions

### DIFF
--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
 set -e
-
-[[ $# == 3 ]] || { echo "You must specify exactly 3 arguments: The image name, the Dockerfile and a hash file to write to"; exit 1; }
-if [[ "${PLATFORM}" =~ , && -z "${OCIFILE}" ]]; then
-    echo Multi-arch builds require OCI output, please set OCIFILE
-    exit 1
-fi
-
 source "${SCRIPTS_DIR}/lib/utils"
+
+[[ $# == 3 ]] || exit_error 'You must specify exactly 3 arguments: The image name, the Dockerfile and a hash file to write to'
+[[ "${PLATFORM}" =~ , && -z "${OCIFILE}" ]] && exit_error 'Multi-arch builds require OCI output, please set OCIFILE'
+
 print_env OCIFILE PLATFORM REPO
 source "${SCRIPTS_DIR}/lib/debug_functions"
 

--- a/scripts/shared/cloud-prepare.sh
+++ b/scripts/shared/cloud-prepare.sh
@@ -45,8 +45,5 @@ declare_kubeconfig
 
 # Run in subshell to check response, otherwise `set -e` is not honored
 ( run_all_clusters cloud_prepare; ) &
-if ! wait $!; then
-    echo "Failed to prepare cloud"
-    exit 1
-fi
+wait $! || exit_error "Failed to prepare cloud"
 

--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -53,9 +53,8 @@ provider_prepare
 # Run in subshell to check response, otherwise `set -e` is not honored
 ( run_all_clusters with_retries 3 provider_create_cluster; ) &
 if ! wait $!; then
-    echo "Failed to create clusters using ${PROVIDER@Q}."
     run_if_defined provider_failed
-    exit 1
+    exit_error "Failed to create clusters using ${PROVIDER@Q}."
 fi
 
 declare_kubeconfig

--- a/scripts/shared/compile.sh
+++ b/scripts/shared/compile.sh
@@ -1,22 +1,19 @@
 #!/usr/bin/env bash
   
 set -e
+source "${SCRIPTS_DIR}/lib/utils"
 
 [[ -n "${BUILD_UPX}" ]] || BUILD_UPX=true
 
 ## Process command line arguments ##
 
-if [[ $# != 2 ]]; then
-    echo "The binary and source must be sepcified!"
-    exit 1
-fi
+[[ $# -eq 2 ]] || exit_error "The binary and source must be specified!"
 
 binary=$1
 source_file=$2
 
 set -e
 
-source "${SCRIPTS_DIR}/lib/utils"
 print_env BUILD_DEBUG BUILD_UPX LDFLAGS
 source "${SCRIPTS_DIR}/lib/debug_functions"
 

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -61,8 +61,7 @@ function create_catalog_source() {
 
   # Wait for the CatalogSource readiness
   if ! with_retries 60 kubectl get catalogsource -n "${MARKETPLACE_NAMESPACE}" "${cs}" -o jsonpath='{.status.connectionState.lastObservedState}'; then
-    echo "[ERROR](${cluster}) CatalogSource ${cs} is not ready."
-    exit 1
+    exit_error "[ERROR](${cluster}) CatalogSource ${cs} is not ready."
   fi
 
   echo "[INFO](${cluster}) Catalog source ${cs} created"
@@ -101,7 +100,7 @@ function install_bundle() {
 
   # Manual Approve
   echo "[INFO](${cluster}) Approve the InstallPlan..."
-  kubectl wait --for condition=InstallPlanPending --timeout=5m -n "${ns}" subs/"${sub}" || (echo "[ERROR](${cluster}) InstallPlan not found."; exit 1)
+  kubectl wait --for condition=InstallPlanPending --timeout=5m -n "${ns}" subs/"${sub}" || exit_error "[ERROR](${cluster}) InstallPlan not found."
   installPlan=$(kubectl get subscriptions.operators.coreos.com "${sub}" -n "${ns}" -o jsonpath='{.status.installPlanRef.name}')
   if [ -n "${installPlan}" ]; then
     kubectl patch installplan -n "${ns}" "${installPlan}" -p '{"spec":{"approved":true}}' --type merge

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
 set -em -o pipefail
+source "${SCRIPTS_DIR}/lib/utils"
 
 [[ "${GLOBALNET}" = "true" ]] && gn=-globalnet || gn=
 ginkgo_args=()
 [[ -n "${FOCUS}" ]] && ginkgo_args+=("-ginkgo.focus=${FOCUS}")
 [[ -n "${SKIP}" ]] && ginkgo_args+=("-ginkgo.skip=${SKIP}")
 
-source "${SCRIPTS_DIR}/lib/utils"
 print_env FOCUS GLOBALNET LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TESTDIR
 source "${SCRIPTS_DIR}/lib/debug_functions"
 

--- a/scripts/shared/lib/deploy_bundle
+++ b/scripts/shared/lib/deploy_bundle
@@ -16,9 +16,9 @@ BROKER_K8S_CA=""
 ### Functions ###
 
 function deploytool_prereqs() {
-  [[ -z "${SUBM_NS}" ]] && (echo "[ERROR] Required environment variables SUBM_NS not loaded"; exit 3)
-  [[ -z "${SUBM_CS}" ]] && (echo "[ERROR] Required environment variables SUBM_CS not loaded"; exit 3)
-  [[ -z "${SUBM_INDEX_IMG}" ]] && (echo "[ERROR] Required environment variables SUBM_INDEX_IMG not loaded"; exit 3)
+  expect_env SUBM_NS
+  expect_env SUBM_CS
+  expect_env SUBM_INDEX_IMG
 
   # Create new namespace
   run_subm_clusters "create_namespace ${SUBM_NS}"
@@ -37,8 +37,7 @@ function setup_broker() {
   local brokerClientSecret
 
   if ! (timeout 5m bash -c "until kubectl --context=${cluster} get crds brokers.submariner.io > /dev/null 2>&1; do sleep 10; done"); then
-      echo "[ERROR] Broker CRD was not found."
-      exit 1
+      exit_error "Broker CRD was not found."
   fi
 
   # Create the broker Namespace & RBAC
@@ -61,8 +60,7 @@ function setup_broker() {
 
   echo "[INFO] Wait for the broker readiness..."
   if ! (timeout 5m bash -c "until kubectl --context=${cluster} get brokers.submariner.io submariner-broker -n ${SUBM_NS} > /dev/null 2>&1; do sleep 10; done"); then
-      echo "[ERROR] Broker is not ready."
-      exit 1
+      exit_error "Broker is not ready."
   fi
 
   brokerClientSecret=$(kubectl -n "${BROKER_NAMESPACE}" get secrets -o json | jq -r -c '[.items[] | select(.metadata.annotations."kubernetes.io/service-account.name"=="'"${BROKER_CLIENT_SA}"'") | select(.data.token != null) | select(.data."ca.crt" != null)] | .[0]')
@@ -87,8 +85,7 @@ function install_subm() {
   fi
 
   if ! (timeout 5m bash -c "until kubectl --context=${cluster} get crds submariners.submariner.io > /dev/null 2>&1; do sleep 10; done"); then
-      echo "[ERROR] Submariner CRD was not found."
-      exit 1
+      exit_error "Submariner CRD was not found."
   fi
 
   # Create the Submariner instance

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -43,11 +43,7 @@ function get_svc_ip() {
         svc_ip=$(kubectl --context="$cluster" get svc -l "app=${svc_name}" | awk 'FNR == 2 {print $3}')
     fi
 
-    if [[ -z "$svc_ip" ]]; then
-        echo "Failed to get ${svc_name} IP"
-        exit 1
-    fi
-
+    [[ -n "$svc_ip" ]] || exit_error "Failed to get ${svc_name} IP"
     echo "$svc_ip"
 }
 
@@ -129,10 +125,7 @@ function remove_resource() {
 function find_submariner_namespace() {
     local namespace
     namespace="$(kubectl get pods --all-namespaces | awk '/submariner/{ print $1 }' | grep -v broker | head -n 1)"
-    if [[ "${namespace}" == "" ]]; then
-        echo "Could not find a submariner deployment namespace" >&2
-        exit 1
-    fi
+    [[ -n "${namespace}" ]] || exit_error "Could not find a Submariner deployment namespace"
     echo "${namespace}"
 }
 

--- a/scripts/shared/lib/deploy_ocm
+++ b/scripts/shared/lib/deploy_ocm
@@ -12,12 +12,9 @@ readonly HUB="cluster1"
 ### Functions ###
 
 function deploytool_prereqs() {
-  # shellcheck disable=SC2153 # this variable is defined elsewhere
-  [[ -z "${SUBM_NS}" ]] && (echo "[ERROR] Required environment variables SUBM_NS not loaded"; exit 3)
-  # shellcheck disable=SC2153 # this variable is defined elsewhere
-  [[ -z "${SUBM_CS}" ]] && (echo "[ERROR] Required environment variables SUBM_CS not loaded"; exit 3)
-  # shellcheck disable=SC2153 # this variable is defined elsewhere
-  [[ -z "${SUBM_INDEX_IMG}" ]] && (echo "[ERROR] Required environment variables SUBM_INDEX_IMG not loaded"; exit 3)
+  expect_env SUBM_NS
+  expect_env SUBM_CS
+  expect_env SUBM_INDEX_IMG
 
   # Create new namespace
   with_context "${HUB}" "create_namespace ${OCM_NS}"
@@ -105,8 +102,7 @@ function create_managed_clusters() {
       echo "[INFO](${cluster}) Accept the managed cluster ${mc} and approve its Certificate Signing Request (CSR)..."
       # Wait for the managed cluster resource
       if ! with_retries 120 kubectl get managedclusters.cluster.open-cluster-management.io "${mc}"; then
-        echo "[ERROR] Unable to find the managed cluster ${mc}."
-        exit 1
+        exit_error "Unable to find the managed cluster ${mc}."
       fi
       # Accept the managed cluster
       kubectl patch managedclusters.cluster.open-cluster-management.io "${mc}" \
@@ -116,7 +112,7 @@ function create_managed_clusters() {
       kubectl certificate approve "${csr_name}"
       # Wait for the managed cluster readiness
       kubectl wait --for condition=ManagedClusterJoined --timeout=5m managedclusters.cluster.open-cluster-management.io "${mc}" \
-      || (echo "[ERROR](${cluster}) The managed cluster ${mc} is not ready."; exit 1)
+      || exit_error "[ERROR](${cluster}) The managed cluster ${mc} is not ready."
       # Add the managed cluster to the submariner clusterset
       kubectl label managedclusters.cluster.open-cluster-management.io "${mc}" \
       "cluster.open-cluster-management.io/clusterset=submariner" --overwrite

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -23,6 +23,20 @@ function kubectl() {
     fi
 }
 
+# Exit after printing an error message
+function exit_error() {
+    >&2 printf "ERROR: %s\n" "$*"
+    exit 1
+}
+
+# Fail if the ENV variable is empty (with an optional message)
+function expect_env() {
+    declare -n value="$1"
+    local err="Expected env variable ${1@Q} can't be empty"
+    [[ -z "${*:2}" ]] || err+=" (${*:2})"
+    [[ -n "${value}" ]] || exit_error "$err"
+}
+
 # Render a template file
 function render_template() {
     eval "echo \"$(cat "$1")\""
@@ -45,8 +59,7 @@ function with_retries() {
         ((iteration++))
     done
 
-    echo "Max attempts reached, failed to run '${*:2}'!"
-    exit 1
+    exit_error "Max attempts reached, failed to run '${*:2}'!"
 }
 
 function sleep_on_fail() {
@@ -180,10 +193,7 @@ function run_if_defined() {
 }
 
 function load_settings() {
-    if [[ -z "${SETTINGS}" ]]; then
-        echo "Settings file must be specified!"
-        exit 1
-    fi
+    expect_env SETTINGS "Deployment settings file"
 
     load_settings_from_yaml
     cat << EOM
@@ -243,10 +253,10 @@ function load_library() {
     local lib_var="$2"
     declare -n library="${lib_var}"
 
-    [[ -n "${library}" ]] || { echo "No ${lib_var} specified, please specify a ${lib_var}."; exit 1; }
+    [[ -n "${library}" ]] || exit_error "No ${lib_var} specified, please specify a ${lib_var}."
 
     local lib_file="${SCRIPTS_DIR}/lib/${cmnd}_${library//-/_}"
-    [[ -f "$lib_file" ]] || { echo "Unknown ${lib_var} ${library@Q}"; exit 1; }
+    [[ -f "$lib_file" ]] || exit_error "Unknown ${lib_var} ${library@Q}"
 
     echo "Will use ${library@Q} for ${cmnd}"
     . "$lib_file"

--- a/scripts/shared/release_images.sh
+++ b/scripts/shared/release_images.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
 set -e
-
-if [[ $# == 0 ]]; then
-    echo "At least one image to release must be specified!"
-    exit 1
-fi
-
 source "${SCRIPTS_DIR}/lib/utils"
+
+[[ $# -gt 0 ]] || exit_error "At least one image to release must be specified!"
+
 print_env REPO TAG
 source "${SCRIPTS_DIR}/lib/debug_functions"
 

--- a/test/scripts/post_mortem/test.sh
+++ b/test/scripts/post_mortem/test.sh
@@ -27,8 +27,5 @@ echo "$post_mortem"
 
 for cluster in "${clusters[@]}"; do
     img=$(image_name)
-    if [[ ! $post_mortem =~ $(image_name) ]]; then
-        echo "Post mortem failed, didn't find failure for ${cluster}"
-        exit 1
-    fi
+    [[ $post_mortem =~ $(image_name) ]] || exit_error "Post mortem failed, didn't find failure for ${cluster}"
 done


### PR DESCRIPTION
This logic repeats all over the place, extract small util functions to
cut down repetitiveness and do it properly.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
