### PR TITLE
Adjust golangci-lint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,30 +39,43 @@ linters-settings:
 linters:
   disable-all: true
   enable:
+    - asasalint
     - asciicheck
     - bidichk
     - bodyclose
+    # - canonicalheader # This is a slow linter and we don't use the net/http.Header API
+    - containedctx
     - contextcheck
     - copyloopvar
     # - cyclop # This is equivalent to gocyclo
+    - decorder
     # - depguard # depguard now denies by default, it should only be enabled if we actually use it
     - dogsled
     - dupl
+    - dupword
     - durationcheck
     - err113
     - errcheck
+    - errchkjson
+    - errorlint
     - errname
     - errorlint
+    # - execinquery # No SQL
     - exhaustive
-    # - exhaustivestruct # Not recommended for general use - meant to be used only for special cases
+    - exptostd
+    # - exhaustruct # This is too cumbersome as it requires all string, int, pointer et al fields to be initialized even when the
+    # type's default suffices, which is most of the time
+    - fatcontext
     # - forbidigo # We don't forbid any statements
     # - forcetypeassert # There are many unchecked type assertions that would be the result of a programming error so the
     #                     reasonable recourse would be to panic anyway if checked so this doesn't seem useful
     # - funlen # gocyclo is enabled which is generally a better metric than simply LOC.
     - gci
     - ginkgolinter
+    - gocheckcompilerdirectives
     # - gochecknoglobals # We don't want to forbid global variable constants
     # - gochecknoinits # We use init functions for valid reasons
+    # - gochecksumtype # The usefulness is very narrow
     - gocognit
     - goconst
     - gocritic
@@ -73,42 +86,58 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    # - gomnd # It doesn't seem useful in general to enforce constants for all numeric values
     - gomoddirectives
     # - gomodguard # We don't block any modules
     # - goprintffuncname # This doesn't seem useful at all
     - gosec
     - gosimple
-    - gosmopolitan
+    # - gosmopolitan # This is related to internationalization which is not a concern for us
     - govet
-    # - ifshort # This is a style preference and doesn't seem compelling
+    - grouper
+    - iface
     - importas
+    - inamedparam
     - ineffassign
+    # - interfacebloat # We track complexity elsewhere
+    - intrange
     # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
     #             an interface to avoid exposing the entire underlying struct
     - lll
+    - loggercheck
+    - maintidx
     - makezero
     - mirror
     - misspell
+    # - mnd # It doesn't seem useful in general to enforce constants for all numeric values
     - nakedret
     # - nestif # This calculates cognitive complexity but we're doing that elsewhere
     - nilerr
+    - nilnesserr
     - nilnil
     # - nlreturn # This is reasonable with a block-size of 2 but setting it above isn't honored
     # - noctx # We don't send HTTP requests
     - nolintlint
+    - nonamedreturns
+    # - nosprintfhostport # The use of this is very narrow
     # - paralleltest # Not relevant for Ginkgo UTs
+    - perfsprint
     - prealloc
     - predeclared
     - promlinter
+    - reassign
+    - recvcheck
     - revive
     # - rowserrcheck # We don't use SQL
+    # - sloglint # We don't use log/slog
+    # - spancheck # We don't use OpenTelemetry/OpenCensus
     # - sqlclosecheck # We don't use SQL
     - staticcheck
     - stylecheck
     - tagalign
     # - tagliatelle # Inconsistent with stylecheck and not as good
     # - tenv # Not relevant for our Ginkgo UTs
+    # - testableexamples # We don't need this
+    # - testifylint # We don't use testify
     - testpackage
     # - thelper # Not relevant for our Ginkgo UTs
     # - tparallel # Not relevant for our Ginkgo UTs
@@ -116,12 +145,14 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
+    - usetesting
     # - varnamelen # It doesn't seem necessary to enforce a minimum variable name length
     - wastedassign
     - whitespace
     - wrapcheck
     - wsl
-    - zerologlint
+    # - zerologlint # We use zerolog indirectly so this isn't needed
 issues:
   exclude-rules:
     # Allow dot-imports for Gomega BDD directives per idiomatic Gomega

--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -43,7 +43,7 @@ func (f *Framework) AwaitClusterGlobalEgressIPs(cluster ClusterIndex, name strin
 }
 
 func AwaitAllocatedEgressIPs(client dynamic.ResourceInterface, name string) []string {
-	obj := AwaitUntil(fmt.Sprintf("await allocated egress IPs for %s", name),
+	obj := AwaitUntil("await allocated egress IPs for "+name,
 		func() (interface{}, error) {
 			resGip, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {

--- a/test/e2e/framework/ginkgowrapper/wrapper.go
+++ b/test/e2e/framework/ginkgowrapper/wrapper.go
@@ -136,7 +136,7 @@ func pruneStack(skip int) string {
 	var prunedStack []string
 
 	// skip the top of the stack
-	for i := 0; i < 2*skip+1; i++ {
+	for range 2*skip + 1 {
 		scanner.Scan()
 	}
 

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -325,7 +325,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 					Command: []string{
 						"sh",
 						"-c",
-						"for in in $(seq 1 $BUFS_NUM);" +
+						"for i in $(seq $BUFS_NUM);" +
 							" do echo [dataplane] connector says $SEND_STRING; done" +
 							" | for i in $(seq $CONN_TRIES);" +
 							" do if nc -v $REMOTE_IP $REMOTE_PORT -w $CONN_TIMEOUT;" +

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -63,7 +63,7 @@ func (f *Framework) NewService(name, portName string, port int32, protocol corev
 }
 
 func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, port int32) *corev1.Service {
-	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
+	tcpService := f.NewService("test-svc-"+selectorName, "tcp", port, corev1.ProtocolTCP,
 		map[string]string{TestAppLabel: selectorName}, false)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
@@ -71,7 +71,7 @@ func (f *Framework) CreateTCPService(cluster ClusterIndex, selectorName string, 
 }
 
 func (f *Framework) CreateHeadlessTCPService(cluster ClusterIndex, selectorName string, port int32) *corev1.Service {
-	tcpService := f.NewService(fmt.Sprintf("test-svc-%s", selectorName), "tcp", port, corev1.ProtocolTCP,
+	tcpService := f.NewService("test-svc"+selectorName, "tcp", port, corev1.ProtocolTCP,
 		map[string]string{TestAppLabel: selectorName}, true)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 


### PR DESCRIPTION
Added new linters (some commented out if not needed) and removed deprecated linters. Also addressed violations reported by new linters (in separate commits).

Related to https://github.com/submariner-io/enhancements/issues/231
