### PR TITLE
Add fips functions

### DIFF
--- a/test/e2e/framework/fips.go
+++ b/test/e2e/framework/fips.go
@@ -1,0 +1,106 @@
+/*
+SPDX-License-Identifier: Apache-2.0
+
+Copyright Contributors to the Submariner project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	fipsNamespace     = "kube-system"
+	fipsConfigMapName = "cluster-config-v1"
+)
+
+func DetectFIPSConfig(cluster ClusterIndex) (bool, error) {
+	configMap, err := KubeClients[cluster].CoreV1().ConfigMaps(fipsNamespace).Get(context.TODO(), fipsConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if strings.Contains(configMap.Data["install-config"], "fips: true") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (f *Framework) FindFIPSEnabledCluster() ClusterIndex {
+	for idx := range TestContext.ClusterIDs {
+		fipsEnabled, err := DetectFIPSConfig(ClusterIndex(idx))
+		Expect(err).NotTo(HaveOccurred())
+
+		if fipsEnabled {
+			return ClusterIndex(idx)
+		}
+	}
+
+	return -1
+}
+
+func verifyFIPSOutput(data string) bool {
+	if strings.Contains(strings.ToLower(data), "fips mode: yes") &&
+		strings.Contains(strings.ToLower(data), "fips mode enabled for pluto daemon") {
+		return true
+	}
+
+	return false
+}
+
+func (f *Framework) TestGatewayNodeFIPSMode(cluster ClusterIndex, gwPod string) {
+	By(fmt.Sprintf("Verify FIPS mode is enabled on gateway pod %q", gwPod))
+
+	ctx := context.TODO()
+	cmd := []string{"ipsec", "pluto", "--selftest"}
+
+	stdOut, stdErr, err := f.ExecWithOptions(ctx, &ExecOptions{
+		Command:       cmd,
+		Namespace:     TestContext.SubmarinerNamespace,
+		PodName:       gwPod,
+		ContainerName: SubmarinerGateway,
+		CaptureStdout: true,
+		CaptureStderr: true,
+	}, cluster)
+	Expect(err).To(Succeed())
+
+	if stdOut == "" && stdErr == "" {
+		Fail(fmt.Sprintf("No output received from command %q", cmd))
+	}
+
+	// The output of the "ipsec pluto --selftest" command could be written to stdout or stderr.
+	// Checking both outputs for the expected strings.
+	fipsStdOutResult := verifyFIPSOutput(stdOut)
+	fipsStdErrResult := verifyFIPSOutput(stdErr)
+
+	if fipsStdOutResult || fipsStdErrResult {
+		By(fmt.Sprintf("FIPS mode is enabled on gateway pod %q", gwPod))
+		return
+	}
+
+	Fail(fmt.Sprintf("FIPS mode is not enabled on gateway pod %q", gwPod))
+}


### PR DESCRIPTION
As part of FIPS test creation, add the following support functions:
- FindFipsConfig The function will search for the FIPS enabled cluster. FIPS enablement configuration stored within "cluster-config-v1" configmap of "kube-system" namespace.

- FindFipsEnabledCluster The function finds the fips enabled cluster. Returns clusters ID index if found. Otherwise, returns - "-1".

- TestGatewayNodeFipsMode The function checks for the FIPS enabled configuration within the submariner gateway pod. Expects to find the following strings:
  - "fips mode: yes"
  - "fips mode enabled for pluto daemon" If not found, returns an error.

Currently, FIPS is not supported on pure k8s.
It is supported on OCP clusters.
https://docs.openshift.com/container-platform/4.10/installing/installing-fips.html

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
