### PR TITLE
[Backport 0.13] Generate 12 characters short hashes

### DIFF
--- a/Makefile.versions
+++ b/Makefile.versions
@@ -1,7 +1,7 @@
 # Calculate versions; these can be overridden
 CUTTING_EDGE := release-0.13
 DEV_VERSION := dev
-override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short HEAD)
+override CALCULATED_VERSION := $(BASE_BRANCH)-$(shell git rev-parse --short=12 HEAD)
 VERSION ?= $(CALCULATED_VERSION)
 
 export CUTTING_EDGE DEV_VERSION VERSION


### PR DESCRIPTION
The hashes are used for versioning, amongst other things, the images. Sometimes the hash can be longer than the default 7, but when releasing the calculated hash is 7 characters long.

To be consistent, without risk of collisions, always generate a 12 character long hash.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 8c6afd54666e60dd1e5f9f0dc9e09a9913200838)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
