### PR TITLE
Pull the dummypod image from Quay

### DIFF
--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -21,7 +21,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: dummypod
-          image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
+          image: quay.io/submariner/nettest:devel
           imagePullPolicy: IfNotPresent
           command:
             - sleep


### PR DESCRIPTION
This reverts part of
https://github.com/submariner-io/shipyard/pull/940 to allow CI tests to complete. Currently, CI ends up relying on nettest from the local registry, but downstream projects shouldn't have to know this; this reverts to the previous behaviour of always pulling the image from Quay.

We'll fix this properly later on.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
