### PR TITLE
Drop older kind versions

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -67,15 +67,9 @@ ENV LINT_VERSION=v1.50.1 \
     YQ_VERSION=4.20.2
 
 # This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
-# We install kind-0.12, kind-0.15 and kind-${KIND_VERSION};
-# we need to test K8s 1.17, our oldest-supported version,
-# and kind-0.12 was the last version to ship K8s 1.17 images;
-# kind-0.15 was the last version to ship 1.18 images.
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \
-    curl -Lo /go/bin/kind-0.12 "https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind-0.12 && \
-    curl -Lo /go/bin/kind-0.15 "https://github.com/kubernetes-sigs/kind/releases/download/v0.15.0/kind-linux-${ARCH}" && chmod a+x /go/bin/kind-0.15 && \
     curl -Lo /go/bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}" && chmod a+x /go/bin/kind && \
     GOFLAGS="" go install -v github.com/onsi/ginkgo/ginkgo@latest && \
     GOFLAGS="" go install -v github.com/mikefarah/yq/v4@v${YQ_VERSION} && \

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -5,13 +5,7 @@
 
 ## Kubernetes version mapping, as supported by kind ##
 # See the release notes of the kind version in use
-declare -gA kind_k8s_versions kind_binaries
-# kind-0.12 hashes
-kind_k8s_versions[1.17]=1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5
-kind_binaries[1.17]='kind-0.12'
-# kind-0.15 hashes
-kind_k8s_versions[1.18]=1.18.20@sha256:61c9e1698c1cb19c3b1d8151a9135b379657aee23c59bde4a8d87923fcb43a91
-kind_binaries[1.18]='kind-0.15'
+declare -gA kind_k8s_versions
 # kind 0.17 hashes
 kind_k8s_versions[1.19]=1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7
 kind_k8s_versions[1.20]=1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394
@@ -88,9 +82,9 @@ function provider_create_cluster() {
     export KUBECONFIG=${KUBECONFIGS_DIR}/kind-config-${cluster}
     rm -f "$KUBECONFIG"
 
-    if "${kind}" get clusters | grep -q "^${cluster}$"; then
+    if kind get clusters | grep -q "^${cluster}$"; then
         echo "KIND cluster already exists, skipping its creation..."
-        "${kind}" export kubeconfig --name="${cluster}"
+        kind export kubeconfig --name="${cluster}"
         kind_fixup_config
         return
     fi
@@ -105,9 +99,9 @@ function provider_create_cluster() {
     local image_flag=''
     [[ -z "${K8S_VERSION}" ]] || image_flag="--image=kindest/node:v${K8S_VERSION}"
 
-    "${kind}" version
+    kind version
     cat "${RESOURCES_DIR}/${cluster}-config.yaml"
-    "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
+    kind create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
     kind_fixup_config
 
     [[ -n "${cluster_cni[$cluster]}" ]] || delete_cluster_on_fail schedule_dummy_pod
@@ -138,7 +132,7 @@ function delete_cluster_on_fail() {
     if ! wait $! ; then
         echo "Failed to run '$*', removing the cluster"
         kubectl cluster-info dump || echo "Can't get cluster info" 1>&2
-        "${kind}" delete cluster --name="${cluster}"
+        kind delete cluster --name="${cluster}"
         return 1
     fi
 }
@@ -261,7 +255,6 @@ function download_ovnk() {
 
 function provider_prepare() {
     [[ -z "${K8S_VERSION}" ]] && K8S_VERSION="${DEFAULT_K8S_VERSION}"
-    kind="${kind_binaries[$K8S_VERSION]:-kind}"
     [[ -n "${kind_k8s_versions[$K8S_VERSION]}" ]] && K8S_VERSION="${kind_k8s_versions[$K8S_VERSION]}"
 
     download_kind


### PR DESCRIPTION
Our tests no longer work on K8s before 1.19, so we no longer use kind versions older than 0.17. Stop installing them and drop support for alternate kind binaries.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
