### PR TITLE
Set `SHELLCHECK_ARGS` automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ IMAGES ?= shipyard-dapper-base shipyard-linting nettest
 MULTIARCH_IMAGES ?= nettest
 PLATFORMS ?= linux/amd64,linux/arm64
 NON_DAPPER_GOALS += images multiarch-images
-SHELLCHECK_ARGS := $(shell find scripts -type f -exec awk 'FNR == 1 && /sh$$/ { print FILENAME }' {} +)
 FOCUS ?=
 SKIP ?=
 PLUGIN ?=

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -30,6 +30,9 @@ export FOCUS LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TESTDIR
 # Specific to `reload-images`
 export RESTART ?= none
 
+# Specific to `shellcheck`
+export SHELLCHECK_ARGS += $(shell [[ ! -d scripts ]] || find scripts -type f -exec awk 'FNR == 1 && /sh$$/ { print FILENAME }' {} +)
+
 # Specific to `compile.sh`
 export BUILD_DEBUG BUILD_UPX LDFLAGS
 


### PR DESCRIPTION
Set the variable automatically to any `sh` script under the `scripts` directory.
This way, consuming projects can (if they want) run shellcheck effortlessly.

Depends on https://github.com/submariner-io/admiral/pull/416
Depends on https://github.com/submariner-io/subctl/pull/260
Depends on https://github.com/submariner-io/submariner-operator/pull/2238
Depends on https://github.com/submariner-io/submariner/pull/2007
Depends on https://github.com/submariner-io/coastguard/pull/84

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
