### PR TITLE
Don't set skip default in E2E composite GHA

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -24,7 +24,6 @@ inputs:
   skip:
     description: '-ginkgo.skip argument to pass to E2E tests'
     required: false
-    default: '\[external-dataplane\]'
   test_args:
     description: 'Extra arguments to pass to E2E tests'
     required: false


### PR DESCRIPTION
No need to set it, especially not to external net, as the tests in the `submariner` repo are structured in a way making this unnecessary.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
