### PR TITLE
Create configmap to control Submariner packetfilter driver

### DIFF
--- a/scripts/shared/deploy.sh
+++ b/scripts/shared/deploy.sh
@@ -136,6 +136,18 @@ function schedule_dummy_pod() {
     deploy_resource "${RESOURCES_DIR}"/dummypod.yaml "$ns"
 }
 
+function deploy_subm_global_cm() {
+    local ns="submariner-operator"
+    source "${SCRIPTS_DIR}"/lib/deploy_funcs
+
+    echo "Creating the ${ns} namespace..."
+    kubectl create namespace "${ns}" || :
+    echo Setting up submariner global configmap...
+    NFTABLES="${NFTABLES:-false}"
+    deploy_resource "${RESOURCES_DIR}"/sm-global-cm.yaml "$ns"
+}
+
+
 ### Main ###
 
 load_settings
@@ -153,7 +165,7 @@ declare_kubeconfig
 load_library deploy DEPLOYTOOL
 deploytool_prereqs
 [[ "$PROVIDER" != kind ]] || run_all_clusters schedule_dummy_pod
-
+run_all_clusters deploy_subm_global_cm
 run_if_defined pre_deploy
 
 with_context "$broker" setup_broker

--- a/scripts/shared/resources/sm-global-cm.yaml
+++ b/scripts/shared/resources/sm-global-cm.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+data:
+  use-nftables: \"${NFTABLES}\"
+kind: ConfigMap
+metadata:
+  name: submariner-global
+  namespace: ${ns}


### PR DESCRIPTION
We want to start testing Submariner with nftables, to do so we need to change RouteAgent and GlobalNet to dynamically configure the required packet filter driver (iptables or nftables), as it is currently hardcoded into iptables.

This PR creates a configmap with the desired use-nftables value.

