### PR TITLE
Ignore Helm CVEs that require K8s major bump

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,11 @@ ignore:
   - vulnerability: CVE-2021-22570
     package:
       name: google.golang.org/protobuf
+  # Update requires K8s major version update. Low severity doesn't justify an update for stable branches.
+  # https://github.com/submariner-io/shipyard/pull/1932#issuecomment-2830451046
+  - vulnerability: GHSA-4hfp-h4cw-hj8p
+    package:
+      name: helm.sh/helm/v3
+  - vulnerability: GHSA-5xqw-8hwv-wg92
+    package:
+      name: helm.sh/helm/v3


### PR DESCRIPTION
Updating Helm to get the fix also requires updating significant dependencies, like K8s, across major version boundaries. We shouldn't do this on older, stable release branches.

These are CVE-2025-32386 and CVE-2025-32387.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
