### PR TITLE
Update Helm version to 3.11.3, fix CVEs

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -59,7 +59,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 ENV LINT_VERSION=v1.52.2 \
-    HELM_VERSION=v3.9.0 \
+    HELM_VERSION=v3.11.3 \
     KIND_VERSION=v0.18.0 \
     BUILDX_VERSION=v0.8.2 \
     GH_VERSION=2.20.2 \


### PR DESCRIPTION
There where a number of CVEs fixed between these releases:

https://github.com/helm/helm/security/advisories/GHSA-pwcw-6f5g-gxf8 https://github.com/helm/helm/security/advisories/GHSA-6rx9-889q-vv2r https://github.com/helm/helm/security/advisories/GHSA-53c4-hhmh-vw5q https://github.com/helm/helm/security/advisories/GHSA-67fx-wx78-jx33 https://github.com/helm/helm/security/advisories/GHSA-7hfp-qfw3-5jxh

It's also built with a newer Go version, which includes CVE fixes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
