### PR TITLE
Automated backport of #1408: Apply variants of air-gapped jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -118,10 +118,8 @@ jobs:
           - extra-toggles: air-gap
           - extra-toggles: air-gap
             globalnet: globalnet
-          - extra-toggles: air-gap
-            lighthouse: lighthouse
-          - extra-toggles: air-gap
-            ovn: ovn
+          - extra-toggles: 'air-gap, lighthouse'
+          - extra-toggles: 'air-gap, ovn'
           - extra-toggles: dual-stack
           - extra-toggles: ovn
           - deploytool: operator
@@ -132,7 +130,7 @@ jobs:
           - extra-toggles: prometheus
     steps:
       - name: Reclaim space on GHA host (if the job needs it)
-        if: ${{ matrix.ovn != '' }}
+        if: ${{ contains('ovn', matrix.extra-toggles) }}
         run: rm -rf /usr/share/dotnet
 
       - name: Check out the repository

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -146,9 +146,6 @@ override PRELOAD_IMAGES = $(EXTRA_PRELOAD_IMAGES) nettest \
 ifeq ($(GLOBALNET),true)
 override PRELOAD_IMAGES += submariner-globalnet
 endif
-ifneq (,$(shell grep -w ovn $(SETTINGS)))
-override PRELOAD_IMAGES += submariner-networkplugin-syncer
-endif
 ifeq ($(LIGHTHOUSE),true)
 override PRELOAD_IMAGES += lighthouse-agent lighthouse-coredns
 endif


### PR DESCRIPTION
Backport of #1408 on release-0.15.

#1408: Apply variants of air-gapped jobs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.