### PR TITLE
Automated backport of #1203: Allow container images to be cached

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,6 +11,7 @@ env:
 jobs:
   build-multiarch-images:
     name: Build multi-arch images
+    needs: images
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
@@ -22,6 +23,9 @@ jobs:
       - name: Set up buildx
         uses: docker/setup-buildx-action@f03ac48505955848960e80bbb68046aa35c7b9e7
 
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
+
       - name: Build the multi-arch images
         run: make multiarch-images
 
@@ -30,11 +34,15 @@ jobs:
 
   clean-clusters:
     name: Clean up clusters
+    needs: images
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Deploy clusters
         run: make clusters TIMEOUT=1m
@@ -64,11 +72,15 @@ jobs:
 
   clusters:
     name: Clusters
+    needs: images
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Deploy clusters
         run: make clusters TIMEOUT=1m
@@ -79,16 +91,21 @@ jobs:
 
   compilation:
     name: Compilation
+    needs: images
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Test the compile.sh script
         run: make script-test SCRIPT_TEST_ARGS="test/scripts/compile/test.sh"
 
   deployment:
     name: Deployment
+    needs: images
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
@@ -126,6 +143,9 @@ jobs:
       - name: Fetch all git tags
         run: git fetch origin +refs/tags/*:refs/tags/*
 
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
+
       - name: Deploy clusters and Submariner
         run: make deploy using="${{ matrix.globalnet }} ${{ matrix.deploytool }} ${{ matrix.extra-toggles }}" TIMEOUT=1m
 
@@ -135,11 +155,15 @@ jobs:
 
   e2e:
     name: E2E
+    needs: images
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Run E2E deployment and tests
         run: make e2e
@@ -148,22 +172,40 @@ jobs:
         if: failure()
         uses: ./gh-actions/post-mortem
 
-  mutliple-gateways-support:
-    name: Multiple gateways support
+  images:
+    name: Images
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Build the images if necessary
+        uses: ./gh-actions/cache-images
+
+  mutliple-gateways-support:
+    name: Multiple gateways support
+    needs: images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Deploy clusters and test cloud-prepare
         run: make script-test SCRIPT_TEST_ARGS="test/scripts/cloud-prepare/test.sh"
 
   post-mortem:
     name: Post mortem
+    needs: images
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Deploy some clusters
         run: make clusters
@@ -173,10 +215,14 @@ jobs:
 
   unit:
     name: Unit tests
+    needs: images
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Restore images from the cache
+        uses: ./gh-actions/restore-images
 
       - name: Running `make unit` is expected to pass
         run: make unit

--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -1,0 +1,31 @@
+---
+name: 'Cache Images'
+description: 'Builds project images and caches them'
+inputs:
+  cache:
+    description: 'Location of the cache'
+    required: false
+    default: '~/image-cache'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up the cache
+      id: image-cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: ${{ inputs.cache }}
+        key: image-cache-${{ github.sha }}
+
+    - name: Build the images if necessary
+      if: steps.image-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "::group::Building images and storing them"
+        make images
+        mkdir -p ${{ inputs.cache }}
+        for image in package/.image.*; do \
+          docker save quay.io/submariner/${image#package/.image.} | \
+          gzip > ${{ inputs.cache }}/${image#package/.image.}.tar.gz; \
+          cp $image ${{ inputs.cache }}; \
+        done
+        echo "::endgroup::"

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -74,7 +74,7 @@ runs:
         echo "::endgroup::"
 
     - name: Restore images from the cache
-      uses: ./gh-actions/restore-images
+      uses: submariner-io/shipyard/gh-actions/restore-images@release-0.15
       with:
         cache: ${{ inputs.cache }}
         working-directory: ${{ inputs.working-directory }}

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -2,6 +2,10 @@
 name: 'End to End'
 description: 'Runs end to end tests with multiple clusters'
 inputs:
+  cache:
+    description: 'Location of the cache'
+    required: false
+    default: '~/image-cache'
   k8s_version:
     description: 'Version of Kubernetes to use for clusters'
     required: false
@@ -68,6 +72,12 @@ runs:
         sudo apt install -y linux-headers-$(uname -r) wireguard
         sudo modprobe wireguard
         echo "::endgroup::"
+
+    - name: Restore images from the cache
+      uses: ./gh-actions/restore-images
+      with:
+        cache: ${{ inputs.cache }}
+        working-directory: ${{ inputs.working-directory }}
 
     - name: Run E2E deployment and tests
       shell: bash

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -1,0 +1,28 @@
+---
+name: 'Restore Images'
+description: 'Restores cached images'
+inputs:
+  cache:
+    description: 'Location of the cache'
+    required: false
+    default: '~/image-cache'
+  working-directory:
+    description: 'Working directory to run in'
+    required: false
+    default: '.'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up the cache
+      id: image-cache
+      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      with:
+        path: ${{ inputs.cache }}
+        key: image-cache-${{ github.sha }}
+
+    - name: Restore images from cache
+      if: steps.image-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        for archive in ${{ inputs.cache }}/*.tar*; do docker load -i $archive; done
+        cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/


### PR DESCRIPTION
Backport of #1203 on release-0.15.

#1203: Allow container images to be cached

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.