### PR TITLE
[Backport/0.14] Deploy `dummypod` as part of kind clusters

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -108,8 +108,27 @@ function provider_create_cluster() {
     "${kind}" create cluster ${image_flag:+"$image_flag"} --name="${cluster}" --config="${RESOURCES_DIR}/${cluster}-config.yaml"
     kind_fixup_config
 
+    [[ -n "${cluster_cni[$cluster]}" ]] || delete_cluster_on_fail schedule_dummy_pod
     [[ "$LOAD_BALANCER" != true ]] || delete_cluster_on_fail deploy_load_balancer
     [[ "$AIR_GAPPED" != true ]] || air_gap_iptables
+}
+
+# This is a workaround and can be removed once we switch the CNI from kindnet to a different one.
+# In order to support health-check and hostNetwork use-cases, submariner requires an IPaddress from the podCIDR
+# for each node in the cluster. Normally, most of the CNIs create a cniInterface on the host and assign an IP
+# from the podCIDR to the interface. Submariner relies on this interface to support the aforementioned use-cases.
+# However, with kindnet CNI, it was seen that it does not create a dedicated CNI Interface on the nodes.
+# But as soon as a pod is scheduled on a node, it creates a veth-xxx interface which has an IPaddress from the
+# podCIDR. In this workaround, we are scheduling a dummy pod as a demonSet on the cluster to trigger the creation
+# of this veth-xxx interface which can be used as a cniInterface and we can continue to validate Submariner use-cases.
+function schedule_dummy_pod() {
+    local ns="subm-kindnet-workaround"
+    source "${SCRIPTS_DIR}"/lib/deploy_funcs
+    import_image "${REPO}/nettest"
+
+    echo "Creating the ${ns} namespace..."
+    kubectl create namespace "${ns}" || :
+    deploy_resource "${RESOURCES_DIR}"/dummypod.yaml "$ns"
 }
 
 function delete_cluster_on_fail() {

--- a/scripts/shared/lib/deploy_funcs
+++ b/scripts/shared/lib/deploy_funcs
@@ -2,6 +2,13 @@
 # shellcheck source=scripts/shared/lib/source_only
 . "${BASH_SOURCE%/*}"/source_only
 
+### Global Variables ###
+
+# shellcheck disable=SC2034
+SUBM_IMAGE_REPO=localhost:5000
+# shellcheck disable=SC2034
+SUBM_IMAGE_TAG="${IMAGE_TAG}"
+
 ### Functions ###
 
 function import_image() {
@@ -91,21 +98,18 @@ function verify_gw_status() {
 
 function deploy_resource() {
     local resource_file=$1
-    local resource_name
+    local ns=${2:-default}
+    local resource_name resource
     resource_name=$(basename "$resource_file" ".yaml")
     render_template "${resource_file}" | kubectl apply -f -
-    echo "Waiting for ${resource_name} pods to be ready."
-    kubectl rollout status "deploy/${resource_name}" --timeout="${TIMEOUT}"
-}
 
-function deploy_daemonset() {
-    local namespace=$1
-    local resource_file=$2
-    local resource_name
-    resource_name=$(basename "$resource_file" ".yaml")
-    render_template "${resource_file}" | kubectl -n "${namespace}" apply -f -
-    echo "Waiting for ${resource_name} pods to be ready."
-    kubectl -n "${namespace}" rollout status "ds/${resource_name}" --timeout="${TIMEOUT}"
+    for kind in Deployment DaemonSet; do
+        resource=$(yq e ".metadata.name == \"${resource_name}\" | parent | parent | select(.kind == \"${kind}\")" "$resource_file")
+        [[ -n "$resource" ]] || continue
+
+        echo "Waiting for ${kind} ${resource_name} to be ready."
+        kubectl rollout status -n "$ns" "${kind,,}/${resource_name}" --timeout="${TIMEOUT}"
+    done
 }
 
 function remove_resource() {

--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: dummypod
+  namespace: ${ns}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
As this is a workaround for kind based clusters, deploy it when creating such clusters.
This makes more logical sense if you want to only create clusters, and manually deploy on top of them.
This also avoids deploying dummypods on other infra, such as aws-ocp.

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>
(cherry picked from commit 9a2641cbe17caddf4253d7d3370f1ce2a36da0fe)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
