### PR TITLE
Fix override for some images when using operator

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -8,6 +8,13 @@
 # Some projects rely on the default subctl being determined by the PATH
 readonly SUBCTL=${SUBCTL:-subctl}
 
+### Variables ###
+
+declare -gA component_by_image
+component_by_image['submariner-route-agent']=submariner-routeagent
+component_by_image['lighthouse-agent']=submariner-lighthouse-agent
+component_by_image['lighthouse-coredns']=submariner-lighthouse-coredns
+
 ### Functions ###
 
 function deploytool_prereqs() {
@@ -55,7 +62,9 @@ function subctl_install_subm() {
     declare -a image_overrides
     if [ "${SUBM_IMAGE_TAG}" != "subctl" ]; then
         for image in ${PRELOAD_IMAGES}; do
-            image_overrides+=(--image-override "${image}=${SUBM_IMAGE_REPO}/${image}:${SUBM_IMAGE_TAG}")
+            local image_key="${image}"
+            [[ -n "${component_by_image[$image]}" ]] && image_key="${component_by_image[$image]}"
+            image_overrides+=(--image-override "${image_key}=${SUBM_IMAGE_REPO}/${image}:${SUBM_IMAGE_TAG}")
         done
     fi
 


### PR DESCRIPTION
Several image overrides use a component key which doesn't match the
image name.
This needs specific attention when deploying with the operator.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
