### PR TITLE
Only check out ovn-kubernetes contrib and dist

### DIFF
--- a/scripts/shared/clusters.sh
+++ b/scripts/shared/clusters.sh
@@ -317,8 +317,20 @@ function download_ovnk() {
     fi
 
     echo "Cloning ovn-kubernetes from source"
-    git clone https://github.com/ovn-org/ovn-kubernetes.git \
-        || { git -C ovn-kubernetes fetch && git -C ovn-kubernetes reset --hard origin/master; }
+    mkdir -p ovn-kubernetes
+    # We only need the contrib directory, use a sparse checkout
+    cd ovn-kubernetes
+    git init
+    git config core.sparseCheckout true
+    echo contrib/ > .git/info/sparse-checkout
+    echo dist/ >> .git/info/sparse-checkout
+    if git remote add -f origin https://github.com/ovn-org/ovn-kubernetes.git
+    then
+        git pull origin master
+    else
+        git fetch && git reset --hard origin/master
+    fi
+    cd ..
 }
 
 ### Main ###


### PR DESCRIPTION
We only need the contrib and dist directories from ovn-kubernetes, so
only check those out. This doesn't save any download time, but it
avoids build-tool confusion due to the introduction of new Go modules
in ovn-kubernetes.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
