### PR TITLE
Don't overlap IPv6 CIDRs on deployment

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -121,6 +121,8 @@ jobs:
           - extra-toggles: 'air-gap, lighthouse'
           - extra-toggles: 'air-gap, ovn'
           - extra-toggles: dual-stack
+          - extra-toggles: dual-stack
+            globalnet: globalnet
           - extra-toggles: ipv6-stack
           - extra-toggles: ovn
           - extra-toggles: ovn-ic

--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -168,13 +168,13 @@ function set_cluster_cidrs() {
     local val=$1
     local idx=$2
 
+    cluster_IPv6_CIDRs[$idx]="fc00:$((val+1000))::/48"
+    service_IPv6_CIDRs[$idx]="fc00:$((val+2000))::/112"
+
     [[ "$OVERLAPPING" != "true" ]] || val="0"
 
     cluster_CIDRs[$idx]="10.$((val+129)).0.0/16"
     service_CIDRs[$idx]="100.$((val+65)).0.0/16"
-
-    cluster_IPv6_CIDRs[$idx]="fc00:$((val+1000))::/48"
-    service_IPv6_CIDRs[$idx]="fc00:$((val+2000))::/112"
 }
 
 function declare_cidrs() {


### PR DESCRIPTION
...as Globalnet is not implemented for IPv6.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
