### PR TITLE
Automated backport of #1225: Don't fail when restoring images if there are none
#1828: Bump custom GHA actions/cache from 4.0.2 to 4.2.0

### DIFF
--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -11,7 +11,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -25,4 +25,6 @@ runs:
       shell: bash
       run: |
         for archive in ${{ inputs.cache }}/*.tar*; do docker load -i $archive; done
-        cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/
+        if [ -d ${{ inputs.working-directory }}/package ]; then \
+          cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/; \
+        fi

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -15,7 +15,7 @@ runs:
   steps:
     - name: Set up the cache
       id: image-cache
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57
       with:
         path: ${{ inputs.cache }}
         key: image-cache-${{ github.sha }}


### PR DESCRIPTION
Backport of #1225 #1828 on release-0.15.

#1225: Don't fail when restoring images if there are none
#1828: Bump custom GHA actions/cache from 4.0.2 to 4.2.0

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.