### PR TITLE
Update OVN Image and commit

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -44,7 +44,7 @@ ENV HOST_ARCH=${DAPPER_HOST_ARCH} ARCH=${DAPPER_HOST_ARCH} PATH=/go/bin:/root/.l
 # - Any unnecessary packages and executables
 RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
                    gcc git-core curl moby-engine make golang kubernetes-client \
-                   findutils moreutils upx jq gitlint procps-ng \
+                   findutils moreutils upx jq gitlint procps-ng pip\
                    qemu-user-static python3-jinja2-cli skopeo file unzip gh && \
     rpm -e --nodeps containerd && \
     rpm -qa "selinux*" | xargs -r rpm -e --nodeps && \

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -243,20 +243,16 @@ function provider_failed() {
 function prepare_ovn() {
     export OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
 
-    echo "Building ovn-kubernetes with interconnect (OVN-IC) from source"
-    echo "This will become unnecessary if OVN CI image publishing is fixed"
-    echo "https://github.com/ovn-org/ovn-kubernetes/actions/workflows/docker.yml"
     rm -rf ovn-kubernetes
     git clone https://github.com/ovn-org/ovn-kubernetes
     pushd ovn-kubernetes || exit
-    git checkout d462cf088c44ff501e5fcf746e9163193afa2dc4
 
-    make -C go-controller
+    # When updating commit, Update the OVN_SRC_IMAGE to the corressponding commit
+    git checkout 24b0ae73a996e409bfefad7b90cb42224e34be54
+    local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master@sha256:ba102783d520f0474e5c7dd5f2a0a1dce0ec2bda6cd42ac547621892e57c25e2"
 
-    cp go-controller/_output/go/bin/* dist/images
-
-    echo "ref: $(git rev-parse --symbolic-full-name HEAD) commit: $(git rev-parse HEAD)" > dist/images/git_info
-    docker build -t "${OVN_IMAGE}" -f dist/images/Dockerfile.fedora dist/images/
+    docker pull "${OVN_SRC_IMAGE}"
+    docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
     docker push "${OVN_IMAGE}"
 
     popd || exit


### PR DESCRIPTION
OVN now builds and pushes image with every commit. So changed to use OVN Image than buildng locally.

Added pip to shipyard-dapper-base as it is required for
kind.sh to set up the Jinja2 tools

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
