### PR TITLE
Automated backport of #967: Fix flaky e2e failures with kindnet cni

### DIFF
--- a/.shipyard.e2e.yml
+++ b/.shipyard.e2e.yml
@@ -1,5 +1,4 @@
 ---
-cni: weave
 submariner: true
 nodes: control-plane worker
 clusters:

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -50,6 +50,8 @@ readonly BROKER_NAMESPACE="submariner-k8s-broker"
 readonly BROKER_CLIENT_SA="submariner-k8s-broker-client"
 readonly MARKETPLACE_NAMESPACE="olm"
 readonly IPSEC_PSK="$(dd if=/dev/urandom count=64 bs=8 | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)"
+# we use this namespace to deploy a dummypod as a daemonSet as a workaround for kindnet clusters.
+readonly KINDNET_WORKAROUND_NS="subm-kindnet-workaround"
 
 ### Common functions ###
 
@@ -85,6 +87,11 @@ function create_catalog_source() {
   fi
 
   echo "[INFO](${cluster}) Catalog source ${cs} created"
+}
+
+function schedule_dummy_pod_on_all_clusters() {
+    run_subm_clusters create_namespace ${KINDNET_WORKAROUND_NS}
+    run_subm_clusters deploy_daemonset ${KINDNET_WORKAROUND_NS} "${RESOURCES_DIR}"/dummypod.yaml
 }
 
 # Create an OperatorGroup
@@ -139,7 +146,17 @@ declare_kubeconfig
 bash -c "curl -Ls https://get.submariner.io | VERSION=${CUTTING_EDGE} DESTDIR=/go/bin bash" ||
 bash -c "curl -Ls https://get.submariner.io | VERSION=devel DESTDIR=/go/bin bash"
 
-load_deploytool $deploytool
+# This is a workaround and can be removed once we switch the CNI from kindnet to a different one.
+# In order to support health-check and hostNetwork use-cases, submariner requires an IPaddress from the podCIDR
+# for each node in the cluster. Normally, most of the CNIs create a cniInterface on the host and assign an IP
+# from the podCIDR to the interface. Submariner relies on this interface to support the aforementioned use-cases.
+# However, with kindnet CNI, it was seen that it does not create a dedicated CNI Interface on the nodes.
+# But as soon as a pod is scheduled on a node, it creates a veth-xxx interface which has an IPaddress from the
+# podCIDR. In this workaround, we are scheduling a dummy pod as a demonSet on the cluster to trigger the creation
+# of this veth-xxx interface which can be used as a cniInterface and we can continue to validate Submariner use-cases.
+schedule_dummy_pod_on_all_clusters
+
+load_deploytool "$deploytool"
 deploytool_prereqs
 
 run_if_defined pre_deploy

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -120,6 +120,16 @@ function deploy_resource() {
     kubectl rollout status "deploy/${resource_name}" --timeout="${timeout}"
 }
 
+function deploy_daemonset() {
+    local namespace=$1
+    local resource_file=$2
+    local resource_name
+    resource_name=$(basename "$resource_file" ".yaml")
+    render_template "${resource_file}" | kubectl -n "${namespace}" apply -f -
+    echo "Waiting for ${resource_name} pods to be ready."
+    kubectl -n "${namespace}" rollout status "ds/${resource_name}" --timeout="5m"
+}
+
 function remove_resource() {
     local resource_file=$1
     kubectl delete -f "$resource_file"

--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dummypod
+spec:
+  selector:
+    matchLabels:
+      app: dummypod
+  template:
+    metadata:
+      labels:
+        app: dummypod
+    spec:
+      containers:
+        - name: dummypod
+          image: "quay.io/submariner/nettest:devel"
+          imagePullPolicy: IfNotPresent
+          command:
+            - sleep
+            - infinity
+      restartPolicy: Always


### PR DESCRIPTION
Backport of #967 on release-0.12.

#967: Fix flaky e2e failures with kindnet cni

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.