### PR TITLE
Collect subctl gather in post-mortem

### DIFF
--- a/gh-actions/post-mortem/action.yaml
+++ b/gh-actions/post-mortem/action.yaml
@@ -18,3 +18,8 @@ runs:
         echo "::group::Running post mortem"
         make post-mortem
         echo "::endgroup::"
+
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      with:
+        name: submariner-gather
+        path: gather_output

--- a/scripts/shared/post_mortem.sh
+++ b/scripts/shared/post_mortem.sh
@@ -59,6 +59,9 @@ function post_analyze() {
     print_section "* Output of 'subctl diagnose all' in $cluster *"
     subctl diagnose all --context "$cluster"
 
+    print_section "* Collecting 'subctl gather' in $cluster *"
+    subctl gather --context "$cluster" --dir gather_output
+
     return 0
 }
 


### PR DESCRIPTION
To aid in debugging, in particular submariner-io/submariner#2420, collect and archive `subctl gather` when running post mortems.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
