### PR TITLE
Search for NonGatewayNodes with GatewayLabel absent

### DIFF
--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -50,7 +50,8 @@ func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
 func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
 	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(
-			NewRequirement(GatewayLabel, selection.Exists, []string{}),
+			// Ignore the control plane node labeled as master as it doesn't allow scheduling of pods
+			NewRequirement("node-role.kubernetes.io/master", selection.DoesNotExist, []string{}),
 			NewRequirement(GatewayLabel, selection.NotEquals, []string{"true"})).String(),
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When searching for NonGatewayNodes, the function should search for the nodes with missing "submariner.io/gateway" label instead of the label with "false" value.

Filter out the nodes with "node-role.kubernetes.io/master" label as it doesn't allow to schedule the pods on it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
