### PR TITLE
Enhance e2e to pick non-Gateway nodes via labels

### DIFF
--- a/release-notes/20230508-e2e-non-gw-nodes.md
+++ b/release-notes/20230508-e2e-non-gw-nodes.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable MD041 -->
+`subctl verify` has been enhanced to select nodes labeled with `test.submariner.io/non-gateway-node=true` as non-Gateway
+nodes while scheduling the test pods. If none of the nodes have the label `test.submariner.io/non-gateway-node=true`, the
+test framework falls back to the existing approach of randomly selecting a non-Gateway node.

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -65,6 +65,7 @@ const (
 	RouteAgent         = "submariner-routeagent"
 	GatewayLabel       = "submariner.io/gateway"
 	ActiveGatewayLabel = "gateway.submariner.io/status=active"
+	TestNonGWNodeLabel = "test.submariner.io/non-gateway-node=true"
 )
 
 type PatchFunc func(pt types.PatchType, payload []byte) error


### PR DESCRIPTION
Currently, subctl verify ... picks random non-Gateway nodes to verify various use-cases. However, in large deployments if there is any connectivity issue on a specific node, the tool will not be able to identify the issue unless the client/server pod is scheduled on the node.

This PR enhances the code to select non-Gateway nodes specifically labeled with `test.submariner.io/non-gateway-node=true` while validating datapath use-cases. If none of the nodes have the label, the test framework falls back to the existing approach of randomly selecting a non-Gateway node.

Fixes: https://github.com/submariner-io/shipyard/issues/1244

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
