### PR TITLE
Automated backport of #1524: Drop Coastguard from GHAs

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [
-          'admiral', 'cloud-prepare', 'coastguard', 'lighthouse',
+          'admiral', 'cloud-prepare', 'lighthouse',
           'subctl', 'submariner', 'submariner-charts', 'submariner-operator'
         ]
     steps:
@@ -138,7 +138,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [
-          'admiral', 'cloud-prepare', 'coastguard', 'lighthouse',
+          'admiral', 'cloud-prepare', 'lighthouse',
           'subctl', 'submariner', 'submariner-charts', 'submariner-operator'
         ]
     steps:

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         project: [
-          'admiral', 'cloud-prepare', 'coastguard', 'lighthouse', 'shipyard',
+          'admiral', 'cloud-prepare', 'lighthouse', 'shipyard',
           'subctl', 'submariner-bot', 'submariner', 'submariner-operator'
         ]
     steps:


### PR DESCRIPTION
Backport of #1524 on release-0.16.

#1524: Drop Coastguard from GHAs

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.