### PR TITLE
nettest: pass VERSION as an argument

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -1,6 +1,7 @@
 ARG FEDORA_VERSION=41
 
 FROM --platform=${BUILDPLATFORM} fedora:${FEDORA_VERSION} AS base
+ARG VERSION
 ARG FEDORA_VERSION
 ARG TARGETPLATFORM
 
@@ -12,6 +13,7 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
 
 FROM scratch
 ARG TARGETPLATFORM
+ARG VERSION
 ENV PATH="/app:$PATH"
 
 COPY --from=base /output/nettest /


### PR DESCRIPTION
This ensures that it is available when writing /app/version. Without that, /app/version is empty and subctl show versions can't show the corresponding version information.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
