### PR TITLE
Do not skip "master" nodes for non-gw nodes search

### DIFF
--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -50,8 +50,6 @@ func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
 func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
 	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(
-			// Ignore the control plane node labeled as master as it doesn't allow scheduling of pods
-			NewRequirement("node-role.kubernetes.io/master", selection.DoesNotExist, []string{}),
 			NewRequirement(GatewayLabel, selection.NotEquals, []string{"true"})).String(),
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
The "FindNonGatewayNodes" function search for the nodes of the cluster that do not hold the gateway label.
- Filter the nodes by missing the gateway label instead of comparing it to "false"

- A change between k8s version 1.23 and 1.25 is the removal of "master" label from the control-plane nodes. In order to not rely on this label, which existance changes between the versions, do not filter the nodes by it.

Signed-off-by: Maxim Babushkin <mbabushk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
