### PR TITLE
Allow test framework restconfigs to be provided

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -155,26 +155,28 @@ func init() {
 func BeforeSuite() {
 	By("Creating kubernetes clients")
 
-	if len(TestContext.KubeConfig) > 0 {
-		Expect(len(TestContext.KubeConfigs)).To(BeZero(),
-			"Either KubeConfig or KubeConfigs must be specified but not both")
+	if len(RestConfigs) == 0 {
+		if len(TestContext.KubeConfig) > 0 {
+			Expect(len(TestContext.KubeConfigs)).To(BeZero(),
+				"Either KubeConfig or KubeConfigs must be specified but not both")
 
-		for _, ctx := range TestContext.KubeContexts {
-			RestConfigs = append(RestConfigs, createRestConfig(TestContext.KubeConfig, ctx))
-		}
+			for _, ctx := range TestContext.KubeContexts {
+				RestConfigs = append(RestConfigs, createRestConfig(TestContext.KubeConfig, ctx))
+			}
 
-		// if cluster IDs are not provided we assume that cluster-id == context
-		if len(TestContext.ClusterIDs) == 0 {
-			TestContext.ClusterIDs = TestContext.KubeContexts
+			// if cluster IDs are not provided we assume that cluster-id == context
+			if len(TestContext.ClusterIDs) == 0 {
+				TestContext.ClusterIDs = TestContext.KubeContexts
+			}
+		} else if len(TestContext.KubeConfigs) > 0 {
+			Expect(len(TestContext.KubeConfigs)).To(Equal(len(TestContext.ClusterIDs)),
+				"One ClusterID must be provided for each item in the KubeConfigs")
+			for _, kubeConfig := range TestContext.KubeConfigs {
+				RestConfigs = append(RestConfigs, createRestConfig(kubeConfig, ""))
+			}
+		} else {
+			Fail("One of KubeConfig or KubeConfigs must be specified")
 		}
-	} else if len(TestContext.KubeConfigs) > 0 {
-		Expect(len(TestContext.KubeConfigs)).To(Equal(len(TestContext.ClusterIDs)),
-			"One ClusterID must be provided for each item in the KubeConfigs")
-		for _, kubeConfig := range TestContext.KubeConfigs {
-			RestConfigs = append(RestConfigs, createRestConfig(kubeConfig, ""))
-		}
-	} else {
-		Fail("One of KubeConfig or KubeConfigs must be specified")
 	}
 
 	for _, restConfig := range RestConfigs {


### PR DESCRIPTION
With the revamp of subctl benchmark and verify, it turns out to be useful to provide restconfigs to the test framework instead of expecting it to re-create them from kubeconfig(s) and context(s).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
