### PR TITLE
Automated backport of #1093: Ensure e2e test pods on GW nodes are scheduled on active GW

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -61,9 +61,10 @@ const (
 )
 
 const (
-	SubmarinerGateway = "submariner-gateway"
-	RouteAgent        = "submariner-routeagent"
-	GatewayLabel      = "submariner.io/gateway"
+	SubmarinerGateway  = "submariner-gateway"
+	RouteAgent         = "submariner-routeagent"
+	GatewayLabel       = "submariner.io/gateway"
+	ActiveGatewayLabel = "gateway.submariner.io/status=active"
 )
 
 type PatchFunc func(pt types.PatchType, payload []byte) error


### PR DESCRIPTION
Backport of #1093 on release-0.14.

#1093: Ensure e2e test pods on GW nodes are scheduled on active GW

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.