### PR TITLE
Automated backport of #1062: Do not skip "master" nodes for non-gw nodes search

### DIFF
--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -50,8 +50,6 @@ func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
 func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
 	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(
-			// Ignore the control plane node labeled as master as it doesn't allow scheduling of pods
-			NewRequirement("node-role.kubernetes.io/master", selection.DoesNotExist, []string{}),
 			NewRequirement(GatewayLabel, selection.NotEquals, []string{"true"})).String(),
 	})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Backport of #1062 on release-0.14.

#1062: Do not skip "master" nodes for non-gw nodes search

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.