### PR TITLE
Automated backport of #1247: Add missing shell parameter expansion quotes

### DIFF
--- a/scripts/shared/e2e.sh
+++ b/scripts/shared/e2e.sh
@@ -54,7 +54,7 @@ function order_clusters {
 
     local orig_cluster="${clusters[0]}"
     clusters[0]="${clusters[$biggest_cluster]}"
-    clusters[$biggest_cluster]="${orig_cluster}"
+    clusters[biggest_cluster]="${orig_cluster}"
 }
 
 ### Main ###

--- a/scripts/shared/lib/deploy_ocm
+++ b/scripts/shared/lib/deploy_ocm
@@ -84,13 +84,13 @@ function install_submariner_addon() {
     submariner_addon_dir=/tmp/submariner-addon/deploy
   fi
   # Set submariner-addon imagePullPolicy to IfNotPresent
-  sed -i -- '/image: quay.io*/a\        imagePullPolicy: IfNotPresent' ${submariner_addon_dir}/config/operator/operator.yaml
+  sed -i -- '/image: quay.io*/a\        imagePullPolicy: IfNotPresent' "${submariner_addon_dir}/config/operator/operator.yaml"
   # Add master apiserver to submariner-addon deployment
   broker_api_server=$(kubectl get endpoints kubernetes -n default -o jsonpath="{.subsets[0].addresses[0].ip}:{.subsets[0].ports[?(@.name=='https')].port}")
   yq eval -i '.spec.template.spec.containers[].env += {"name": "BROKER_API_SERVER", "value": "'"${broker_api_server}"'"}' \
-  ${submariner_addon_dir}/config/operator/operator.yaml
+  "${submariner_addon_dir}/config/operator/operator.yaml"
   # Deploy
-  kubectl apply -k ${submariner_addon_dir}/config/manifests
+  kubectl apply -k "${submariner_addon_dir}/config/manifests"
 }
 
 function create_managed_clusters() {

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -131,7 +131,7 @@ function run_parallel() {
     done
 
     for pid in "${pids[@]}"; do
-        wait $pid
+        wait "$pid"
     done
 }
 


### PR DESCRIPTION
Backport of #1247 on release-0.15.

#1247: Add missing shell parameter expansion quotes

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.