### PR TITLE
Automated backport of #1223: Bump to Fedora 38

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,4 +1,4 @@
-FROM fedora:37
+FROM fedora:38
 
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.


### PR DESCRIPTION
Backport of #1223 on release-0.15.

#1223: Bump to Fedora 38

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.