### PR TITLE
Automated backport of #1814: Bump upload-artifact in the post-mortem GHA

### DIFF
--- a/gh-actions/post-mortem/action.yaml
+++ b/gh-actions/post-mortem/action.yaml
@@ -19,7 +19,7 @@ runs:
         make post-mortem
         echo "::endgroup::"
 
-    - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
       with:
         name: submariner-gather
         path: gather_output


### PR DESCRIPTION
Backport of #1814 on release-0.18.

#1814: Bump upload-artifact in the post-mortem GHA

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.