### PR TITLE
Preload `IMAGES` by default, allow extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ BASE_BRANCH ?= devel
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 MULTIARCH_IMAGES ?= nettest
+EXTRA_PRELOAD_IMAGES := $(PRELOAD_IMAGES)
 PLATFORMS ?= linux/amd64,linux/arm64
 NON_DAPPER_GOALS += images multiarch-images
 SHELLCHECK_ARGS := $(shell find scripts -type f -exec awk 'FNR == 1 && /sh$$/ { print FILENAME }' {} +)
@@ -26,6 +27,9 @@ export LAZY_DEPLOY = false
 scale: SETTINGS = $(DAPPER_SOURCE)/.shipyard.scale.yml
 
 include Makefile.inc
+
+# In Shipyard we don't need to preload the dapper images, so override the default behavior.
+override PRELOAD_IMAGES=nettest $(EXTRA_PRELOAD_IMAGES)
 
 # Prevent rebuilding images inside dapper since they're already built outside it in Shipyard's case
 package/.image.nettest package/.image.shipyard-dapper-base: ;

--- a/Makefile.images
+++ b/Makefile.images
@@ -16,6 +16,14 @@ export USE_CACHE ?= true
 # Specific to `images`
 export OCIFILE PLATFORM
 
+# Specific to `preload-images`
+export PRELOAD_IMAGES
+
+# Automatically preload any images that the project builds, on top of any (if there were) requested by the caller
+ifdef IMAGES
+override PRELOAD_IMAGES += $(IMAGES)
+endif
+
 # Specific to `release-images`
 export TAG ?= $(CUTTING_EDGE)
 

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -11,6 +11,10 @@ readonly SUBCTL=${SUBCTL:-subctl}
 ### Variables ###
 
 declare -gA component_by_image
+component_by_image['submariner-gateway']=submariner-gateway
+component_by_image['submariner-globalnet']=submariner-globalnet
+component_by_image['submariner-networkplugin-syncer']=submariner-networkplugin-syncer
+component_by_image['submariner-operator']=submariner-operator
 component_by_image['submariner-route-agent']=submariner-routeagent
 component_by_image['lighthouse-agent']=submariner-lighthouse-agent
 component_by_image['lighthouse-coredns']=submariner-lighthouse-coredns
@@ -62,8 +66,8 @@ function subctl_install_subm() {
     declare -a image_overrides
     if [ "${SUBM_IMAGE_TAG}" != "subctl" ]; then
         for image in ${PRELOAD_IMAGES}; do
-            local image_key="${image}"
-            [[ -n "${component_by_image[$image]}" ]] && image_key="${component_by_image[$image]}"
+            local image_key="${component_by_image[$image]}"
+            [[ -n "${image_key}" ]] || continue
             image_overrides+=(--image-override "${image_key}=${SUBM_IMAGE_REPO}/${image}:${SUBM_IMAGE_TAG}")
         done
     fi


### PR DESCRIPTION
Instead of each project specifying its own images to preload, it would be best to preload the built images by default.
The main exception to the rule is Shipyard itself, which only needs to preload the `nettest` image it builds, but none of the "dapper" images.

This allows *extra* images to be manually specified by the caller using the same `PRELOAD_IMAGES` variable.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
