### PR TITLE
Automated backport of #1558: Bump actions/cache

### DIFF
--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}


### PR DESCRIPTION
Backport of #1558 on release-0.15.

#1558: Bump actions/cache

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.