### PR TITLE
Retry subctl downloads in all cases

### DIFF
--- a/scripts/shared/get-subctl.sh
+++ b/scripts/shared/get-subctl.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -o pipefail
+source "${SCRIPTS_DIR}/lib/utils"
 
 # In case we're pretending to be `subctl`
 if [[ "${0##*/}" = subctl ]] && [[ -L "$0" ]]; then
@@ -11,7 +12,7 @@ if [[ "${0##*/}" = subctl ]] && [[ -L "$0" ]]; then
 fi
 
 # Default to devel if we don't know what base branch were on
-curl -Ls --retry 3 https://get.submariner.io | VERSION="${SUBCTL_VERSION:-${BASE_BRANCH:-devel}}" bash
+with_retries 3 curl -Lsf https://get.submariner.io | VERSION="${SUBCTL_VERSION:-${BASE_BRANCH:-devel}}" bash
 
 # If we're pretending to be subctl, run subctl with any given arguments
 [[ -z "${run_subctl}" ]] || subctl "$@"


### PR DESCRIPTION
curl --retry only retries after transient errors. get-subctl.sh often fails with a 403 error, which isn't transient. Instead of relying on curl's retries, use with_retries.

This adds curl's -f flag so that HTTP errors result in an exit code indicating an error.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
