### PR TITLE
Disable OCP namespace pod security label sync

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -247,10 +247,9 @@ func (f *Framework) BeforeEach() {
 		By(fmt.Sprintf("Creating namespace objects with basename %q", f.BaseName))
 
 		namespaceLabels := map[string]string{
-			"e2e-framework":                      f.BaseName,
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"pod-security.kubernetes.io/audit":   "privileged",
-			"pod-security.kubernetes.io/warn":    "privileged",
+			"e2e-framework":                                  f.BaseName,
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
 		}
 
 		for idx, clientSet := range KubeClients {


### PR DESCRIPTION
We set the `pod-security.kubernetes.io/enforce` label to `privileged` on the E2E test namespace but in OCP _4.12_ the [label synchronization controller](https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission-autolabeling.md) changes it to the default `restricted` level. Rather than granting privileged access via SCC and RBAC, we can simply disable the controller by setting the `security.openshift.io/scc.podSecurityLabelSync` label to false.

Fixes https://github.com/submariner-io/submariner-operator/issues/2330