### PR TITLE
Remove local-registry flag

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -199,7 +199,7 @@ function deploy_kind_ovn(){
     docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
     docker push "${OVN_IMAGE}"
 
-    delete_cluster_on_fail ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -lr -dd "${KIND_CLUSTER_NAME}.local"
+    delete_cluster_on_fail ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric -dd "${KIND_CLUSTER_NAME}.local"
 
     [[ "$AIR_GAPPED" = true ]] && air_gap_iptables
 }
@@ -254,9 +254,9 @@ function download_ovnk() {
         echo contrib/ > .git/info/sparse-checkout
         echo dist/ >> .git/info/sparse-checkout
         if git remote add -f origin https://github.com/ovn-org/ovn-kubernetes.git; then
-            git pull origin af58536d749c2ad377e3e1a032375ffcee4dcb4c
+            git pull origin master
         else
-            git fetch && git reset --hard af58536d749c2ad377e3e1a032375ffcee4dcb4c
+            git fetch && git reset --hard origin/master
         fi
     )
 }


### PR DESCRIPTION
Removing the -lr(local-registry) flag from the cluster create command. This would still use local build, but does not push it local registry

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
