### PR TITLE
Automated backport of #1409: Fix the K8S_VERSION variable case

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -191,7 +191,7 @@ EOF
 }
 
 function deploy_kind_ovn(){
-    export K8s_VERSION="${K8S_VERSION}"
+    export K8S_VERSION
     export NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
     export SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
     export KIND_CLUSTER_NAME="${cluster}"


### PR DESCRIPTION
Backport of #1409 on release-0.16.

#1409: Fix the K8S_VERSION variable case

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.