### PR TITLE
Automated backport of #1828: Bump custom GHA actions/cache from 4.0.2 to 4.2.0

### DIFF
--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}


### PR DESCRIPTION
Backport of #1828 on release-0.19.

#1828: Bump custom GHA actions/cache from 4.0.2 to 4.2.0

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.