### PR TITLE
Fix flaky e2e failures with kindnet cni

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,5 +1,4 @@
 ---
-cni: weave
 submariner: true
 nodes: control-plane worker
 clusters:

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -31,6 +31,8 @@ readonly MARKETPLACE_NAMESPACE="olm"
 IPSEC_PSK="$(dd if=/dev/urandom count=64 bs=8 | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)"
 # shellcheck disable=SC2034
 readonly IPSEC_PSK
+# we use this namespace to deploy a dummypod as a daemonSet as a workaround for kindnet clusters.
+readonly KINDNET_WORKAROUND_NS="subm-kindnet-workaround"
 
 ### Common functions ###
 
@@ -65,6 +67,11 @@ function create_catalog_source() {
   fi
 
   echo "[INFO](${cluster}) Catalog source ${cs} created"
+}
+
+function schedule_dummy_pod_on_all_clusters() {
+    run_subm_clusters create_namespace ${KINDNET_WORKAROUND_NS}
+    run_subm_clusters deploy_daemonset ${KINDNET_WORKAROUND_NS} "${RESOURCES_DIR}"/dummypod.yaml
 }
 
 # Create an OperatorGroup
@@ -117,6 +124,16 @@ declare_kubeconfig
 
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
 "${SCRIPTS_DIR}/get-subctl.sh"
+
+# This is a workaround and can be removed once we switch the CNI from kindnet to a different one.
+# In order to support health-check and hostNetwork use-cases, submariner requires an IPaddress from the podCIDR
+# for each node in the cluster. Normally, most of the CNIs create a cniInterface on the host and assign an IP
+# from the podCIDR to the interface. Submariner relies on this interface to support the aforementioned use-cases.
+# However, with kindnet CNI, it was seen that it does not create a dedicated CNI Interface on the nodes.
+# But as soon as a pod is scheduled on a node, it creates a veth-xxx interface which has an IPaddress from the
+# podCIDR. In this workaround, we are scheduling a dummy pod as a demonSet on the cluster to trigger the creation
+# of this veth-xxx interface which can be used as a cniInterface and we can continue to validate Submariner use-cases.
+schedule_dummy_pod_on_all_clusters
 
 load_library deploy DEPLOYTOOL
 deploytool_prereqs

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -105,6 +105,16 @@ function deploy_resource() {
     kubectl rollout status "deploy/${resource_name}" --timeout="${TIMEOUT}"
 }
 
+function deploy_daemonset() {
+    local namespace=$1
+    local resource_file=$2
+    local resource_name
+    resource_name=$(basename "$resource_file" ".yaml")
+    render_template "${resource_file}" | kubectl -n "${namespace}" apply -f -
+    echo "Waiting for ${resource_name} pods to be ready."
+    kubectl -n "${namespace}" rollout status "ds/${resource_name}" --timeout="${TIMEOUT}"
+}
+
 function remove_resource() {
     local resource_file=$1
     render_template "${resource_file}" | kubectl delete -f -

--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dummypod
+spec:
+  selector:
+    matchLabels:
+      app: dummypod
+  template:
+    metadata:
+      labels:
+        app: dummypod
+    spec:
+      containers:
+        - name: dummypod
+          image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
+          imagePullPolicy: IfNotPresent
+          command:
+            - sleep
+            - infinity
+      restartPolicy: Always


### PR DESCRIPTION
While transitioning to kindnet CNI in our KIND deployments, it was seen that HostNetworking e2e tests were occasionally failing. On debugging this issue, it was found that kindnet CNI does not create a dedicated CNI Interface on the nodes. Submariner relies on the CNI Interface to support some of the use-cases like Health-check between the GW nodes and HostNetwork to remote cluster support. However, it was seen that as soon as we schedule a pod on the node, kindnet CNI creates a veth-xxx interface on the Host which can be used as a CNI Interface. So, in order to continue validating the above Submariner use-cases, this PR schedules a dummypod as a DaemonSet in the clusters as a workaround (and this can be removed when we switch to a different CNI).

Fixes: https://github.com/submariner-io/shipyard/issues/966
Related to: https://github.com/submariner-io/shipyard/issues/858
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
