### PR TITLE
Include context info while running post-mortem

### DIFF
--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -54,10 +54,10 @@ function post_analyze() {
     print_pods_logs "submariner-operator"
 
     print_section "* Output of 'subctl show all' in $cluster *"
-    subctl show all
+    subctl show all --context "$cluster"
 
     print_section "* Output of 'subctl diagnose all' in $cluster *"
-    subctl diagnose all
+    subctl diagnose all --context "$cluster"
 
     return 0
 }


### PR DESCRIPTION
As part of post-mortem script, when we try to collect the output of various subctl commands, since we were not explicitly passing the context, the command was getting executed on all the cluster contexts. This PR fixes it by specifying the appropriate context.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
