### PR TITLE
Revert to busybox nc for metricsproxy

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -9,7 +9,7 @@ COPY scripts/shared/dnf_install /
 
 RUN /dnf_install -a ${TARGETPLATFORM} -v ${FEDORA_VERSION} -r /output/nettest \
     glibc bash glibc-minimal-langpack coreutils-single libcurl-minimal \
-    bind-utils curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
+    bind-utils busybox curl-minimal iperf3 iproute iputils netperf nmap-ncat tcpdump
 
 FROM scratch
 ARG TARGETPLATFORM

--- a/scripts/nettest/metricsproxy
+++ b/scripts/nettest/metricsproxy
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Arguments: source-port target-IP target-port
-exec /usr/bin/ncat -v -lk -p "$1" -c "/usr/bin/ncat $2 $3"
+exec /usr/sbin/busybox nc -v -lk -p "$1" -e /usr/sbin/busybox nc "$2" "$3"


### PR DESCRIPTION
nmap-ncat is causing issues in metricsproxy with globalnet:

Ncat: Version 7.92 ( https://nmap.org/ncat )
Ncat: Listening on :::8081
Ncat: Listening on 0.0.0.0:8081
Ncat: Connection from 10.129.0.19.
Ncat: Connection from 10.129.0.19:45064.
Ncat: assertion failed: count <= INT_MAX QUITTING.

It's not clear how to fix that, so this installs busybox and reverts to busybox nc instead. To avoid having too many changes in nettest, nmap-ncat is preserved for other uses.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
