### PR TITLE
Increase duration while checking gw connections

### DIFF
--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -81,7 +81,7 @@ function connectivity_tests() {
 }
 
 function verify_gw_status() {
-    sleep_duration=6
+    sleep_duration=8
     # helm doesn't use the operator yet, and connection status is based on the operator object
     if subctl show connections 2>&1 | grep "the server could not find the requested resource"; then
         return 0


### PR DESCRIPTION
Sometimes it was seen that public-ip resolution using api.ipify.org was timing out (default interval is 30s). Because of this local endpoint is created with some delay and the side-effect of this issue is that connections take slightly longer time to get established. Currently, in our scripts we wait for 3 mins after installing Submariner on the clusters and if connections are not established within this duration the CI job is marked as failed.

However, looking at the post-mortem scripts it was seen that connections were all successfully established after a while. So, this PR increases the wait interval from 3 mins to 4 mins.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
