### PR TITLE
Use local `Shipyard` when testing consuming E2E

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -41,36 +41,41 @@ jobs:
           - project: submariner-operator
             k8s_version: '1.24'
     steps:
-      - name: Check out the Shipyard repository
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-
-      - name: Build the latest Shipyard image
-        run: make images
-
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
         with:
           # This is replaced to stable branch by auto release process
           ref: devel
           repository: submariner-io/${{ matrix.project }}
-          path: ${{ matrix.project }}
+
+      # Check out Shipyard as a sub directory of the project, so that `go replace` can work.
+      # As it's all run inside an ephemeral container, this way guarantees the Shipyard bits will be readily available for `go replace`.
+      - name: Check out the Shipyard repository
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+        with:
+          path: shipyard
+
+      - name: Build the latest Shipyard images
+        run: make -C shipyard images
 
       - name: Copy Shipyard resources
-        run: cp -n Dockerfile.* Makefile.dapper .dapper ${{ matrix.project }}/
+        run: cp -n shipyard/{Dockerfile.*,Makefile.dapper,.dapper} .
 
       - name: Make sure ${{ matrix.project }} is using the built Shipyard image
-        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' ${{ matrix.project }}/Dockerfile.dapper
+        run: sed -i 's/shipyard-dapper-base:*.*/shipyard-dapper-base:dev/' Dockerfile.dapper
+
+      - name: Make sure ${{ matrix.project }} is using the Shipyard go module
+        run: make go-replace REPLACE=github.com/submariner-io/shipyard=./shipyard
 
       - name: Run E2E deployment and tests
-        uses: ./gh-actions/e2e
+        uses: ./shipyard/gh-actions/e2e
         with:
           k8s_version: ${{ matrix.k8s_version }}
           using: ${{ matrix.cabledriver }} ${{ matrix.deploytool }}
-          working-directory: ./${{ matrix.project }}
 
       - name: Post mortem
         if: failure()
-        uses: ./gh-actions/post-mortem
+        uses: ./shipyard/gh-actions/post-mortem
 
   lint-consuming:
     name: Lint

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -275,6 +275,11 @@ yamllint:
 backport:
 	$(SCRIPTS_DIR)/backport.sh $(release) $(pr)
 
+# [go-replace] allows anyone to quickly and easily set a Go replace
+go-replace:
+	go mod edit -replace=$(REPLACE)
+	go mod tidy
+
 # [post-mortem] prints a heap of information, to help in debugging failures on the KIND clusters
 post-mortem:
 	$(SCRIPTS_DIR)/post_mortem.sh

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -13,10 +13,6 @@ inputs:
   using:
     description: 'Various options to pass via using="..."'
     required: false
-  working-directory:
-    description: 'Working directory to run in'
-    required: false
-    default: '.'
   target:
     description: 'Target for make'
     required: false
@@ -81,7 +77,6 @@ runs:
 
     - name: Run E2E deployment and tests
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       run: |
         k8s_version=${{ inputs.k8s_version }} &&
         make "${{ inputs.target }}" \


### PR DESCRIPTION
Consuming projects running E2E tests rely on code supplied by Shipyard. Use the local Shipyard when testing them, to make sure the latest code is tested, and catch any breakages.

Resolves #756 

Depends on #1112 

Signed-off-by: Mike Kolesnik <mkolesni@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
