### PR TITLE
Allow k8s.io dependabot tracking on the 0.14/0.15 branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,30 @@ updates:
     schedule:
       interval: monthly
   - package-ecosystem: gomod
+    target-branch: "release-0.14"
+    directory: "/"
+    schedule:
+      interval: weekly
+    allow:
+      # Pick up k8s.io updates
+      - dependency-name: k8s.io/client-go
+    ignore:
+      # 0.14 tracks the 0.25 branch
+      - dependency-name: k8s.io/*
+        versions: ">= 0.26.0-alpha.0"
+  - package-ecosystem: gomod
+    target-branch: "release-0.15"
+    directory: "/"
+    schedule:
+      interval: weekly
+    allow:
+      # Pick up k8s.io updates
+      - dependency-name: k8s.io/client-go
+    ignore:
+      # 0.15 tracks the 0.26 branch
+      - dependency-name: k8s.io/*
+        versions: ">= 0.27.0-alpha.0"
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
This ensures we get bug fixes on the appropriate k8s.io branches.

There's no point in configuring earlier branches than 0.14, because the versions of k8s.io they track have reached their EOL. We can revisit this if we bump to a supported k8s.io release on those release branches.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
