### PR TITLE
Show connections when connections fail

### DIFF
--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -93,6 +93,8 @@ function verify_gw_status() {
     else
        return 0
     fi
+    # Before returning, show the subctl output
+    subctl show connections
     return 1
 }
 


### PR DESCRIPTION
When waiting for a connection to be set up, deploy_funcs repeatedly runs "subctl show connections", but filters its output. This means that when a connection fails to come up, the logs don't provide much information; in particular, when making changes to subctl, it's possible that the connection is actually up but "subctl show connections" itself is failing.

Running "subctl show connections" again without filtering its output before returning an error will help improve diagnostics in CI.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
