### PR TITLE
Check unmerged commits in dependencies

### DIFF
--- a/scripts/shared/check-non-release-versions.sh
+++ b/scripts/shared/check-non-release-versions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf $tmpdir' EXIT
+
+# List all submariner-io dependencies with a - in their version
+# We're looking for versions pointing to commits, of the form
+# vX.Y.Z-0.YYYYMMDDhhmmss-hash
+failed=0
+shopt -s lastpipe
+GOWORK=off go list -m -mod=mod -json all |
+    jq -r 'select(.Path | contains("/submariner-io/")) | select(.Main != true) | select(.Version | contains ("-")) | select(.Version | length > 14) | "\(.Path) \(.Version)"' |
+    while read -r project version; do
+        cd "$tmpdir" || exit 1
+        git clone "https://$project"
+        cd "${project##*/}" || exit 1
+        hash="${version##*-}"
+        branch="${GITHUB_BASE_REF:-devel}"
+        if ! git merge-base --is-ancestor "$hash" "origin/$branch"; then
+            printf "This project depends on %s %s\n" "$project" "$version"
+            printf "but %s branch %s does not contain commit %s\n" "$project" "$branch" "$hash"
+            failed=1
+        fi
+    done
+
+exit $failed


### PR DESCRIPTION
This adds a script which examines submariner-io dependencies with versions referencing untagged git commits, that is to say commits which haven't been released. It ensures that any such dependencies point to a commit in the relevant branch, to avoid merging PRs with pointers to unmerged commits. Since the project rebases on PR merge, the commit hashes change, and dependent PRs can end up being merged with a reference to an in-development commit; that can break local builds.

Since Shipyard doesn't have any submariner-io dependencies, this isn't integrated into CI yet; it will be used in other Submariner projects.

See https://github.com/submariner-io/submariner-operator/pull/3237 for a check involving this (and correctly failing).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
