### PR TITLE
Bump golangci-lint to 1.52.2

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -58,7 +58,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
-ENV LINT_VERSION=v1.50.1 \
+ENV LINT_VERSION=v1.52.2 \
     HELM_VERSION=v3.9.0 \
     KIND_VERSION=v0.17.0 \
     BUILDX_VERSION=v0.8.2 \


### PR DESCRIPTION
This adds support for Go 1.20, and the following linters:
* ginkgolinter
* gocheckcompilerdirectives
* musttag
* timeformat (govet)

All our configured linters now support generics.

Changelogs:
* https://github.com/golangci/golangci-lint/releases/tag/v1.51.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.51.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.51.2
* https://github.com/golangci/golangci-lint/releases/tag/v1.52.0
* https://github.com/golangci/golangci-lint/releases/tag/v1.52.1
* https://github.com/golangci/golangci-lint/releases/tag/v1.52.2

Depends on https://github.com/submariner-io/coastguard/pull/144
Depends on https://github.com/submariner-io/lighthouse/pull/1183
Depends on https://github.com/submariner-io/subctl/pull/650
Depends on https://github.com/submariner-io/submariner/pull/2396
Depends on https://github.com/submariner-io/submariner-operator/pull/2585