### PR TITLE
Add DoFailover function to failover GW node of k8s/ocp cluster

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -568,4 +569,11 @@ func NestedString(obj map[string]interface{}, fields ...string) string {
 	Expect(err).To(Succeed())
 
 	return str
+}
+
+func DetectProvider(cluster ClusterIndex, nodeName string) string {
+	node, err := KubeClients[cluster].CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	return strings.Split(node.Spec.ProviderID, ":")[0]
 }


### PR DESCRIPTION
- The DoFailover function will perform a fail over of the gateway node depends on the environment. If the platform is "kind", the failover will happen by setting the gateway label to false. In case of any other environment, the function will crash the node.

  The use of crashing the node on "kind" env is not possible as it will crash the host as well.

- Add a function to detect the ProviderID value.

Details of the change:
https://github.com/submariner-io/submariner/issues/2013

Depends On https://github.com/submariner-io/shipyard/pull/963

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
