### PR TITLE
Apply variants of air-gapped jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -118,10 +118,8 @@ jobs:
           - extra-toggles: air-gap
           - extra-toggles: air-gap
             globalnet: globalnet
-          - extra-toggles: air-gap
-            lighthouse: lighthouse
-          - extra-toggles: air-gap
-            ovn: ovn
+          - extra-toggles: 'air-gap, lighthouse'
+          - extra-toggles: 'air-gap, ovn'
           - extra-toggles: dual-stack
           - extra-toggles: ovn
           - extra-toggles: ovn-ic
@@ -133,7 +131,7 @@ jobs:
           - extra-toggles: prometheus
     steps:
       - name: Reclaim space on GHA host (if the job needs it)
-        if: ${{ matrix.ovn != '' }} && ${{ matrix.ovn-ic != '' }}
+        if: ${{ contains('ovn', matrix.extra-toggles) }}
         run: rm -rf /usr/share/dotnet
 
       - name: Check out the repository

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -146,9 +146,6 @@ override PRELOAD_IMAGES = $(EXTRA_PRELOAD_IMAGES) nettest \
 ifeq ($(GLOBALNET),true)
 override PRELOAD_IMAGES += submariner-globalnet
 endif
-ifneq (,$(shell grep -w ovn $(SETTINGS)))
-override PRELOAD_IMAGES += submariner-networkplugin-syncer
-endif
 ifeq ($(LIGHTHOUSE),true)
 override PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns
 endif


### PR DESCRIPTION
The job definitions only consider globalnet, deploytool, and extra-toggles matrix entries; ovn, lighthouse etc. are ignored. This uses extra-toggles for all matrix entries apart from globalnet and deploytool, and adjusts the "Reclaim space" test accordingly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
