### PR TITLE
Pass make options in flags instead of env vars

### DIFF
--- a/.github/workflows/clean-tests.yml
+++ b/.github/workflows/clean-tests.yml
@@ -18,9 +18,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Deploy clusters
-        env:
-          TIMEOUT: 1m
-        run: make clusters
+        run: make clusters TIMEOUT=1m
 
       - name: Clean up clusters
         run: make clean-clusters

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -18,9 +18,7 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
 
       - name: Deploy clusters
-        env:
-          TIMEOUT: 1m
-        run: make clusters
+        run: make clusters TIMEOUT=1m
 
       - name: Post mortem
         if: failure()
@@ -78,9 +76,7 @@ jobs:
         run: git fetch origin +refs/tags/*:refs/tags/*
 
       - name: Deploy clusters and Submariner
-        env:
-          TIMEOUT: 1m
-        run: make deploy using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.extra-toggles }}"
+        run: make deploy using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.extra-toggles }}" TIMEOUT=1m
 
       - name: Post mortem
         if: failure()

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -76,11 +76,12 @@ runs:
     - name: Run E2E deployment and tests
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      env:
-        K8S_VERSION: "${{ inputs.k8s_version }}"
-        FOCUS: "${{ inputs.focus }}"
-        SKIP: "${{ inputs.skip }}"
-        PLUGIN: "${{ inputs.plugin }}"
-        E2E_TESTDIR: "${{ inputs.testdir }}"
       run: |
-        make "${{ inputs.target }}" using="${{ inputs.using }}"
+        k8s_version=${{ inputs.k8s_version }} &&
+        make "${{ inputs.target }}" \
+            using="${{ inputs.using }}" \
+            ${k8s_version:+K8S_VERSION="$k8s_version"} \
+            FOCUS="${{ inputs.focus }}" \
+            SKIP="${{ inputs.skip }}" \
+            PLUGIN="${{ inputs.plugin }}" \
+            E2E_TESTDIR="${{ inputs.testdir }}"

--- a/gh-actions/release-images/action.yaml
+++ b/gh-actions/release-images/action.yaml
@@ -20,11 +20,9 @@ runs:
     - name: Build new images
       # This needs to be kept separate so that the release stage runs using the new Shipyard base image
       shell: bash
-      env:
-        USE_CACHE: false
       run: |
         echo "::group::Build new images"
-        make images multiarch-images
+        make images multiarch-images USE_CACHE=false
         echo "::endgroup::"
     - name: Release newly built images
       shell: bash


### PR DESCRIPTION
Environment vars should be still useful for passwords/tokens and such, but we should generally pass make options as flags as they get retained inside the dapper container without any special handling.

Resolves #1054

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
