### PR TITLE
Bump custom GHA actions/cache from 4.0.2 to 4.2.0

### DIFF
--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}


### PR DESCRIPTION
The actions/cache package is deprecating versions older than v4. While the SHA we pin to is actually after the deprecation range, the release notes indicate that usages with pinned SHAs need to update to 4.2.0.

https://github.com/actions/cache/releases/tag/v4.2.0

This will fix a warning that is currently occurring across the org.

> Your workflow is using a version of actions/cache that is scheduled
for deprecation, actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions.

https://github.com/submariner-io/submariner-operator/actions/runs/12959809332

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
