### PR TITLE
Automated backport of #992: Use the base branch when linting

### DIFF
--- a/Dockerfile.linting
+++ b/Dockerfile.linting
@@ -1,4 +1,5 @@
-FROM quay.io/submariner/shipyard-linting:devel
+ARG BASE_BRANCH
+FROM quay.io/submariner/shipyard-linting:${BASE_BRANCH}
 
 ENV DAPPER_ENV="GITHUB_SHA MAKEFLAGS" \
     DAPPER_SOURCE=/opt/linting


### PR DESCRIPTION
Backport of #992 on release-0.13.

#992: Use the base branch when linting

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.