### PR TITLE
Remove stale globalnet e2e code

### DIFF
--- a/test/e2e/dataplane/tcp_connectivity.go
+++ b/test/e2e/dataplane/tcp_connectivity.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("[dataplane] Basic TCP connectivity test", func() {
 	f := framework.NewFramework("dataplane")
 
-	When("a pod connects to another pod via TCP", func() {
+	When("a pod connects to another pod via TCP in the same cluster", func() {
 		It("should send the expected data to the other pod", func() {
 			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
 				Framework:             f,

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -150,24 +150,3 @@ func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
 		return nil, KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }
-
-// AwaitUntilAnnotationOnService queries the service and looks for the presence of annotation.
-func (f *Framework) AwaitUntilAnnotationOnService(cluster ClusterIndex, annotation, svcName, namespace string) *corev1.Service {
-	return AwaitUntil("get"+annotation+" annotation for service "+svcName, func() (interface{}, error) {
-		service, err := KubeClients[cluster].CoreV1().Services(namespace).Get(context.TODO(), svcName, metav1.GetOptions{})
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return service, err
-	}, func(result interface{}) (bool, string, error) {
-		if result == nil {
-			return false, "No Service found", nil
-		}
-
-		service := result.(*corev1.Service)
-		if service.GetAnnotations()[annotation] == "" {
-			return false, fmt.Sprintf("Service %q does not have annotation %q yet", svcName, annotation), nil
-		}
-		return true, "", nil
-	}).(*corev1.Service)
-}


### PR DESCRIPTION
Starting with Globalnet 2.0, we no longer use any globalIP annotations on the pods/services. This PR removes the associated stale code.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
