### PR TITLE
Refactor GatewayCleanup function

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -95,6 +95,7 @@ type Framework struct {
 	Namespace                string          // Every test has a namespace at least unless creation is skipped
 	namespacesToDelete       map[string]bool // Some tests have more than one.
 	NamespaceDeletionTimeout time.Duration
+	gatewayNodesToReset      map[int][]string // Store GW nodes for the final cleanup
 
 	// To make sure that this framework cleans up after itself, no matter what,
 	// we install a Cleanup action before each test and clear it after.  If we
@@ -113,8 +114,9 @@ var (
 // NewBareFramework creates a test framework, without ginkgo dependencies.
 func NewBareFramework(baseName string) *Framework {
 	return &Framework{
-		BaseName:           baseName,
-		namespacesToDelete: map[string]bool{},
+		BaseName:            baseName,
+		namespacesToDelete:  map[string]bool{},
+		gatewayNodesToReset: map[int][]string{},
 	}
 }
 


### PR DESCRIPTION
The "GatewayCleanup" function restores the state of the GW node on the cluster if required.

The test should call the "SaveGatewayNodeForTest" function in order to save the state of the GW node into the Framework.

At the end of the test, the "GatewayCleanup" function will restore the state of the GW node if defined within the Framework state.

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
