### PR TITLE
Test connectivity with Lighthouse if available

### DIFF
--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -52,20 +52,7 @@ function test_connection() {
     local target_address=$2
 
     echo "Attempting connectivity between clusters - $source_pod --> $target_address"
-    wait_time=30
-    start_time=$(date +%s)
-    if ! kubectl exec "${source_pod}" -- curl --output /dev/null -m "${wait_time}" --silent --head --fail "${target_address}"; then
-        end_time=$(date +%s)
-        execution_time=$(( end_time - start_time))
-        if [ $execution_time -lt $wait_time ]
-        then
-           remaining_time=$(( wait_time - execution_time))
-           echo "curl returned too soon. Sleeping for $remaining_time secs"
-           sleep $remaining_time
-        fi
-        return 1
-    fi
-
+    kubectl exec "${source_pod}" -- curl --output /dev/null -m 10 --silent --head --fail "${target_address}"
     echo "Connection test was successful!"
 }
 
@@ -82,11 +69,12 @@ function connectivity_tests() {
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 
-    local netshoot_pod nginx_svc_ip
+    local netshoot_pod
     netshoot_pod=$(kubectl get pods -l app=netshoot | awk 'FNR == 2 {print $1}')
-    nginx_svc_ip=$(with_context "$target_cluster" get_svc_ip nginx-demo)
+    local nginx_svc=nginx-demo.default.svc.clusterset.local
+    [[ "$LIGHTHOUSE" = true ]] || nginx_svc=$(with_context "$target_cluster" get_svc_ip nginx-demo)
 
-    with_retries 5 test_connection "$netshoot_pod" "$nginx_svc_ip"
+    with_retries 10 sleep_on_fail 10s test_connection "$netshoot_pod" "$nginx_svc"
 
     remove_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" remove_resource "${RESOURCES_DIR}/nginx-demo.yaml"


### PR DESCRIPTION
If we're deploying with Lighthouse enabled, it would be better to do the smoke test for connectivity using the FQDN rather than the service IP. This way we're validating that we've deployed Lighthouse properly.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
