### PR TITLE
Preload `nettest` image when deploying on KIND

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -122,6 +122,9 @@ load_settings
 declare_cidrs
 declare_kubeconfig
 
+# Always import nettest image on kind, to be able to test connectivity and other things
+[[ "${PROVIDER}" != 'kind' ]] || import_image "${REPO}/nettest"
+
 # Always get subctl since we're using moving versions, and having it in the image results in a stale cached one
 "${SCRIPTS_DIR}/get-subctl.sh"
 

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -59,7 +59,6 @@ function test_connection() {
 function connectivity_tests() {
     target_cluster="$1"
 
-    [[ "${PROVIDER}" != 'kind' ]] || import_image "${REPO}/nettest"
     deploy_resource "${RESOURCES_DIR}/netshoot.yaml"
     with_context "$target_cluster" deploy_resource "${RESOURCES_DIR}/nginx-demo.yaml"
 


### PR DESCRIPTION
This is needed for connectivity tests and other tests on a KIND environment, in many circumstances.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
