### PR TITLE
Reset clients before populating them

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -179,6 +179,9 @@ func BeforeSuite() {
 		}
 	}
 
+	KubeClients = nil
+	DynClients = nil
+
 	for _, restConfig := range RestConfigs {
 		KubeClients = append(KubeClients, createKubernetesClient(restConfig))
 		DynClients = append(DynClients, createDynamicClient(restConfig))


### PR DESCRIPTION
In the test framework, since KubeClients and DynClients are global variables, they keep their values between test runs. If the test framework is used multiple times in the same process (e.g. by subctl), this can result in panics since the slices can end up having more entries than are present in ClusterIDs.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
