### PR TITLE
Switch to Fedora for nettest and use packaged netperf

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -1,32 +1,20 @@
-FROM alpine
+ARG FEDORA_VERSION=41
 
-WORKDIR /app
+FROM --platform=${BUILDPLATFORM} fedora:${FEDORA_VERSION} AS base
+ARG FEDORA_VERSION
+ARG TARGETPLATFORM
 
-RUN apk add --update --no-cache gcc libc-dev make git automake autoconf
+COPY scripts/shared/dnf_install /
 
-RUN git clone --depth 1 https://github.com/HewlettPackard/netperf \
-    && git -C netperf reset --hard 3bc455b23f901dae377ca0a558e1e32aa56b31c4
-RUN cd netperf \
-    && ./autogen.sh \
-    && ./configure CFLAGS=-fcommon \
-    && make -C src && make -C src install
+RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
+    glibc bash glibc-minimal-langpack coreutils-single libcurl-minimal \
+    bind-utils curl-minimal iperf3 iputils netperf nmap-ncat tcpdump
 
+FROM scratch
+ARG TARGETPLATFORM
 
-FROM alpine
+COPY --from=base /output/nettest /
 
-WORKDIR /app
-
-ARG VERSION
-
-RUN apk add --no-cache \
-	bash \
-	bind-tools \
-	curl \
-	iputils \
-	iperf3 \
-	tcpdump
-
-COPY --from=0 /usr/local/bin/net* /usr/local/bin/
 COPY scripts/nettest/* /app/
 
 RUN echo ${VERSION} >> /app/version

--- a/scripts/nettest/metricsproxy
+++ b/scripts/nettest/metricsproxy
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Arguments: source-port target-IP target-port
-exec /usr/bin/nc -v -lk -p "$1" -e nc "$2" "$3"
+exec /usr/bin/ncat -v -lk -p "$1" -c "/usr/bin/ncat $2 $3"

--- a/scripts/nettest/nc
+++ b/scripts/nettest/nc
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This wrapper converts Busybox syntax to nmap ncat:
+# * -e becomes -c
+# * -w and -i need a s suffix on their argument
+# * with -l, -p XX and -s YY become YY XX
+
+args=()
+listening=
+sourceport=
+sourceaddress=
+while [ -n "$1" ] && [ "$1" != "-e" ]; do
+    case "$1" in
+        -w|-i)
+            args+=("$1" "$2"s)
+            shift 2;;
+        -l|-lk)
+            listening=1
+            args+=("$1")
+            shift;;
+        -p)
+            sourceport="$2"
+            shift 2;;
+        -s)
+            sourceaddress="$2"
+            shift 2;;
+        *)
+            args+=("$1")
+            shift;;
+    esac
+done
+
+if [ -n "$listening" ]; then
+    args+=(-l ${sourceaddress:+"$sourceaddress"} ${sourceport:+"$sourceport"})
+else
+    if [ -n "$sourceaddress" ]; then
+        args+=(-s "$sourceaddress")
+    fi
+    if [ -n "$sourceport" ]; then
+        args+=(-p "$sourceport")
+    fi
+fi
+
+cmd=""
+if [ "$1" = "-e" ]; then
+    shift
+    cmd="$*"
+fi
+
+exec /usr/bin/ncat "${args[@]}" ${cmd:+"-c $cmd"}

--- a/scripts/nettest/simpleserver
+++ b/scripts/nettest/simpleserver
@@ -3,5 +3,5 @@ set -e
 
 while true
 do
-    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | nc -l -p 8080
+    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | /usr/bin/ncat -l 8080
 done

--- a/scripts/shared/dnf_install
+++ b/scripts/shared/dnf_install
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Installs packages using dnf to a named root:
+# -a arch - use arch instead of the native arch
+# -k      - keep the package cache
+# -r root - install to the named root instead of /output/base
+# -v ver  - use the given Fedora version (required)
+#
+# %arch in the package references will be replaced with the chosen arch
+
+set -e
+
+INSTALL_ROOT=/output/base
+
+# Limit the number of files so that dnf doesn't spend ages processing fds
+if [[ $(ulimit -n) -gt 1048576 ]]; then
+    ulimit -n 1048576
+fi
+
+while getopts a:kr:v: o
+do
+    case "$o" in
+    a)
+        ARCH="$OPTARG"
+        ;;
+    k)
+        KEEP_CACHE=true
+        ;;
+    r)
+        INSTALL_ROOT="$OPTARG"
+        ;;
+    v)
+        FEDORA_VERSION="$OPTARG"
+        ;;
+    *)
+        echo "$0 doesn't support $o" >&2
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+arch_args=()
+
+if [[ -n "${ARCH}" ]]; then
+    # Convert container arch to Fedora arch
+    ARCH="${ARCH##*/}"
+    case "${ARCH}" in
+        amd64) ARCH=x86_64;;
+        arm64) ARCH=aarch64;;
+    esac
+    arch_args=(--forcearch "${ARCH}")
+else
+    # This will be used later, but we won't force
+    ARCH="$(rpm -q --qf "%{arch}" rpm)"
+fi
+
+[[ -z "${FEDORA_VERSION}" ]] && echo I need to know which version of Fedora to install, specify it with -v >&2 && exit 1
+
+if [[ "${INSTALL_ROOT}" != /output/base ]] && [[ ! -d "${INSTALL_ROOT}" ]] && [[ -d /output/base ]]; then
+    cp -a /output/base "${INSTALL_ROOT}"
+fi
+
+dnf -y --setopt=install_weak_deps=0 --nodocs --use-host-config "${arch_args[@]}" \
+    --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" \
+    install "${@//\%arch/${ARCH}}"
+
+[[ "${KEEP_CACHE}" == true ]] || dnf -y "${arch_args[@]}" --installroot "${INSTALL_ROOT}" --releasever "${FEDORA_VERSION}" clean all


### PR DESCRIPTION
netperf currently fails to build with the latest Alpine images, even with _GNU_SOURCE fixes.

To allow building the nettest image again, this switches to Fedora, where netperf is available as a package (so we don't need to deal with building it). The image size is more than doubled, from 24.2MiB with Alpine to 59.8MiB with Fedora.

This ends up with nmap ncat rather than busybox ncat, so the nettest scripts are adjusted to suit, and a busybox nc emulation script is included for other users of nc.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
