### PR TITLE
Use the base branch when linting

### DIFF
--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -1,4 +1,5 @@
-FROM quay.io/submariner/shipyard-linting:devel
+ARG BASE_BRANCH
+FROM quay.io/submariner/shipyard-linting:${BASE_BRANCH}
 
 ENV DAPPER_ENV="GITHUB_SHA MAKEFLAGS" \
     DAPPER_SOURCE=/opt/linting


### PR DESCRIPTION
This ensures that the base linting image matches the tested branch's expectations (e.g. the availability of shflags).

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
