### PR TITLE
Linting: handle existing workspaces

### DIFF
--- a/Makefile.linting
+++ b/Makefile.linting
@@ -20,9 +20,9 @@ golangci-lint:
 ifneq (,$(shell find . -name '*.go'))
 	golangci-lint version
 	golangci-lint linters
-# Set up a workspace to include all modules
-	go work init
-	find . -name go.mod -execdir git grep -qFl 'func ' -- '*.go' \; -printf '%h ' | xargs go work use
+# Set up a workspace to include all modules, if necessary
+# If a workspace is already set up, it will be used instead
+	find . -name go.mod -execdir git grep -qFl 'func ' -- '*.go' \; -printf '%h ' | xargs go work init ||:
 # Analyse all the modules containing function declarations
 	golangci-lint run --out-format=github-actions --timeout 10m $$(find . -name go.mod -execdir git grep -qFl 'func ' -- '*.go' \; -printf '%h/...\n')
 else


### PR DESCRIPTION
The linting target tries to create a workspace unconditionally; this fails if a workspace already exists. Ignore errors here so that existing workspaces can be used.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
