### PR TITLE
Add version to nettest image

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -16,6 +16,8 @@ FROM alpine
 
 WORKDIR /app
 
+ARG VERSION
+
 RUN apk add --no-cache \
 	bash \
 	bind-tools \
@@ -26,5 +28,7 @@ RUN apk add --no-cache \
 
 COPY --from=0 /usr/local/bin/net* /usr/local/bin/
 COPY scripts/nettest/* /app/
+
+RUN echo ${VERSION} >> /app/version
 
 CMD ["/bin/bash","-l"]

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -55,7 +55,7 @@ fi
 [[ -n "$PLATFORM" ]] || PLATFORM="$default_platform"
 
 # Rebuild the image to update any changed layers and tag it back so it will be used.
-buildargs_flags=(--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg "BASE_BRANCH=${BASE_BRANCH}")
+buildargs_flags=(--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg "BASE_BRANCH=${BASE_BRANCH}" --build-arg "VERSION=${VERSION}")
 if [[ "${PLATFORM}" != "${default_platform}" ]] && docker buildx version > /dev/null 2>&1; then
     docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
     docker buildx build "${output_flag}" -t "${local_image}" "${cache_flags[@]}" -f "${dockerfile}" --iidfile "${hashfile}" --platform "${PLATFORM}" "${buildargs_flags[@]}" .


### PR DESCRIPTION
Adds a `version` file to nettest image which can help determine version in-use for submariner-metrics-proxy pods

Refer https://github.com/submariner-io/enhancements/pull/204

Fixes #1327 