### PR TITLE
Stop cloning ovn-k in prepare_ovn

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -268,20 +268,11 @@ function provider_failed() {
 
 function prepare_ovn() {
     export OVN_IMAGE="localhost:5000/ovn-daemonset-f:latest"
-
-    rm -rf ovn-kubernetes
-    git clone https://github.com/ovn-org/ovn-kubernetes
-    pushd ovn-kubernetes || exit
-
-    # When updating commit, Update the OVN_SRC_IMAGE to the corressponding commit
-    git checkout 24b0ae73a996e409bfefad7b90cb42224e34be54
     local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master@sha256:ba102783d520f0474e5c7dd5f2a0a1dce0ec2bda6cd42ac547621892e57c25e2"
 
     docker pull "${OVN_SRC_IMAGE}"
     docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"
     docker push "${OVN_IMAGE}"
-
-    popd || exit
 }
 
 function provider_prepare() {


### PR DESCRIPTION
The function no longer does anything with the cloned repository.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
