### PR TITLE
Ignore k8s dependencies included with client-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      # These are included by k8s.io/client-go
+      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/apimachinery


### PR DESCRIPTION
...in the dependabot config.

