### PR TITLE
Upgrade kind to 0.15, add K8s 1.25

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -57,14 +57,14 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 ENV LINT_VERSION=v1.47.3 \
     HELM_VERSION=v3.9.0 \
-    KIND_VERSION=v0.14.0 \
+    KIND_VERSION=v0.15.0 \
     BUILDX_VERSION=v0.8.2 \
     GH_VERSION=2.5.1 \
     YQ_VERSION=4.20.2
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
-# We temporarily install kind-0.12 and kind-0.14; kind-0.14 is the default, and kind-0.12 is used for K8s before 1.24, until
-# all kind images are available with containerd 1.6.5 or later
+# We install kind-0.12 and kind-0.15; we need to test K8s 1.17, our oldest-supported version, and kind-0.12 was the last version to
+# ship K8s 1.17 images and also work with Weave (because of containerd version 1.6.5 incompatabilty)
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -7,15 +7,16 @@
 declare -gA kind_k8s_versions kind_binaries
 # kind-0.12 hashes
 kind_k8s_versions[1.17]=1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5
-kind_k8s_versions[1.18]=1.18.20@sha256:e3dca5e16116d11363e31639640042a9b1bd2c90f85717a7fc66be34089a8169
-kind_k8s_versions[1.19]=1.19.16@sha256:81f552397c1e6c1f293f967ecb1344d8857613fb978f963c30e907c32f598467
-kind_k8s_versions[1.20]=1.20.15@sha256:393bb9096c6c4d723bb17bceb0896407d7db581532d11ea2839c80b28e5d8deb
-kind_k8s_versions[1.21]=1.21.10@sha256:84709f09756ba4f863769bdcabe5edafc2ada72d3c8c44d6515fc581b66b029c
-kind_k8s_versions[1.22]=1.22.7@sha256:1dfd72d193bf7da64765fd2f2898f78663b9ba366c2aa74be1fd7498a1873166
-kind_k8s_versions[1.23]=1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
-# kind-0.14 hashes
-kind_k8s_versions[1.24]=1.24.2@sha256:a3220cefdf4f9be6681c871da35521eaaf59fadd7d509613a9e1881c5f74b587
-kind_binaries[1.24]='kind'
+kind_binaries[1.17]='kind-0.12'
+# kind-0.15 hashes
+kind_k8s_versions[1.18]=1.18.20@sha256:61c9e1698c1cb19c3b1d8151a9135b379657aee23c59bde4a8d87923fcb43a91
+kind_k8s_versions[1.19]=1.19.16@sha256:707469aac7e6805e52c3bde2a8a8050ce2b15decff60db6c5077ba9975d28b98
+kind_k8s_versions[1.20]=1.20.15@sha256:d67de8f84143adebe80a07672f370365ec7d23f93dc86866f0e29fa29ce026fe
+kind_k8s_versions[1.21]=1.21.14@sha256:f9b4d3d1112f24a7254d2ee296f177f628f9b4c1b32f0006567af11b91c1f301
+kind_k8s_versions[1.22]=1.22.13@sha256:4904eda4d6e64b402169797805b8ec01f50133960ad6c19af45173a27eadf959
+kind_k8s_versions[1.23]=1.23.10@sha256:f047448af6a656fae7bc909e2fab360c18c487ef3edc93f06d78cdfd864b2d12
+kind_k8s_versions[1.24]=1.24.4@sha256:adfaebada924a26c2c9308edd53c6e33b3d4e453782c0063dc0028bdebaddf98
+kind_k8s_versions[1.25]=1.25.0@sha256:428aaa17ec82ccde0131cb2d1ca6547d13cf5fdabcc0bbecf749baa935387cbf
 
 ### Functions ###
 
@@ -281,7 +282,7 @@ function download_ovnk() {
 
 function provider_prepare() {
     [[ -z "${K8S_VERSION}" ]] && K8S_VERSION="${DEFAULT_K8S_VERSION}"
-    kind="${kind_binaries[$K8S_VERSION]:-kind-0.12}"
+    kind="${kind_binaries[$K8S_VERSION]:-kind}"
     [[ -n "${kind_k8s_versions[$K8S_VERSION]}" ]] && K8S_VERSION="${kind_k8s_versions[$K8S_VERSION]}"
 
     download_kind


### PR DESCRIPTION
Keep kind 0.12 to support testing the oldest known-working K8s version.

Relates-to: #949
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
