### PR TITLE
Retry `cloud-prepare` operation

### DIFF
--- a/scripts/shared/cloud-prepare.sh
+++ b/scripts/shared/cloud-prepare.sh
@@ -51,6 +51,6 @@ declare_kubeconfig
 [[ "${PROVIDER}" == "kind" ]] || "${SCRIPTS_DIR}/get-subctl.sh"
 
 # Run in subshell to check response, otherwise `set -e` is not honored
-( run_all_clusters cloud_prepare; ) &
+( run_all_clusters with_retries 3 cloud_prepare; ) &
 wait $! || exit_error "Failed to prepare cloud"
 


### PR DESCRIPTION
Retry the operation in case it failed. For OCP setups it might sometimes fail, so retrying it would be desirable.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
