### PR TITLE
Automated backport of #1373: Use a specific OVNK commit

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -248,6 +248,7 @@ function prepare_ovn() {
     rm -rf ovn-kubernetes
     git clone https://github.com/ovn-org/ovn-kubernetes
     pushd ovn-kubernetes || exit
+    git checkout c6d8579689fe3b15c87abdf7e7647777bad26605
 
     make -C go-controller
 


### PR DESCRIPTION
Backport of #1373 on release-0.16.

#1373: Use a specific OVNK commit

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.