### PR TITLE
Fix linting image build failure due to PEP 668

### DIFF
--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -29,7 +29,7 @@ ENV MARKDOWNLINT_VERSION=0.33.0 \
 RUN apk add --no-cache bash findutils git grep make nodejs py3-six shellcheck upx yamllint yq && \
     apk add --no-cache --virtual installers npm py3-pip && \
     npm install -g markdownlint-cli@${MARKDOWNLINT_VERSION} && \
-    pip install gitlint==${GITLINT_VERSION} && \
+    pip install --break-system-packages gitlint==${GITLINT_VERSION} && \
     find /usr/bin/ -type f -executable -newercc /proc -size +1M  \( -execdir upx {} \; -o -true \) && \
     find /usr/lib/ -name __pycache__ -type d -exec rm -rf {} + && \
     apk del installers


### PR DESCRIPTION
Pip had a check enabled that fails the install due to packages being managed by the OS.
The added flag ignores this check.

Otherwise, the build fails with:
```
11.85 × This environment is externally managed
11.85 ╰─>
11.85     The system-wide python installation should be maintained using the
11.85     system package manager (apk) only.
...
11.85 note: If you believe this is a mistake, please contact your Python
  installation or OS distribution provider. You can override this, at the risk
  of breaking your Python installation or OS, by passing
  --break-system-packages.
11.85 hint: See PEP 668 for the detailed specification.
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
