### PR TITLE
Automated backport of #1793: nettest: add iproute

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -1,6 +1,7 @@
 ARG FEDORA_VERSION=41
 
 FROM --platform=${BUILDPLATFORM} fedora:${FEDORA_VERSION} AS base
+ARG VERSION
 ARG FEDORA_VERSION
 ARG TARGETPLATFORM
 
@@ -12,6 +13,7 @@ RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
 
 FROM scratch
 ARG TARGETPLATFORM
+ARG VERSION
 ENV PATH="/app:$PATH"
 
 COPY --from=base /output/nettest /

--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -9,7 +9,7 @@ COPY scripts/shared/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
     glibc bash glibc-minimal-langpack coreutils-single libcurl-minimal \
-    bind-utils curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
+    bind-utils busybox curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
 
 FROM scratch
 ARG TARGETPLATFORM

--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -8,7 +8,7 @@ COPY scripts/shared/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
     glibc bash glibc-minimal-langpack coreutils-single libcurl-minimal \
-    bind-utils curl-minimal iperf3 iputils netperf nmap-ncat tcpdump
+    bind-utils curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
 
 FROM scratch
 ARG TARGETPLATFORM

--- a/scripts/nettest/metricsproxy
+++ b/scripts/nettest/metricsproxy
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Arguments: source-port target-IP target-port
-exec /usr/bin/ncat -v -lk -p "$1" -c "/usr/bin/ncat $2 $3"
+exec /usr/sbin/busybox nc -v -lk -p "$1" -e /usr/sbin/busybox nc "$2" "$3"


### PR DESCRIPTION
Backport of #1793 on release-0.19.

#1793: nettest: add iproute

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.