### PR TITLE
Give the full path to restore-images in e2e

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -74,7 +74,7 @@ runs:
         echo "::endgroup::"
 
     - name: Restore images from the cache
-      uses: ./gh-actions/restore-images
+      uses: submariner-io/shipyard/gh-actions/restore-images@devel
       with:
         cache: ${{ inputs.cache }}
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Relative action paths are interpreted relative to the path invoking the action; so a relative path in e2e only works in Shipyard. Specifying the full path allows e2e to work elsewhere again.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
