### PR TITLE
Remove remnants of vendoring support

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -223,9 +223,6 @@ gitlint:
 	    gitlint --config $(SHIPYARD_DIR)/.gitlint --commits origin/$(BASE_BRANCH)..HEAD; \
 	fi
 
-# List of vendor/modules.txt files we might encounter
-VENDOR_MODULES := $(shell find . -name vendor -prune -o -writable -name go.mod -printf "%h/vendor/modules.txt\n")
-
 # [golangci-lint] validates Go code in the project
 golangci-lint:
 ifneq (,$(shell find . -name '*.go'))
@@ -238,7 +235,7 @@ endif
 
 # [markdownlint] validates Markdown files in the project
 markdownlint:
-	md_ignored=($(patsubst %/modules.txt,%,$(VENDOR_MODULES))); \
+	md_ignored=(); \
 	if [ -r .mdignore ]; then \
 		md_ignored+=($$(< .mdignore)); \
 	fi; \
@@ -285,17 +282,6 @@ post-mortem:
 # [unit] executes the Go unit tests of the project
 unit:
 	$(SCRIPTS_DIR)/unit_test.sh
-
-vendor/modules.txt: go.mod
-	$(GO) mod download
-	$(GO) mod vendor
-	$(GO) mod tidy
-
-%/vendor/modules.txt: %/go.mod
-	cd $(patsubst %/vendor/,%,$(dir $@)) && \
-	$(GO) mod download && \
-	$(GO) mod vendor && \
-	$(GO) mod tidy
 
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners


### PR DESCRIPTION
Submariner projects no longer rely on vendoring, remove the remnants of vendoring support.

Depends on https://github.com/submariner-io/coastguard/pull/150 

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
