### PR TITLE
Bump to Fedora 37

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,4 +1,4 @@
-FROM fedora:36
+FROM fedora:37
 
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.
@@ -14,6 +14,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # Component          | Usage
 # -------------------------------------------------------------
 # curl               | download other tools
+# file               | file identification (in compile/test.sh)
 # findutils          | make unit (find unit test dirs)
 # gcc                | needed by `go test -race` (https://github.com/golang/go/issues/27089)
 # gh                 | backport, releases
@@ -33,6 +34,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # python3-setuptools | Needed by j2cli
 # qemu-user-static   | Emulation (for multiarch builds)
 # skopeo             | container image manipulation
+# unzip              | ZIP extraction
 # upx                | binary compression
 # yq                 | YAML processing (OCM deploy tool)
 
@@ -45,7 +47,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
                    findutils moreutils upx jq gitlint python3-setuptools \
-                   qemu-user-static python3-pip skopeo && \
+                   qemu-user-static python3-pip skopeo file unzip && \
     pip install j2cli[yaml] --user && \
     rpm -e --nodeps containerd python3-pip && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \


### PR DESCRIPTION
This gives us Go 1.19. Because of that, golangci-lint has to be bumped
to 1.48.0, the first version supporting Go 1.19.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
