### PR TITLE
Add support for Kind IPV6 clusters deployment

### DIFF
--- a/Makefile.clusters
+++ b/Makefile.clusters
@@ -14,7 +14,7 @@ K8S_VERSION ?= 1.31
 METALLB_VERSION ?= 0.13.5
 OLM_VERSION ?= v0.18.3
 PROVIDER ?= kind
-export AIR_GAPPED DUAL_STACK K8S_VERSION LOAD_BALANCER METALLB_VERSION OLM OLM_VERSION OVERLAPPING PROMETHEUS PROVIDER
+export AIR_GAPPED DUAL_STACK IPV6_STACK K8S_VERSION LOAD_BALANCER METALLB_VERSION OLM OLM_VERSION OVERLAPPING PROMETHEUS PROVIDER
 
 ### PROCESSING `using=` ###
 
@@ -36,6 +36,10 @@ endif
 
 ifneq (,$(filter dual-stack,$(_using)))
 DUAL_STACK = true
+endif
+
+ifneq (,$(filter ipv6-stack,$(_using)))
+IPV6_STACK = true
 endif
 
 ifneq (,$(filter overlapping,$(_using)))

--- a/Makefile.shipyard
+++ b/Makefile.shipyard
@@ -44,7 +44,7 @@ endif
 USING = $(subst $(,), ,$(using))
 _using = ${USING}
 
-ifneq (,$(filter dual-stack,$(_using)))
+ifneq (,$(filter dual-stack ipv6-stack,$(_using)))
 IPV6_FLAGS = --ipv6 --subnet fc00:1234:4444::/64
 endif
 

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -43,10 +43,13 @@ function generate_cluster_yaml() {
     local config_file
     config_file="${RESOURCES_DIR}/${cluster}-config.yaml"
 
-    if [[ "$DUAL_STACK" ]]; then
+    if [[ "$DUAL_STACK" || "$IPV6_STACK" ]]; then
         service_cidr_ipv6="${service_IPv6_CIDRs[${cluster}]}"
         pod_cidr_ipv6="${cluster_IPv6_CIDRs[${cluster}]}"
         render_template "${RESOURCES_DIR}/kind-cluster-dual-stack-config.yaml" > "$config_file"
+        if [[ "$IPV6_STACK" ]]; then
+            render_template "${RESOURCES_DIR}/kind-cluster-ipv6-stack-config.yaml" > "$config_file"
+        fi
     else
         render_template "${RESOURCES_DIR}/kind-cluster-config.yaml" > "$config_file"
     fi
@@ -58,9 +61,14 @@ function generate_cluster_yaml() {
 }
 
 function kind_fixup_config() {
-    local master_ip
-    master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}-control-plane" | head -n 1)
-    yq -i ".clusters[0].cluster.server = \"https://${master_ip}:6443\"" "${KUBECONFIG}"
+    local master_ip master_ipv6
+    if [[ "$IPV6_STACK" ]]; then
+       master_ipv6=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.GlobalIPv6Address}}{{end}}' "${cluster}-control-plane" | head -n 1)
+       yq -i ".clusters[0].cluster.server = \"https://[${master_ipv6}]:6443\"" "${KUBECONFIG}"
+    else
+       master_ip=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${cluster}-control-plane" | head -n 1)
+       yq -i ".clusters[0].cluster.server = \"https://${master_ip}:6443\"" "${KUBECONFIG}"
+    fi
     yq -i "(.. | select(. == \"kind-${cluster}\")) = \"${cluster}\"" "${KUBECONFIG}"
     chmod a+r "${KUBECONFIG}"
 }

--- a/scripts/shared/resources/kind-cluster-ipv6-stack-config.yaml
+++ b/scripts/shared/resources/kind-cluster-ipv6-stack-config.yaml
@@ -1,0 +1,23 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: ${disable_cni}
+  podSubnet: ${pod_cidr_ipv6}
+  serviceSubnet: ${service_cidr_ipv6}
+  ipFamily: ipv6
+containerdConfigPatches:
+  - |-
+    [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"localhost:5000\"]
+      endpoint = [\"http://kind-registry:5000\"]
+kubeadmConfigPatches:
+  - |
+    apiVersion: kubeadm.k8s.io/v1beta2
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    networking:
+      podSubnet: ${pod_cidr_ipv6}
+      serviceSubnet: ${service_cidr_ipv6}
+      dnsDomain: ${dns_domain}
+nodes: ${nodes}


### PR DESCRIPTION
Run 'make clusters using=ipv6-stack' to deploy IPV6 Kind clusters.
This capability will be useful for verifying Submariner's IPv6 support.

