### PR TITLE
Revert "Fix deployment error while overriding network plugin syncer"

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -146,6 +146,9 @@ override PRELOAD_IMAGES = $(EXTRA_PRELOAD_IMAGES) nettest \
 ifeq ($(GLOBALNET),true)
 override PRELOAD_IMAGES += submariner-globalnet
 endif
+ifneq (,$(shell grep -w ovn $(SETTINGS)))
+override PRELOAD_IMAGES += submariner-networkplugin-syncer
+endif
 ifeq ($(LIGHTHOUSE),true)
 override PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns
 endif

--- a/scripts/shared/lib/deploy_operator
+++ b/scripts/shared/lib/deploy_operator
@@ -13,6 +13,7 @@ readonly SUBCTL=${SUBCTL:-subctl}
 declare -gA component_by_image
 component_by_image['submariner-gateway']=submariner-gateway
 component_by_image['submariner-globalnet']=submariner-globalnet
+component_by_image['submariner-networkplugin-syncer']=submariner-networkplugin-syncer
 component_by_image['submariner-operator']=submariner-operator
 component_by_image['submariner-route-agent']=submariner-routeagent
 component_by_image['lighthouse-agent']=submariner-lighthouse-agent


### PR DESCRIPTION
Reverts submariner-io/shipyard#1340

Related to: https://github.com/submariner-io/subctl/pull/877