### PR TITLE
Don't fail when restoring images if there are none

### DIFF
--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -25,4 +25,6 @@ runs:
       shell: bash
       run: |
         for archive in ${{ inputs.cache }}/*.tar*; do docker load -i $archive; done
-        cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/
+        if [ -d ${{ inputs.working-directory }}/package ]; then \
+          cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/; \
+        fi


### PR DESCRIPTION
In projects which don't build images, there's no package directory; restore-images shouldn't fail because of this.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
