### PR TITLE
.dapper: don't require BuildKit (and buildx)

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -75,7 +75,7 @@ buildargs=(--build-arg "ORG=${ORG}" --build-arg "PROJECT=${PROJECT}")
 gitid="$(git symbolic-ref --short HEAD 2>/dev/null | tr / _ || :)"
 gitid="${gitid:-$(git show --format=%h -s)}"
 container="$(basename "$(pwd)"):${gitid}"
-DOCKER_BUILDKIT=1 docker build -t "${container}" -f "${file}" "${buildargs[@]}" .
+docker build -t "${container}" -f "${file}" "${buildargs[@]}" .
 
 extract_var() {
     docker inspect "$1" | grep "$2" | sed -E "s/.*\"$2=(.*)\",?/\1/;q"


### PR DESCRIPTION
Building the .dapper-targeted container image doesn't require BuildKit and buildx; this allows "make clusters" etc. to work on setups without buildx.

Fixes: https://github.com/submariner-io/submariner-operator/issues/3093

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
