### PR TITLE
Lint all Go modules

### DIFF
--- a/Makefile.linting
+++ b/Makefile.linting
@@ -20,7 +20,11 @@ golangci-lint:
 ifneq (,$(shell find . -name '*.go'))
 	golangci-lint version
 	golangci-lint linters
-	golangci-lint run --timeout 10m
+# Set up a workspace to include all modules
+	go work init
+	find . -name go.mod -execdir git grep -qFl 'func ' -- '*.go' \; -printf '%h ' | xargs go work use
+# Analyse all the modules containing function declarations
+	golangci-lint run --timeout 10m $$(find . -name go.mod -execdir git grep -qFl 'func ' -- '*.go' \; -printf '%h/...\n')
 else
 	@echo 'There are no Go files to lint.'
 endif


### PR DESCRIPTION
In projects with multiple modules, Shipyard's linting rule ends up ignoring all but the main module. To find all modules which need to be analysed, this looks for directories containing a file named go.mod and *.go files declaring functions.

Depends on https://github.com/submariner-io/lighthouse/pull/1505

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
