### PR TITLE
Update buildx to 0.10.4, adds SBOM support

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -61,7 +61,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 ENV LINT_VERSION=v1.52.2 \
     HELM_VERSION=v3.9.0 \
     KIND_VERSION=v0.18.0 \
-    BUILDX_VERSION=v0.8.2 \
+    BUILDX_VERSION=v0.10.4 \
     GH_VERSION=2.20.2 \
     YQ_VERSION=4.20.2
 


### PR DESCRIPTION
The 0.10.x releases of buildx add support for creating Software Bill of Materials during the build process. It seems like they can even capture software used during the build that doesn't make it into the final container.

This may support submariner-io/enhancements#185.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
