### PR TITLE
Fix E2E panic due to invalid nil check

### DIFF
--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -52,11 +52,12 @@ func AwaitAllocatedEgressIPs(client dynamic.ResourceInterface, name string) []st
 			return resGip, err
 		},
 		func(result interface{}) (bool, string, error) {
-			if result == nil {
+			obj := result.(*unstructured.Unstructured)
+			if obj == nil {
 				return false, fmt.Sprintf("Egress IP resource %q not found yet", name), nil
 			}
 
-			globalIPs := getGlobalIPs(result.(*unstructured.Unstructured))
+			globalIPs := getGlobalIPs(obj)
 			if len(globalIPs) == 0 {
 				return false, fmt.Sprintf("Egress IP resource %q exists but allocatedIPs not available yet", name), nil
 			}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -288,12 +288,8 @@ func DetectGlobalnet() {
 		}
 		return clusters, err
 	}, func(result interface{}) (bool, string, error) {
-		if result == nil {
-			return false, "No Cluster found", nil
-		}
-
 		clusterList := result.(*unstructured.UnstructuredList)
-		if len(clusterList.Items) == 0 {
+		if clusterList == nil || len(clusterList.Items) == 0 {
 			return false, "No Cluster found", nil
 		}
 
@@ -343,7 +339,7 @@ func fetchClusterIDs() {
 
 			return ds, err
 		}, func(result interface{}) (bool, string, error) {
-			if result == nil {
+			if result.(*appsv1.DaemonSet) == nil {
 				return false, "No DaemonSet found", nil
 			}
 

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -59,11 +59,11 @@ func (f *Framework) AwaitGatewayWithStatus(cluster ClusterIndex, name, status st
 			return findGateway(cluster, name)
 		},
 		func(result interface{}) (bool, string, error) {
-			if result == nil {
+			gw := result.(*unstructured.Unstructured)
+			if gw == nil {
 				return false, "gateway not found yet", nil
 			}
 
-			gw := result.(*unstructured.Unstructured)
 			haStatus := NestedString(gw.Object, "status", "haStatus")
 			if haStatus != status {
 				return false, fmt.Sprintf("gateway %q exists but has wrong status %q, expected %q", gw.GetName(), haStatus, status), nil
@@ -118,11 +118,11 @@ func (f *Framework) AwaitGatewayFullyConnected(cluster ClusterIndex, name string
 			return findGateway(cluster, name)
 		},
 		func(result interface{}) (bool, string, error) {
-			if result == nil {
+			gw := result.(*unstructured.Unstructured)
+			if gw == nil {
 				return false, "gateway not found yet", nil
 			}
 
-			gw := result.(*unstructured.Unstructured)
 			haStatus := NestedString(gw.Object, "status", "haStatus")
 			if haStatus != "active" {
 				return false, fmt.Sprintf("Gateway %q exists but not active yet",

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -47,11 +47,12 @@ func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace s
 				return resGip, err
 			},
 			func(result interface{}) (bool, string, error) {
-				if result == nil {
+				obj := result.(*unstructured.Unstructured)
+				if obj == nil {
 					return false, fmt.Sprintf("GlobalEgressIP %s not found yet", name), nil
 				}
 
-				globalIP := getGlobalIP(result.(*unstructured.Unstructured))
+				globalIP := getGlobalIP(obj)
 				if globalIP == "" {
 					return false, fmt.Sprintf("GlobalIngress %q exists but allocatedIP not available yet",
 						name), nil

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -116,11 +116,11 @@ func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation, 
 		}
 		return pod, err
 	}, func(result interface{}) (bool, string, error) {
-		if result == nil {
+		pod := result.(*v1.Pod)
+		if pod == nil {
 			return false, "No Pod found", nil
 		}
 
-		pod := result.(*v1.Pod)
 		if pod.GetAnnotations()[annotation] == "" {
 			return false, fmt.Sprintf("Pod %q does not have annotation %q yet", podName, annotation), nil
 		}


### PR DESCRIPTION
This code results in a panic if the underlying value of `result` is nil:

```
func(result interface{}) (bool, string, error) {
    if result == nil {
        return false, "gateway not found yet", nil
    }

    gw := result.(*unstructured.Unstructured)
    haStatus := NestedString(gw.Object, "status", "haStatus") => PANIC
    ...
})
```

But it first checks if `result` is nil so how can this be? A simple nil check does not work because interfaces in Go contain both a type and a value. In this case, we want to check for nil after casting.
