### PR TITLE
Don't preload any images in Shipyard

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -73,12 +73,10 @@ endif
 
 ifneq (,$(filter lighthouse,$(_using)))
 LIGHTHOUSE = true
-override PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns
 endif
 
 ifneq (,$(filter globalnet,$(_using)))
 GLOBALNET = true
-override PRELOAD_IMAGES += submariner-globalnet
 endif
 
 ifneq (,$(filter helm,$(_using)))
@@ -88,22 +86,16 @@ endif
 ifneq (,$(filter bundle,$(_using)))
 OLM = true
 DEPLOYTOOL = bundle
-override PRELOAD_IMAGES += submariner-operator-index
 endif
 
 ifneq (,$(filter ocm,$(_using)))
 OLM = true
 DEPLOYTOOL = ocm
 LIGHTHOUSE = true
-override PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns submariner-operator-index
 endif
 
 ifneq (,$(filter prometheus,$(_using)))
 PROMETHEUS = true
-endif
-
-ifneq (,$(filter ovn,$(_using)))
-override PRELOAD_IMAGES += submariner-networkplugin-syncer
 endif
 
 # Force running E2E with `subctl verify`


### PR DESCRIPTION
Each project can choose whether to preload images or not, it's not
necessary to preload any images in Shipyard anymore.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
