### PR TITLE
Deploy dummypod ds even on control-nodes

### DIFF
--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -12,6 +12,13 @@ spec:
       labels:
         app: dummypod
     spec:
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: dummypod
           image: "quay.io/submariner/nettest:devel"


### PR DESCRIPTION
In order to support HostNetwork use-cases with the kindnet CNI, as part of one of the previous PRs[1], we were deploying a dummyPod as a daemonSet. The DS pods are scheduled on all the worker nodes of the cluster except for the control-node. Normally, the control-nodes host some pods like coredns/provisioner etc on the nodes. In such scenarios, scheduling dummyPod on the control-nodes was not necessary. However, in some KIND deployments, it was seen that all the coredns, provisioner pods were scheduled on the worker nodes and not on the control node. Because of this, the route-agent was unable to discover the CNI interface on the control-node and it was causing failures in e2e hostnetwork use-case.

This PR modifies the dummyPod daemonSet yaml to include the necessary tolerations so that they will be scheduled even on the control-nodes as well, which should fix the e2e errors.

[1] https://github.com/submariner-io/shipyard/pull/967/files

Fixes: https://github.com/submariner-io/shipyard/issues/966
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
