### PR TITLE
Automated backport of #1024: Disable OCP namespace pod security label sync

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -247,10 +247,9 @@ func (f *Framework) BeforeEach() {
 		By(fmt.Sprintf("Creating namespace objects with basename %q", f.BaseName))
 
 		namespaceLabels := map[string]string{
-			"e2e-framework":                      f.BaseName,
-			"pod-security.kubernetes.io/enforce": "privileged",
-			"pod-security.kubernetes.io/audit":   "privileged",
-			"pod-security.kubernetes.io/warn":    "privileged",
+			"e2e-framework":                                  f.BaseName,
+			"pod-security.kubernetes.io/enforce":             "privileged",
+			"security.openshift.io/scc.podSecurityLabelSync": "false",
 		}
 
 		for idx, clientSet := range KubeClients {


### PR DESCRIPTION
Backport of #1024 on release-0.14.

#1024: Disable OCP namespace pod security label sync

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.