### PR TITLE
Pin gitlint version

### DIFF
--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -23,12 +23,13 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} \
 # yamllint         | YAML linting
 # yq               | YAML processing
 
-ENV MARKDOWNLINT_VERSION=0.33.0
+ENV MARKDOWNLINT_VERSION=0.33.0 \
+    GITLINT_VERSION=0.19.1
 
 RUN apk add --no-cache bash findutils git grep make nodejs py3-six shellcheck upx yamllint yq && \
     apk add --no-cache --virtual installers npm py3-pip && \
     npm install -g markdownlint-cli@${MARKDOWNLINT_VERSION} && \
-    pip install gitlint && \
+    pip install gitlint==${GITLINT_VERSION} && \
     find /usr/bin/ -type f -executable -newercc /proc -size +1M  \( -execdir upx {} \; -o -true \) && \
     find /usr/lib/ -name __pycache__ -type d -exec rm -rf {} + && \
     apk del installers


### PR DESCRIPTION
Avoid unplanned changes in linting requirements that can make it harder to get unrelated patches merged.

I looked at removing the need for pip by installing gitlint from the OS, but it's not available in Alpine (it is in Fedora).

Relates-to: #884

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
