### PR TITLE
Ensure e2e test pods on GW nodes are scheduled on active GW node

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -61,9 +61,10 @@ const (
 )
 
 const (
-	SubmarinerGateway = "submariner-gateway"
-	RouteAgent        = "submariner-routeagent"
-	GatewayLabel      = "submariner.io/gateway"
+	SubmarinerGateway  = "submariner-gateway"
+	RouteAgent         = "submariner-routeagent"
+	GatewayLabel       = "submariner.io/gateway"
+	ActiveGatewayLabel = "gateway.submariner.io/status=active"
 )
 
 type PatchFunc func(pt types.PatchType, payload []byte) error


### PR DESCRIPTION
In order to validate e2e gateway failover use-cases, the following PR* enables multiple Gateway nodes in the KIND clusters. The Shipyard e2e framework only looks for submariner.io/gateway label on the node while trying to deploy a pod on the Gateway node. Currently, Submariner only supports Active/Passive HA so even when multiple nodes are labelled as GW nodes, only one of them will be the active Gateway node. This PR modifies the code to check the active Gateway node and schedule the pods accordingly.

* https://github.com/submariner-io/submariner/pull/2177

Related to: https://github.com/submariner-io/submariner/issues/2215
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
