### PR TITLE
filter_dependabot: handle branches

### DIFF
--- a/scripts/shared/filter_dependabot.sh
+++ b/scripts/shared/filter_dependabot.sh
@@ -25,6 +25,9 @@
 # entries are removed). This tool assumes that all Submariner projects
 # are checked out alongside each other (i.e. ../shipyard contains
 # Shipyard, ../admiral contains Admiral etc.).
+#
+# By default, the default branch is processed; specify another branch
+# as argument to handle that instead.
 
 declare -a seendeps
 
@@ -41,33 +44,48 @@ function depseen() {
 base="$(pwd)"
 conffile="${base}/.github/dependabot.yml"
 
-for dir in $(yq '(.updates[] | select(.package-ecosystem == "gomod")).directory' "$conffile"); do
+branch="${1:-null}"
+
+gomodfilter=".updates[] | select(.package-ecosystem == \"gomod\")"
+
+for dir in $(yq "(${gomodfilter}).directory" "$conffile"); do
+
+    dirfilter="${gomodfilter} | select(.directory == \"${dir}\")"
+
+    # Looping over branch is pointless since dependencies need to track
+    # (i.e. other repos need to be in the same branch)
+
+    if [ "$branch" = "null" ]; then
+        branchfilter="${dirfilter} | select(has(\"target-branch\") | not)"
+    else
+        branchfilter="${dirfilter} | select(.target-branch == \"$branch\")"
+    fi
 
     (cd "${base}${dir}" || exit
 
      # Count the ignores
-     ignores="$(yq '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'") | .ignore | length' "$conffile")"
+     ignores="$(yq "(${branchfilter}).ignore | length" "$conffile")"
      firstauto=0
 
      # Look for the start of automated ignores
      for (( i=0; i < ignores; i++ )); do
-         if [ "$(yq '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'") | .ignore['"$i"'].dependency-name' "$conffile")" = "github.com/submariner-io/*" ]; then
+         if [ "$(yq "(${branchfilter}).ignore[$i].dependency-name" "$conffile")" = "github.com/submariner-io/*" ]; then
              firstauto=$i
              break
          fi
      done
 
      # Remove the existing automated ignores
-     while [ "$(yq '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'") | .ignore | length' "$conffile")" -gt "$firstauto" ]; do
-         yq -i -P 'del(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'") | .ignore['"$firstauto"'])' "$conffile"
+     while [ "$(yq "(${branchfilter}).ignore | length" "$conffile")" -gt "$firstauto" ]; do
+         yq -i -P "del(${branchfilter}.ignore[$firstauto])" "$conffile"
      done
 
      # "See" remaining ignores
-     read -ar seendeps < <(yq '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'") | .ignore[].dependency-name)' "$conffile")
+     read -ar seendeps < <(yq "(${branchfilter}).ignore[].dependency-name" "$conffile")
 
      # Restore the submariner-io exclusion
-     yq -i -P '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'")).ignore['"$firstauto"'].dependency-name = "github.com/submariner-io/*"' "$conffile"
-     yq -i -P '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'")).ignore['"$firstauto"'] head_comment = "Our own dependencies are handled during releases"' "$conffile"
+     yq -i -P "(${branchfilter}).ignore[$firstauto].dependency-name = \"github.com/submariner-io/*\"" "$conffile"
+     yq -i -P "(${branchfilter}).ignore[$firstauto] head_comment = \"Our own dependencies are handled during releases\"" "$conffile"
 
      # Ignore all parent dependencies
      for parent in $(GOWORK=off go list -m -mod=mod -json all | jq -r 'select(.Path | contains("/submariner-io/")) | select(.Main != true) .Path | gsub("github.com/submariner-io/"; "")'); do
@@ -75,9 +93,9 @@ for dir in $(yq '(.updates[] | select(.package-ecosystem == "gomod")).directory'
          for dep in $(GOWORK=off go list -m -mod=mod -json all | jq -r 'select(.Path | contains("/submariner-io") | not) | select(.Indirect != true) | select(.Main != true) .Path'); do
              if ! depseen "$dep"; then
                  if grep -q "$dep" "$base/../$parent/go.mod" && ! grep -q "$dep .*// indirect" "$base/../$parent/go.mod"; then
-                     yq -i -P '(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'")).ignore += { "dependency-name": "'"$dep"'" }' "$conffile"
+                     yq -i -P "(${branchfilter}).ignore += { \"dependency-name\": \"$dep\" }" "$conffile"
                      if $first; then
-                         yq -i -P 'with(.updates[] | select(.package-ecosystem == "gomod") | select(.directory == "'"$dir"'"); .ignore[.ignore | length - 1] head_comment = "Managed in '"$parent"'")' "$conffile"
+                         yq -i -P "with(${branchfilter}; .ignore[.ignore | length - 1] head_comment = \"Managed in $parent\")" "$conffile"
                          first=false
                      fi
                      seendeps+=("$dep")


### PR DESCRIPTION
dependabot configurations in the same directory across different branches break the filtering tool, since no distinction is made between branches. This fixes that by explicitly filtering either on the absence of a branch (by default), or using the target branch specified as the first argument to the script.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
