### PR TITLE
Support Ginkgo v2 only

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -20,7 +20,7 @@ inputs:
   test_args:
     description: 'Extra arguments to pass to E2E tests'
     required: false
-    default: '-ginkgo.failFast'
+    default: '--ginkgo.fail-fast'
   testdir:
     description: 'Where to look for the E2E tests'
     required: false

--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -27,21 +27,12 @@ function generate_kubecontexts() {
 function test_with_e2e_tests {
     cd "${DAPPER_SOURCE}/${TESTDIR}"
 
-    if go mod graph | grep 'submariner.*ginkgo/v2' >/dev/null; then
-        # shellcheck disable=SC2086 # TEST_ARGS is split on purpose
-        ${GO:-go} test -v -timeout 30m -args -test.timeout 15m \
-            -submariner-namespace $SUBM_NS "${clusters[@]/#/-dp-context=}" \
-            --ginkgo.v --ginkgo.randomize-all --ginkgo.trace \
-            --ginkgo.junit-report "${DAPPER_OUTPUT}/e2e-junit.xml" \
-            $TEST_ARGS 2>&1 | tee "${DAPPER_OUTPUT}/e2e-tests.log"
-    else
-        # shellcheck disable=SC2086 # TEST_ARGS is split on purpose
-        ${GO:-go} test -v -timeout 30m -args -test.timeout 15m \
-            -submariner-namespace $SUBM_NS "${clusters[@]/#/-dp-context=}" \
-            -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.trace \
-            -ginkgo.reportPassed -ginkgo.reportFile "${DAPPER_OUTPUT}/e2e-junit.xml" \
-            $TEST_ARGS 2>&1 | tee "${DAPPER_OUTPUT}/e2e-tests.log"
-    fi
+    # shellcheck disable=SC2086 # TEST_ARGS is split on purpose
+    "${GO:-go}" test -v -timeout 30m -args -test.timeout 15m \
+        -submariner-namespace "$SUBM_NS" "${clusters[@]/#/-dp-context=}" \
+        --ginkgo.v --ginkgo.randomize-all --ginkgo.trace \
+        --ginkgo.junit-report "${DAPPER_OUTPUT}/e2e-junit.xml" \
+         $TEST_ARGS 2>&1 | tee "${DAPPER_OUTPUT}/e2e-tests.log"
 }
 
 function test_with_subctl {

--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -56,13 +56,8 @@ for module in "${modules[@]}"; do
         [ "${ARCH}" == "amd64" ] && race=-race
         # It's important that the `go test` command's exit status is reported from this () block.
         # Can't be one command (with -cover). Need detailed -coverprofile for Sonar and summary to console.
-        if go mod graph | grep 'submariner.*ginkgo/v2' >/dev/null; then
-            ${GO:-go} test -v ${race} -coverprofile unit.coverprofile "${packages[@]}" --ginkgo.v --ginkgo.trace --ginkgo.junit-report junit.xml "$@" && \
-            go tool cover -func unit.coverprofile
-        else
-            ${GO:-go} test -v ${race} -coverprofile unit.coverprofile "${packages[@]}" -ginkgo.v -ginkgo.trace -ginkgo.reportPassed -ginkgo.reportFile junit.xml "$@" && \
-            go tool cover -func unit.coverprofile
-        fi
+        "${GO:-go}" test -v ${race} -coverprofile unit.coverprofile "${packages[@]}" --ginkgo.v --ginkgo.trace --ginkgo.junit-report junit.xml "$@" && \
+        go tool cover -func unit.coverprofile
     ) || result=1
 done
 


### PR DESCRIPTION
Now that all Submariner projects have switched to Ginkgo v2, we can drop support for v1.

Depends on https://github.com/submariner-io/subctl/pull/466
Depends on https://github.com/submariner-io/coastguard/pull/115
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
