### PR TITLE
Introduce "FindGatewayNodes" and "FindNonGatewayNodes" functions

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -290,7 +290,7 @@ func InitNumClusterNodes() error {
 
 func fetchClusterIDs() {
 	for i := range KubeClients {
-		gatewayNodes := findNodesByGatewayLabel(i, true)
+		gatewayNodes := FindGatewayNodes(ClusterIndex(i))
 		if len(gatewayNodes) == 0 {
 			continue
 		}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	. "github.com/onsi/gomega"
-	// We need GCP authentication.
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // We need GCP authentication.
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -54,4 +55,11 @@ func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	}
 
 	ExpectWithOffset(1+offset, err).NotTo(HaveOccurred(), explain...)
+}
+
+func NewRequirement(key string, op selection.Operator, vals []string) labels.Requirement {
+	r, err := labels.NewRequirement(key, op, vals)
+	Expect(err).To(Succeed())
+
+	return *r
 }


### PR DESCRIPTION
In order to make the function meaning cleaner, refactor the "findNodesByGatewayLabel" function.

- Create a "findNodesByLabel" function that is able to search for the nodes within the cluster by defined lablel and return the nodes with the label or without by defining a boolean.

- Create a "FindGatewayNodes" and "FindNonGatewayNodes" functions that will search for the relevant nodes - Gateway and NonGateway.

The patch is a part of the following effort:
https://github.com/submariner-io/submariner/issues/2013

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
