### PR TITLE
Print kube context in dapper shell

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -24,6 +24,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # helm               | e2e tests
 # jq                 | JSON processing (GitHub API)
 # kind               | e2e tests
+# kube-ps1           | print out kube context in dapper shell
 # kubectl            | e2e tests (in kubernetes-client)
 # make               | OLM installation
 # moby-engine        | Docker (for Dapper)
@@ -69,6 +70,7 @@ RUN LINT_VERSION=$(awk '/golangci-lint/ { print $2 }' /tools.mod) && \
     BUILDX_VERSION=$(awk '/docker.buildx/ { print $2 }' /tools.mod) && \
     curl -L "https://github.com/docker/buildx/releases/download/${BUILDX_VERSION}/buildx-${BUILDX_VERSION}.linux-${ARCH}" -o /usr/local/libexec/docker/cli-plugins/docker-buildx && \
     chmod 755 /usr/local/libexec/docker/cli-plugins/docker-buildx && \
+    curl -L https://raw.githubusercontent.com/jonmosco/kube-ps1/1b8fe913b25ba857b84a94c3b1dbf7bb34f7caef/kube-ps1.sh -o /etc/profile.d/kube-ps1.sh && \
     find /go/bin /usr/local/libexec/docker/cli-plugins -type f -executable -newercc /proc -exec strip {} + && \
     find /go/bin /usr/local/libexec/docker/cli-plugins -type f -executable -newercc /proc \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
     go clean -cache -modcache && rm -f /tools.mod
@@ -78,6 +80,9 @@ RUN mkdir -p /root/.local/bin && ln -s $SCRIPTS_DIR/get-subctl.sh /root/.local/b
 
 # Copy kubecfg to always run on the shell
 COPY scripts/shared/lib/kubecfg /etc/profile.d/kubecfg.sh
+
+# Print kube context on interactive shell
+COPY scripts/shared/kubeps1.sh /etc/profile.d/
 
 # Copy shared files so that downstream projects can use them
 COPY Makefile.* .gitlint ${SHIPYARD_DIR}/

--- a/scripts/shared/kubeps1.sh
+++ b/scripts/shared/kubeps1.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+PS1='[\u@\h \W $(kube_ps1)]\$ '


### PR DESCRIPTION
Use `kube-ps1` to print out the current context inside the dapper shell (when running `make shell`).

This makes it easy to keep track of the current context and namespace, and avoid confusion.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
