### PR TITLE
Support for deploying dual-stack k8s clusters

### DIFF
--- a/Makefile.dapper
+++ b/Makefile.dapper
@@ -43,11 +43,18 @@ ifeq (true,$(DEBUG_PRINT))
 MAKE_DEBUG_FLAG = --debug=b
 endif
 
+USING = $(subst $(,), ,$(using))
+_using = ${USING}
+
+ifneq (,$(filter dual-stack,$(_using)))
+IPV6_FLAGS = --ipv6 --subnet fc00:1234:4444::/64
+endif
+
 # Only run command line goals in dapper (except things that have to run outside of dapper).
 # Otherwise, make applies this rule to various files and tries to build them in dapper (which doesn't work, obviously).
 $(filter-out .dapper prune-images shell targets $(NON_DAPPER_GOALS),$(MAKECMDGOALS)): .dapper $(BASE_DAPPER)
 	@[ -z "$$CI" ] || echo "::group::Launching a container to run 'make $@'"
-	-docker network create -d bridge kind
+	-docker network create $(IPV6_FLAGS) -d bridge kind
 	+$(RUN_IN_DAPPER) make $(MAKE_DEBUG_FLAG) $@
 
 # The original dockerfiles will live in Shipyard and be downloaded by consuming projects.

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -9,7 +9,7 @@ DEBUG_PRINT ?= true
 PARALLEL ?= true
 PROVIDER ?= kind
 TIMEOUT ?= 5m
-export AIR_GAPPED DEBUG_PRINT GLOBALNET LOAD_BALANCER PARALLEL PLUGIN PRELOAD_IMAGES PROVIDER SETTINGS TIMEOUT
+export AIR_GAPPED DEBUG_PRINT GLOBALNET LOAD_BALANCER PARALLEL PLUGIN PRELOAD_IMAGES PROVIDER SETTINGS TIMEOUT DUAL_STACK
 
 # Specific to `clusters`
 K8S_VERSION ?= 1.25
@@ -124,6 +124,10 @@ endif
 
 ifneq (,$(filter air-gap,$(_using)))
 AIR_GAPPED = true
+endif
+
+ifneq (,$(filter dual-stack,$(_using)))
+DUAL_STACK = true
 endif
 
 ifeq ($(LIGHTHOUSE),true)

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -19,9 +19,11 @@ kind_k8s_versions[1.25]=1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707
 
 function generate_cluster_yaml() {
     # These are used by render_template
-    local pod_cidr service_cidr dns_domain disable_cni
+    local pod_cidr pod_cidr_ipv6 service_cidr service_cidr_ipv6 dns_domain disable_cni
     pod_cidr="${cluster_CIDRs[${cluster}]}"
+
     service_cidr="${service_CIDRs[${cluster}]}"
+
     dns_domain="${cluster}.local"
     disable_cni="false"
     [[ -z "${cluster_cni[$cluster]}" ]] || disable_cni="true"
@@ -29,7 +31,13 @@ function generate_cluster_yaml() {
     local nodes
     for node in ${cluster_nodes[${cluster}]}; do nodes="${nodes}"$'\n'"- role: $node"; done
 
-    render_template "${RESOURCES_DIR}/kind-cluster-config.yaml" > "${RESOURCES_DIR}/${cluster}-config.yaml"
+    if [[ "$DUAL_STACK" ]]; then
+        service_cidr_ipv6="${service_IPv6_CIDRs[${cluster}]}"
+        pod_cidr_ipv6="${cluster_IPv6_CIDRs[${cluster}]}"
+        render_template "${RESOURCES_DIR}/kind-cluster-dual-stack-config.yaml" > "${RESOURCES_DIR}/${cluster}-config.yaml"
+    else
+        render_template "${RESOURCES_DIR}/kind-cluster-config.yaml" > "${RESOURCES_DIR}/${cluster}-config.yaml"
+    fi
 }
 
 function kind_fixup_config() {

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -175,12 +175,15 @@ function add_cluster_cidrs() {
 
     cluster_CIDRs[$idx]="10.$((val+129)).0.0/16"
     service_CIDRs[$idx]="100.$((val+65)).0.0/16"
+
+    cluster_IPv6_CIDRs[$idx]="fc00:$((val+1000))::/48"
+    service_IPv6_CIDRs[$idx]="fc00:$((val+2000))::/112"
 }
 
 function declare_cidrs() {
     local DEBUG_PRINT=false
     # shellcheck disable=SC2034 # these variables are used elsewhere
-    declare -gA cluster_CIDRs service_CIDRs global_CIDRs
+    declare -gA cluster_CIDRs cluster_IPv6_CIDRs service_CIDRs service_IPv6_CIDRs global_CIDRs
     local cluster i=1
 
     for cluster in "${clusters[@]}"; do

--- a/scripts/shared/resources/kind-cluster-dual-stack-config.yaml
+++ b/scripts/shared/resources/kind-cluster-dual-stack-config.yaml
@@ -1,0 +1,23 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: ${disable_cni}
+  podSubnet: ${pod_cidr},${pod_cidr_ipv6}
+  serviceSubnet: ${service_cidr},${service_cidr_ipv6}
+  ipFamily: dual
+containerdConfigPatches:
+  - |-
+    [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:5000\"]
+      endpoint = [\"http://kind-registry:5000\"]
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    networking:
+      podSubnet: ${pod_cidr},${pod_cidr_ipv6}
+      serviceSubnet: ${service_cidr},${service_cidr_ipv6}
+      dnsDomain: ${dns_domain}
+nodes: ${nodes}


### PR DESCRIPTION
This PR enables necessary support in shipyard to deploy a KIND K8s dual-stack cluster. In order to deploy a dual-stack cluster, pass "dual-stack" as part of make command as shown below.

make deploy using=dual-stack

Related to: https://github.com/submariner-io/submariner/issues/1739
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
