### PR TITLE
Automated backport of #1459: Fix nil interface{} checks

### DIFF
--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -52,12 +52,11 @@ func AwaitAllocatedEgressIPs(client dynamic.ResourceInterface, name string) []st
 			return resGip, err
 		},
 		func(result interface{}) (bool, string, error) {
-			obj := result.(*unstructured.Unstructured)
-			if obj == nil {
+			if result == nil {
 				return false, fmt.Sprintf("Egress IP resource %q not found yet", name), nil
 			}
 
-			globalIPs := getGlobalIPs(obj)
+			globalIPs := getGlobalIPs(result.(*unstructured.Unstructured))
 			if len(globalIPs) == 0 {
 				return false, fmt.Sprintf("Egress IP resource %q exists but allocatedIPs not available yet", name), nil
 			}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -281,11 +281,7 @@ func DetectGlobalnet() {
 	}).Namespace(TestContext.SubmarinerNamespace)
 
 	AwaitUntil("find Clusters to detect if Globalnet is enabled", func() (interface{}, error) {
-		clusters, err := clusters.List(context.TODO(), metav1.ListOptions{})
-		if apierrors.IsNotFound(err) {
-			return nil, nil //nolint:nilnil // We want to repeat but let the checker known that nothing was found.
-		}
-		return clusters, err
+		return clusters.List(context.TODO(), metav1.ListOptions{})
 	}, func(result interface{}) (bool, string, error) {
 		clusterList := result.(*unstructured.UnstructuredList)
 		if clusterList == nil || len(clusterList.Items) == 0 {
@@ -338,7 +334,7 @@ func fetchClusterIDs() {
 
 			return ds, err
 		}, func(result interface{}) (bool, string, error) {
-			if result.(*appsv1.DaemonSet) == nil {
+			if result == nil {
 				return false, "No DaemonSet found", nil
 			}
 

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -47,12 +47,11 @@ func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace s
 				return resGip, err
 			},
 			func(result interface{}) (bool, string, error) {
-				obj := result.(*unstructured.Unstructured)
-				if obj == nil {
+				if result == nil {
 					return false, fmt.Sprintf("GlobalEgressIP %s not found yet", name), nil
 				}
 
-				globalIP := getGlobalIP(obj)
+				globalIP := getGlobalIP(result.(*unstructured.Unstructured))
 				if globalIP == "" {
 					return false, fmt.Sprintf("GlobalIngress %q exists but allocatedIP not available yet",
 						name), nil

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -116,11 +116,11 @@ func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation, 
 		}
 		return pod, err
 	}, func(result interface{}) (bool, string, error) {
-		pod := result.(*v1.Pod)
-		if pod == nil {
+		if result == nil {
 			return false, "No Pod found", nil
 		}
 
+		pod := result.(*v1.Pod)
 		if pod.GetAnnotations()[annotation] == "" {
 			return false, fmt.Sprintf("Pod %q does not have annotation %q yet", podName, annotation), nil
 		}


### PR DESCRIPTION
Backport of #1459 on release-0.16.

#1459: Fix nil interface{} checks

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.