### PR TITLE
Make ginkgo config configurable for E2E

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -86,8 +86,13 @@ func RunE2ETests(t *testing.T) bool {
 	gomega.RegisterFailHandler(Fail)
 
 	suiteConfig, reporterConfig := GinkgoConfiguration()
-	if framework.TestContext.JunitReport != "" {
-		reporterConfig.JUnitReport = framework.TestContext.JunitReport
+
+	if framework.TestContext.SuiteConfig != nil {
+		suiteConfig = *framework.TestContext.SuiteConfig
+	}
+
+	if framework.TestContext.ReporterConfig != nil {
+		reporterConfig = *framework.TestContext.ReporterConfig
 	}
 
 	return RunSpecs(t, "Submariner E2E suite", suiteConfig, reporterConfig)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/onsi/ginkgo/v2/types"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
 )
@@ -30,12 +31,13 @@ import (
 type contextArray []string
 
 type TestContextType struct {
+	ReporterConfig      *types.ReporterConfig
+	SuiteConfig         *types.SuiteConfig
 	KubeConfigs         []string // KubeConfigs provides an alternative to KubeConfig + KubeContexts
 	KubeConfig          string
 	KubeContexts        contextArray
 	ClusterIDs          []string
 	NumNodesInCluster   map[ClusterIndex]int
-	JunitReport         string
 	SubmarinerNamespace string
 	ConnectionTimeout   uint
 	ConnectionAttempts  uint
@@ -66,8 +68,6 @@ func init() {
 	flag.StringVar(&TestContext.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to kubeconfig containing embedded authinfo.")
 	flag.Var(&TestContext.KubeContexts, "dp-context", "kubeconfig context for dataplane clusters (use several times).")
-	flag.StringVar(&TestContext.JunitReport, "junit-report", "",
-		"Path to the directory and filename of the JUnit XML report. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.SubmarinerNamespace, "submariner-namespace", "submariner",
 		"Namespace in which the submariner components are deployed.")
 	flag.UintVar(&TestContext.ConnectionTimeout, "connection-timeout", 18,


### PR DESCRIPTION
In ginkgo v2, the `SuiteConfig` and `ReporterConfig` are no longer global and need to be passed to `RunSpecs`. `subctl` needs to be able to customize some of these fields so add `SuiteConfig` and `ReporterConfig` fields to the `TestContext` to facilitate this.

Note that `TestContext.JunitReport` was removed since the equivalent field exists in `ReporterConfig`.

