### PR TITLE
Add make deploy with IPv4/6 dual-stack job

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -55,6 +55,7 @@ jobs:
             lighthouse: lighthouse
           - extra-toggles: air-gap
             ovn: ovn
+          - extra-toggles: dual-stack
           - extra-toggles: ovn
           - deploytool: operator
             extra-toggles: lighthouse


### PR DESCRIPTION
As discussed on #1173, this adds test coverage for the new dual-stack deployment logic.

Related to: submariner-io/submariner#1739
Signed-off-by: Daniel Farrell <dfarrell@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
