### PR TITLE
Use [ ] in Make shell snippets

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -46,7 +46,7 @@ endif
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
 $(filter-out .dapper prune-images shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper $(BASE_DAPPER)
-	@[[ -z "$$CI" ]] || echo "::group::Launching a container to run 'make $@'"
+	@[ -z "$$CI" ] || echo "::group::Launching a container to run 'make $@'"
 	-docker network create -d bridge kind
 	+$(RUN_IN_DAPPER) make $(MAKE_DEBUG_FLAG) $@
 
@@ -58,7 +58,7 @@ $(BASE_DAPPER) $(LINTING_DAPPER):
 # Run silently as the commands are pretty straightforward and `make` hasn't a lot to do
 $(LINTING_GOALS): DAPPER_ARGS := -f $(LINTING_DAPPER)
 $(LINTING_GOALS): .dapper $(LINTING_DAPPER)
-	@[[ -z "$$CI" ]] || echo "::group::Launching a container to run 'make $@'"
+	@[ -z "$$CI" ] || echo "::group::Launching a container to run 'make $@'"
 	@$(RUN_IN_DAPPER) make $@
 
 # [prune-images] removes all Submariner-provided images and all untagged images

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -33,7 +33,7 @@ export LAZY_DEPLOY SUBCTL_VERIFICATIONS TEST_ARGS TESTDIR
 export RESTART ?= none
 
 # Specific to `shellcheck`
-export SHELLCHECK_ARGS += $(shell [[ ! -d scripts ]] || find scripts -type f -exec awk 'FNR == 1 && /sh$$/ { print FILENAME }' {} +)
+export SHELLCHECK_ARGS += $(shell [ ! -d scripts ] || find scripts -type f -exec awk 'FNR == 1 && /sh$$/ { print FILENAME }' {} +)
 
 # Specific to `compile.sh`
 export BUILD_DEBUG BUILD_UPX LDFLAGS


### PR DESCRIPTION
The shell spawned by Make isn't guaranteed to support [[; we don't need the added features of [[ compared to [, so use the latter.

This fixes "/bin/sh: 1: [[: not found" errors in CI.

Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
