### PR TITLE
Prevent parallel cleanup of kind clusters

### DIFF
--- a/scripts/shared/lib/cleanup_kind
+++ b/scripts/shared/lib/cleanup_kind
@@ -5,6 +5,10 @@
 function provider_initialize() {
     # shellcheck disable=SC2034
     readarray -t clusters < <(kind get clusters)
+
+    # kind cleanup uses a lock but doesn't retry
+    # shellcheck disable=SC2034
+    PARALLEL=false
 }
 
 function provider_delete_cluster() {


### PR DESCRIPTION
kind uses a lock file to protect kubeconfig when it updates it after stopping a cluster, but it fails if the lock file already exists. Avoid this by cleaning up serially.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
