### PR TITLE
Check the deployed version of local components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 BASE_BRANCH ?= devel
 OCM_BASE_BRANCH ?= main
 IMAGES ?= shipyard-dapper-base shipyard-linting nettest
+LOCAL_COMPONENTS := submariner-metrics-proxy
 MULTIARCH_IMAGES ?= $(IMAGES)
 EXTRA_PRELOAD_IMAGES := $(PRELOAD_IMAGES)
 PLATFORMS ?= linux/amd64,linux/arm64
 NON_DAPPER_GOALS += images multiarch-images
 PLUGIN ?=
+
+export LOCAL_COMPONENTS
 
 export BASE_BRANCH OCM_BASE_BRANCH
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -191,7 +191,7 @@ upgrade-e2e: deploy-latest deploy e2e
 # This uses make deploy, but forcefully ignores images so that images
 # are *not* rebuilt (we want to deploy the published images only)
 deploy-latest:
-	$(MAKE) -o images -o preload-images deploy SUBCTL_VERSION=latest IMAGE_TAG=subctl using=$(using)
+	$(MAKE) -o images -o preload-images deploy SUBCTL_VERSION=latest IMAGE_TAG=subctl LOCAL_COMPONENTS= using=$(using)
 
 ##### MISC TARGETS #####
 .PHONY: backport post-mortem unit

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -175,7 +175,8 @@ subctl show versions
 print_clusters_message
 
 # If there are any local components, check that the deployed versions are the newly-built versions
-if [ -n "$LOCAL_COMPONENTS" ]; then
+# This is known to fail with Helm so ignore that
+if [[ -n "$LOCAL_COMPONENTS" && "$DEPLOYTOOL" != helm ]]; then
     for component in $LOCAL_COMPONENTS; do
         for version in $(subctl show versions | awk "/$component/ { print \$4 }"); do
             # shellcheck disable=SC2153 # VERSION is provided externally

--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -173,3 +173,16 @@ run_if_defined post_deploy
 # Print installed versions for manual validation of CI
 subctl show versions
 print_clusters_message
+
+# If there are any local components, check that the deployed versions are the newly-built versions
+if [ -n "$LOCAL_COMPONENTS" ]; then
+    for component in $LOCAL_COMPONENTS; do
+        for version in $(subctl show versions | awk "/$component/ { print \$4 }"); do
+            # shellcheck disable=SC2153 # VERSION is provided externally
+            if [ "$version" != "$VERSION" ]; then
+                printf "Expected version %s of component %s, but got %s.\n" "$VERSION" "$component" "$version"
+                exit 1
+            fi
+        done
+    done
+fi


### PR DESCRIPTION
In projects building deployed components, declaring LOCAL_COMPONENTS allows deploy.sh to check that the deployed version used in tests matches the expected version.

Fixes: #479

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
