### PR TITLE
Use the tools module to build go-mod-outdated

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
       - name: Build go-mod-outdated
-        run: go build -o bin/go-mod-outdated github.com/psampaz/go-mod-outdated
+        run: cd tools && go build -o ../bin/go-mod-outdated github.com/psampaz/go-mod-outdated
 
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9


### PR DESCRIPTION
When the tools module was split off, the periodic outdated dependency check was broken; go-mod-outdated needs to be built using the tools modules. This fixes that.

See https://github.com/submariner-io/shipyard/actions/runs/6061268116 for a series of broken runs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
