### PR TITLE
Fix length tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,7 @@ linters:
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
     # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
     - gci
+    - ginkgolinter
     # - gochecknoglobals # We don't want to forbid global variable constants
     # - gochecknoinits # We use init functions for valid reasons
     - gocognit

--- a/test/e2e/example/example.go
+++ b/test/e2e/example/example.go
@@ -61,7 +61,7 @@ func testListingNodesFromCluster(cs *kubernetes.Clientset) {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Checking that we had more than 0 nodes on the response")
-	Expect(len(nodes.Items)).ToNot(BeZero())
+	Expect(nodes.Items).ToNot(BeEmpty())
 
 	for i := range nodes.Items {
 		inIP, err := getIP(v1.NodeInternalIP, &nodes.Items[i])

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -165,7 +165,7 @@ func BeforeSuite() {
 
 	if len(RestConfigs) == 0 {
 		if len(TestContext.KubeConfig) > 0 {
-			Expect(len(TestContext.KubeConfigs)).To(BeZero(),
+			Expect(TestContext.KubeConfigs).To(BeEmpty(),
 				"Either KubeConfig or KubeConfigs must be specified but not both")
 
 			for _, ctx := range TestContext.KubeContexts {
@@ -177,7 +177,7 @@ func BeforeSuite() {
 				TestContext.ClusterIDs = TestContext.KubeContexts
 			}
 		} else if len(TestContext.KubeConfigs) > 0 {
-			Expect(len(TestContext.KubeConfigs)).To(Equal(len(TestContext.ClusterIDs)),
+			Expect(TestContext.KubeConfigs).To(HaveLen(len(TestContext.ClusterIDs)),
 				"One ClusterID must be provided for each item in the KubeConfigs")
 			for _, kubeConfig := range TestContext.KubeConfigs {
 				RestConfigs = append(RestConfigs, createRestConfig(kubeConfig, ""))

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -564,7 +564,7 @@ func (np *NetworkPod) nodeAffinity(scheduling NetworkPodScheduling) *v1.Affinity
 			}).(*v1.PodList)
 
 		hostname := smGWPodList.Items[0].Labels["gateway.submariner.io/node"]
-		Expect(len(hostname)).NotTo(BeZero())
+		Expect(hostname).NotTo(BeEmpty())
 		nodeSelTerms = addNodeSelectorTerm(nodeSelTerms, "kubernetes.io/hostname", v1.NodeSelectorOpIn, []string{hostname})
 
 	case NonGatewayNode:


### PR DESCRIPTION
* Use BeEmpty() for emptiness tests
* Use HaveLen() for non-constant-zero length comparisons

... and enable ginkgolinter to catch such issues automatically.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
