### PR TITLE
[Backport] Display nodeName of connectorPod in e2e tests

### DIFF
--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -174,7 +174,7 @@ func (np *NetworkPod) AwaitFinishVerbose(verbose bool) {
 		np.TerminationMessage = np.Pod.Status.ContainerStatuses[0].State.Terminated.Message
 
 		if verbose {
-			Logf("Pod %q output:\n%s", np.Pod.Name, removeDupDataplaneLines(np.TerminationMessage))
+			Logf("Pod %q on node %q output:\n%s", np.Pod.Name, np.Pod.Spec.NodeName, removeDupDataplaneLines(np.TerminationMessage))
 		}
 	}
 }

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -174,12 +174,10 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		framework.Logf("Will send traffic from IP: %v", sourceIP)
 	}
 
-	By(fmt.Sprintf("Waiting for the connector pod %q on node %q to exit, returning what connector sent",
-		connectorPod.Pod.Name, connectorPod.Pod.Spec.NodeName))
+	By(fmt.Sprintf("Waiting for the connector pod %q to exit, returning what connector sent", connectorPod.Pod.Name))
 	connectorPod.AwaitFinish()
 
-	By(fmt.Sprintf("Waiting for the listener pod %q on node %q to exit, returning what listener sent",
-		listenerPod.Pod.Name, listenerPod.Pod.Spec.NodeName))
+	By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
 	listenerPod.AwaitFinish()
 
 	framework.Logf("Connector pod has IP: %s", connectorPod.Pod.Status.PodIP)


### PR DESCRIPTION
While looking at the e2e logs, it was seen that sometimes the node on which the connectorPod was scheduled is not displayed. This is an important information which will be helpful while debugging any failures. This PR fixes it.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 4d1de50916443fa7ce4379b90629762ae6bfaa19)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
