### PR TITLE
Add IPFamily support to ConnectivityTestParams

### DIFF
--- a/test/e2e/dataplane/tcp_connectivity.go
+++ b/test/e2e/dataplane/tcp_connectivity.go
@@ -30,7 +30,7 @@ var _ = Describe("[dataplane] Basic TCP connectivity test", func() {
 
 	When("a pod connects to another pod via TCP in the same cluster", func() {
 		It("should send the expected data to the other pod", func() {
-			tcp.RunConnectivityTest(tcp.ConnectivityTestParams{
+			tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        tcp.PodIP,
 				Networking:            framework.HostNetworking,


### PR DESCRIPTION
This PR adds IPFamily field to ConnectivityTestParams struct to support specifying IP protocol family (IPv4 or IPv6) for connectivity tests.

Defaults to IPv4 if unset.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
