### PR TITLE
Add moreutils to our base image

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -28,6 +28,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # kubectl            | e2e tests (in kubernetes-client)
 # make               | OLM installation
 # moby-engine        | Docker (for Dapper)
+# moreutils          | sponge (for system tests)
 # python3-pip        | Needed (temprorarily) to install j2cli, removed once done
 # python3-setuptools | Needed by j2cli
 # qemu-user-static   | Emulation (for multiarch builds)
@@ -43,7 +44,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # - Precompiled packages in go (see https://github.com/golang/go/issues/47257)
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils upx jq gitlint python3-setuptools \
+                   findutils moreutils upx jq gitlint python3-setuptools \
                    qemu-user-static python3-pip skopeo && \
     pip install j2cli[yaml] --user && \
     rpm -e --nodeps containerd python3-pip && \


### PR DESCRIPTION
This provides sponge, which is useful for system tests where we want to see *and* check the output, e.g.

    subctl ... | tee /dev/stderr | sponge | grep -q 'expected text'

This copies the output to standard error, accumulates all the output sent to standard output (so that subctl finishes running before the pipeline terminates), and filters the output through grep. The output copied to standard error shows up unchanged in the logs, and the outcome of the whole pipeline is determined by the presence or absence of 'expected text' in the output. Without sponge, if the output is matched, the pipeline terminates immediately, which results in truncated output from subctl.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
