### PR TITLE
Automated backport of #1018: Change air-gap invocation condition

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -109,7 +109,7 @@ function provider_create_cluster() {
     kind_fixup_config
 
     [[ "$LOAD_BALANCER" != true ]] || delete_cluster_on_fail deploy_load_balancer
-    [[ "$AIR_GAPPED" = true ]] && air_gap_iptables
+    [[ "$AIR_GAPPED" != true ]] || air_gap_iptables
 }
 
 function delete_cluster_on_fail() {


### PR DESCRIPTION
Backport of #1018 on release-0.14.

#1018: Change air-gap invocation condition

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.