### PR TITLE
Add load balancer deployment support

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -55,6 +55,7 @@ jobs:
             extra-toggles: lighthouse
           - deploytool: helm
             extra-toggles: lighthouse
+          - extra-toggles: load-balancer
           - extra-toggles: prometheus
     steps:
       - name: Reclaim space on GHA host (if the job needs it)

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -8,12 +8,13 @@ DEBUG_PRINT ?= true
 PARALLEL ?= true
 PROVIDER ?= kind
 TIMEOUT ?= 5m
-export DEBUG_PRINT GLOBALNET PARALLEL PLUGIN PRELOAD_IMAGES PROVIDER SETTINGS TIMEOUT
+export DEBUG_PRINT GLOBALNET LOAD_BALANCER PARALLEL PLUGIN PRELOAD_IMAGES PROVIDER SETTINGS TIMEOUT
 
 # Specific to `clusters`
 K8S_VERSION ?= 1.25
+METALLB_VERSION ?= 0.13.5
 OLM_VERSION ?= v0.18.3
-export K8S_VERSION OLM OLM_VERSION PROMETHEUS
+export K8S_VERSION METALLB_VERSION OLM OLM_VERSION PROMETHEUS
 
 # Specific to `deploy`
 CABLE_DRIVER ?= libreswan
@@ -109,6 +110,10 @@ endif
 ifneq (,$(filter aws-ocp,$(_using)))
 PROVIDER = aws-ocp
 IMAGE_TAG = subctl
+endif
+
+ifneq (,$(filter load-balancer,$(_using)))
+LOAD_BALANCER = true
 endif
 
 ifeq ($(LIGHTHOUSE),true)

--- a/release-notes/20220919-load-balancer.md
+++ b/release-notes/20220919-load-balancer.md
@@ -1,0 +1,5 @@
+<!-- markdownlint-disable MD041 -->
+Support was added in the Shipyard project to easily deploy Submariner with a LoadBalancer type Service in front.
+To use, simply specify the target (e.g. `deploy`) with `USING=load-balancer` or `LOAD_BALANCER=true`.
+For kind-based deployments, [MetalLB](https://metallb.universe.tf/) is deployed to provide the capability.
+The MetalLB version can be specified using `METALLB_VERSION=x.y.z`.

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -111,10 +111,15 @@ function provider_create_cluster() {
     "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
     kind_fixup_config
 
-    ( deploy_cni; ) &
+    delete_cluster_on_fail deploy_cni
+    [[ "$LOAD_BALANCER" != true ]] || delete_cluster_on_fail deploy_load_balancer
+}
+
+function delete_cluster_on_fail() {
+    ( "$@"; ) &
     if ! wait $! ; then
-        echo "Failed to deploy CNI, removing the cluster"
-        kubectl cluster-info dump 1>&2
+        echo "Failed to run '$*', removing the cluster"
+        kubectl cluster-info dump || echo "Can't get cluster info" 1>&2
         "${kind}" delete cluster --name="${cluster}"
         return 1
     fi
@@ -203,6 +208,34 @@ function deploy_ovn_cni(){
     echo "OVN CNI deployed."
 }
 
+function deploy_load_balancer() {
+    local kind_ip start_ip end_ip net_addr
+    kind_ip=$(docker network inspect -f '{{.IPAM.Config}}' kind | awk '/.*/ { print $2 }')
+    net_addr=$(echo "${cluster_CIDRs[$cluster]}" | cut -f2 -d'.')
+    [[ "$GLOBALNET" != true ]] || net_addr=$(echo "${global_CIDRs[$cluster]}" | cut -f3 -d'.')
+    start_ip=$(echo "$kind_ip" | cut -f1-2 -d'.')."$net_addr".100
+    end_ip=$(echo "$start_ip" | cut -f1-3 -d'.').250
+
+    kubectl apply -f "https://raw.githubusercontent.com/metallb/metallb/v${METALLB_VERSION}/config/manifests/metallb-native.yaml"
+    kubectl wait --for=condition=Ready pods -l app=metallb -n metallb-system --timeout="${TIMEOUT}"
+    kubectl apply -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: submariner-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - ${start_ip}-${end_ip}
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: submariner-l2
+  namespace: metallb-system
+EOF
+}
+
 function deploy_kind_ovn(){
     local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-f:master"
     export K8s_VERSION="${K8S_VERSION}"
@@ -215,12 +248,7 @@ function deploy_kind_ovn(){
     docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
     docker push "${OVN_IMAGE}"
 
-    ( ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"; ) &
-    if ! wait $! ; then
-        echo "Failed to install kind with OVN"
-        "${kind}" delete cluster --name="${cluster}"
-        return 1
-    fi
+    delete_cluster_on_fail ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"
 }
 
 function run_local_registry() {

--- a/scripts/shared/lib/deploy_helm
+++ b/scripts/shared/lib/deploy_helm
@@ -51,6 +51,8 @@ function helm_install_subm() {
         extra_flags+=(--set "images.${image}=${SUBM_IMAGE_REPO}/${image}:${SUBM_IMAGE_TAG}")
     done
 
+    [[ "$LOAD_BALANCER" = true ]] && extra_flags+=(--set submariner.loadBalancerEnabled='true')
+
     echo "Installing Submariner..."
     # shellcheck disable=SC2086 # Split on purpose
     helm --kube-context "${cluster}" install --debug --devel submariner-operator \

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -67,6 +67,7 @@ function subctl_install_subm() {
         done
     fi
 
+    [[ "$LOAD_BALANCER" = true ]] && extra_flags+=(--load-balancer)
     if [ "${PASS_CIDR_ARGS}" == "true" ];then
         extra_flags+=(--clustercidr "${cluster_CIDRs[${cluster}]}" --servicecidr "${service_CIDRs[${cluster}]}")
     fi


### PR DESCRIPTION
This makes it easy to deploy a test environment with the load balancer, by calling e.g. `make deploy using=load-balancer`.

For kind based deployments, `metallb` is deployed and used.

Depends on #952 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
