### PR TITLE
Ignore buildx CVE that requires K8s major bump

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -18,3 +18,8 @@ ignore:
   - vulnerability: GHSA-5xqw-8hwv-wg92
     package:
       name: helm.sh/helm/v3
+  # Update requires K8s major version update. Low severity doesn't justify an update for stable branches.
+  # https://github.com/submariner-io/shipyard/pull/1943#discussion_r2064226633
+  - vulnerability: GHSA-m4gq-fm9h-8q75
+    package:
+      name: github.com/docker/buildx


### PR DESCRIPTION
Updating buildx to get the fix also requires updating significant dependencies, like K8s, across major version boundaries. We shouldn't do this on older, stable release branches.

This is CVE-2025-0495.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
