### PR TITLE
Remove globalnet flag from E2E

### DIFF
--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -3,14 +3,12 @@
 set -em -o pipefail
 source "${SCRIPTS_DIR}/lib/utils"
 
-[[ "${GLOBALNET}" = "true" ]] && gn=-globalnet || gn=
-
 # shellcheck disable=SC2206 # Split on purpose
 ginkgo_args=(${TEST_ARGS})
 [[ -n "${FOCUS}" ]] && ginkgo_args+=("-ginkgo.focus=${FOCUS}")
 [[ -n "${SKIP}" ]] && ginkgo_args+=("-ginkgo.skip=${SKIP}")
 
-print_env FOCUS GLOBALNET LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TEST_ARGS TESTDIR
+print_env FOCUS LAZY_DEPLOY SKIP SUBCTL_VERIFICATIONS TEST_ARGS TESTDIR
 source "${SCRIPTS_DIR}/lib/debug_functions"
 
 ### Functions ###
@@ -35,7 +33,7 @@ function test_with_e2e_tests {
     cd "${DAPPER_SOURCE}/${TESTDIR}"
 
     ${GO:-go} test -v -timeout 30m -args -test.timeout 15m \
-        -submariner-namespace $SUBM_NS "${clusters[@]/#/-dp-context=}" ${gn:+"$gn"} \
+        -submariner-namespace $SUBM_NS "${clusters[@]/#/-dp-context=}" \
         -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace \
         -ginkgo.reportPassed -ginkgo.reportFile "${DAPPER_OUTPUT}/e2e-junit.xml" \
         "${ginkgo_args[@]}" 2>&1 | tee "${DAPPER_OUTPUT}/e2e-tests.log"

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -272,8 +272,6 @@ func (f *Framework) BeforeEach() {
 }
 
 func DetectGlobalnet() {
-	TestContext.GlobalnetEnabled = false
-
 	clusters := DynClients[ClusterA].Resource(schema.GroupVersionResource{
 		Group:    "submariner.io",
 		Version:  "v1",

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -75,7 +75,6 @@ func init() {
 	flag.UintVar(&TestContext.ConnectionAttempts, "connection-attempts", 7,
 		"The number of connection attempts when verifying communication between clusters.")
 	flag.UintVar(&TestContext.OperationTimeout, "operation-timeout", 190, "The general operation timeout in seconds.")
-	flag.BoolVar(&TestContext.GlobalnetEnabled, "globalnet", false, "Indicates if the globalnet feature is enabled.")
 }
 
 func ValidateFlags(t *TestContextType) {


### PR DESCRIPTION
As globalnet is automatically detected, no need to receive it as a flag. Since we're setting globalnet on a clusterset level, detect it from the broker.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
