### PR TITLE
Use new --context subctl flags

### DIFF
--- a/scripts/shared/cloud-prepare.sh
+++ b/scripts/shared/cloud-prepare.sh
@@ -40,7 +40,7 @@ function prepare_kind() {
 }
 
 function prepare_aws_ocp() {
-    subctl cloud prepare aws --kubecontext "${cluster}" --ocp-metadata "${OUTPUT_DIR}/aws-ocp-${cluster}/"
+    subctl cloud prepare aws --context "${cluster}" --ocp-metadata "${OUTPUT_DIR}/aws-ocp-${cluster}/"
     with_retries 60 sleep_on_fail 5s check_gateway_exists
 }
 

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -41,7 +41,7 @@ function test_with_e2e_tests {
 }
 
 function test_with_subctl {
-    subctl verify --only "${SUBCTL_VERIFICATIONS}" --kubecontexts "$(generate_kubecontexts)"
+    subctl verify --only "${SUBCTL_VERIFICATIONS}" --context "${clusters[0]}" --tocontext "${clusters[1]}"
 }
 
 function count_nodes() {

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -43,6 +43,8 @@ function setup_broker() {
     fi
 
     (
+        # The subctl invocation here has to work with the previous release
+        # so that the upgrade tests can run
         cd "${OUTPUT_DIR}" &&
         "${SUBCTL}" deploy-broker \
                --kubecontext "${cluster}" \
@@ -75,6 +77,8 @@ function subctl_install_subm() {
         extra_flags+=(--clustercidr "${cluster_CIDRs[${cluster}]}" --servicecidr "${service_CIDRs[${cluster}]}")
     fi
 
+    # The subctl invocation here has to work with the previous release
+    # so that the upgrade tests can run
     "${SUBCTL}" join --kubecontext "${cluster}" \
                 --clusterid "${cluster}" \
                 --nattport "${CE_IPSEC_NATTPORT}" \


### PR DESCRIPTION
--kubecontext and --kubecontexts are deprecated.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
