### PR TITLE
Use context instead of kubecontext in subctl cmds

### DIFF
--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -47,7 +47,7 @@ function setup_broker() {
         # so that the upgrade tests can run
         cd "${OUTPUT_DIR}" &&
         "${SUBCTL}" deploy-broker \
-               --kubecontext "${cluster}" \
+               --context "${cluster}" \
                 "${extra_flags[@]}"
     )
 }
@@ -79,7 +79,7 @@ function subctl_install_subm() {
 
     # The subctl invocation here has to work with the previous release
     # so that the upgrade tests can run
-    "${SUBCTL}" join --kubecontext "${cluster}" \
+    "${SUBCTL}" join --context "${cluster}" \
                 --clusterid "${cluster}" \
                 --nattport "${CE_IPSEC_NATTPORT}" \
                 --globalnet-cidr "${global_CIDRs[$cluster]}" \


### PR DESCRIPTION
While deploying clusters using operator, the code tries to deploy_broker and join clusters using the "--kubecontext" flags. However, since "--kubecontext" is deprecated, its displaying a Warning message in the output. This PR updates the code accordingly.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
