### PR TITLE
nettest: add iproute

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -8,7 +8,7 @@ COPY scripts/shared/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
     glibc bash glibc-minimal-langpack coreutils-single libcurl-minimal \
-    bind-utils curl-minimal iperf3 iputils netperf nmap-ncat tcpdump
+    bind-utils curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
 
 FROM scratch
 ARG TARGETPLATFORM


### PR DESCRIPTION
This is required notably for subctl diagnose kube-proxy-mode (which relies on the ip command).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
