### PR TITLE
Stop collecting kube-proxy logs in post-mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -47,9 +47,6 @@ function post_analyze() {
         kubectl -n "$ns" logs "$name"
     done
 
-    print_section "* Kube-proxy pod logs for $cluster *"
-    print_pods_logs "kube-system" "k8s-app=kube-proxy"
-
     print_section "* Kube-controller-manager pod logs for $cluster *"
     print_pods_logs "kube-system" "component=kube-controller-manager"
 


### PR DESCRIPTION
Globalnet 1.0 implementation used to depend on some of the iptable chains programmed by kube-proxy and this was causing race conditions. To debug such issues, we were collecting the kube-proxy logs as part of post-mortem script. However, with Globalnet 2.0, we no longer depend on the iptable chains from kube-proxy. This PR removes the associated changes.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
