### PR TITLE
Use the default kind CNI, drop support for Weave

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -65,7 +65,7 @@ ENV LINT_VERSION=v1.47.3 \
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
 # We install kind-0.12 and kind-0.15; we need to test K8s 1.17, our oldest-supported version, and kind-0.12 was the last version to
-# ship K8s 1.17 images and also work with Weave (because of containerd version 1.6.5 incompatabilty)
+# ship K8s 1.17 images
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -111,7 +111,6 @@ function provider_create_cluster() {
     "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
     kind_fixup_config
 
-    delete_cluster_on_fail deploy_cni
     [[ "$LOAD_BALANCER" != true ]] || delete_cluster_on_fail deploy_load_balancer
 }
 
@@ -123,89 +122,6 @@ function delete_cluster_on_fail() {
         "${kind}" delete cluster --name="${cluster}"
         return 1
     fi
-}
-
-function deploy_cni() {
-    [[ -n "${cluster_cni[$cluster]}" ]] || return 0
-
-    eval "deploy_${cluster_cni[$cluster]}_cni"
-}
-
-function deploy_weave_cni(){
-    echo "Applying weave network..."
-
-    WEAVE_YAML=$(curl -sL "https://cloud.weave.works/k8s/net?k8s-version=v$K8S_VERSION&env.IPALLOC_RANGE=${cluster_CIDRs[${cluster}]}" | sed 's!ghcr.io/weaveworks/launcher!weaveworks!')
-
-    # Search the YAML for images that need to be downloaded
-    readarray -t IMAGE_LIST < <(echo "${WEAVE_YAML}" | yq e '.items[].spec.template.spec.containers[].image, .items[].spec.template.spec.initContainers[].image' -)
-    echo "IMAGE_LIST=${IMAGE_LIST[*]}"
-    for image in "${IMAGE_LIST[@]}"
-    do
-        IMAGE_FAILURE=false
-
-        # Check if image is already present, and if not, download it.
-        echo "Processing Image: $image"
-        if [ -z "$(docker images -q "$image")" ] ; then
-            echo "Image $image not found, downloading..."
-            if ! docker pull "$image"; then
-                echo "**** 'docker pull $image' failed. Manually run. ****"
-                IMAGE_FAILURE=true
-            fi
-        else
-            echo "Image $image already downloaded."
-        fi
-
-        if [ "${IMAGE_FAILURE}" == false ] ; then
-            LCL_REG_IMAGE_NAME="${image/weaveworks/localhost:5000}"
-            # Copy image to local registry if not there
-            if [ -z "$(docker images -q "${LCL_REG_IMAGE_NAME}")" ] ; then
-                echo "Image ${LCL_REG_IMAGE_NAME} not found, tagging and pushing ..."
-                if ! docker tag "$image" "${LCL_REG_IMAGE_NAME}"; then
-                    echo "'docker tag $image ${LCL_REG_IMAGE_NAME}' failed."
-                    IMAGE_FAILURE=true
-                else
-                    if ! docker push "${LCL_REG_IMAGE_NAME}"; then
-                        echo "'docker push ${LCL_REG_IMAGE_NAME}' failed."
-                        IMAGE_FAILURE=true
-                    fi
-                fi
-            else
-                echo "Image ${LCL_REG_IMAGE_NAME} already present."
-            fi
-        fi
-
-        if [ "${IMAGE_FAILURE}" == false ] ; then
-            # Update the YAML by replacing upstream image name with the local registry image name
-            WEAVE_YAML=$(echo "${WEAVE_YAML}" | \
-                    image=${image} \
-                    LCL_REG_IMAGE_NAME=${LCL_REG_IMAGE_NAME} \
-                    yq e 'with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.containers[].image | select(. == strenv(image));
-                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single") |
-                          with(.items[] | select(.kind == "DaemonSet")| .spec.template.spec.initContainers[].image | select(. == strenv(image));
-                            . = strenv(LCL_REG_IMAGE_NAME) | . style="single")
-                    ' - )
-        fi
-    done
-
-    echo "${WEAVE_YAML}" | kubectl apply -f -
-    echo "Waiting for weave-net pods to be ready..."
-    with_retries 5 ensure_weave_pods
-    kubectl wait --for=condition=Ready pods -l name=weave-net -n kube-system --timeout="${TIMEOUT}"
-    echo "Waiting for core-dns deployment to be ready..."
-    kubectl -n kube-system rollout status deploy/coredns --timeout="${TIMEOUT}"
-}
-
-function ensure_weave_pods() {
-    if kubectl get pods -l name=weave-net -n kube-system | grep weave-net; then
-       return 0
-    fi
-
-    sleep 3
-    return 1
-}
-
-function deploy_ovn_cni(){
-    echo "OVN CNI deployed."
 }
 
 function deploy_load_balancer() {


### PR DESCRIPTION
Weave is no longer actively maintained, and our tests work with the default kind CNI. Until we need something more featureful, switch to the default kind CNI, and remove support for Weave altogether.

See https://github.com/submariner-io/shipyard/issues/858.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

Depends on https://github.com/submariner-io/lighthouse/pull/880
Depends on https://github.com/submariner-io/releases/pull/495
Depends on https://github.com/submariner-io/subctl/pull/270
Depends on https://github.com/submariner-io/submariner/pull/2029
Depends on https://github.com/submariner-io/submariner-charts/pull/268
Depends on https://github.com/submariner-io/submariner-operator/pull/2246
Fixes #858

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
