### PR TITLE
Find multiple gateways

### DIFF
--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -31,6 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	gatewayStatusLabel  = "gateway.submariner.io/status"
+	gatewayStatusActive = "active"
+)
+
 // FindGatewayNodes finds nodes in a given cluster by matching 'submariner.io/gateway' value.
 func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
 	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
@@ -51,6 +56,19 @@ func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
 	Expect(err).NotTo(HaveOccurred())
 
 	return nodes.Items
+}
+
+// FindClusterWithMultipleGateways finds the cluster with multiple GW nodes.
+// Returns cluster index.
+func (f *Framework) FindClusterWithMultipleGateways() int {
+	for idx := range TestContext.ClusterIDs {
+		gatewayNodes := FindGatewayNodes(ClusterIndex(idx))
+		if len(gatewayNodes) >= 2 {
+			return idx
+		}
+	}
+
+	return -1
 }
 
 // SetGatewayLabelOnNode sets the 'submariner.io/gateway' value for a node to the specified value.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -63,3 +63,15 @@ func NewRequirement(key string, op selection.Operator, vals []string) labels.Req
 
 	return *r
 }
+
+// FindOtherClusterIndex looks within the environment for another cluster
+// besides the one provided and returns its index or -1 if none other is found.
+func FindOtherClusterIndex(mainCluster int) int {
+	for idx := range TestContext.ClusterIDs {
+		if idx != mainCluster {
+			return idx
+		}
+	}
+
+	return -1
+}


### PR DESCRIPTION
As part of the gateway failover test refactoring, the test will look for a cluster that contains two gateway nodes.
Add a function that will search for two gateway nodes over available clusters and return selected cluster.

Refactoring details:
https://github.com/submariner-io/submariner/issues/2013

Depends On https://github.com/submariner-io/shipyard/pull/964/files

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
