### PR TITLE
Configure IPv6 addresses for kind OVNK

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -199,12 +199,32 @@ EOF
 
 function deploy_kind_ovn(){
     export K8S_VERSION
-    export NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
-    export SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
+    export SVC_CIDR_IPV4
+    export NET_CIDR_IPV4
+    export SVC_CIDR_IPV6
+    export NET_CIDR_IPV6
     export KIND_CLUSTER_NAME="${cluster}"
 
     local ovn_flags=()
     [[ "$OVN_IC" != true ]] || ovn_flags=( -ic -npz 1 -wk 3 )
+
+    if [[ "$IPV6_STACK" ]]; then
+        ovn_flags+=( -n4 -i6 -sw)
+        SVC_CIDR_IPV6="${service_IPv6_CIDRs[${cluster}]}"
+        NET_CIDR_IPV6="${cluster_IPv6_CIDRs[${cluster}]}"
+
+    elif [[ "$DUAL_STACK" ]]; then
+        ovn_flags+=(-i6 -sw)
+        SVC_CIDR_IPV6="${service_IPv6_CIDRs[${cluster}]}"
+        NET_CIDR_IPV6="${cluster_IPv6_CIDRs[${cluster}]}"
+        NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
+        SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
+
+    else
+        NET_CIDR_IPV4="${cluster_CIDRs[${cluster}]}"
+        SVC_CIDR_IPV4="${service_CIDRs[${cluster}]}"
+    fi
+
     delete_cluster_on_fail ./ovn-kubernetes/contrib/kind.sh -ov "$OVN_IMAGE" -cn "${KIND_CLUSTER_NAME}" -ric "${ovn_flags[@]}" -lr -dd "${KIND_CLUSTER_NAME}.local" --disable-ovnkube-identity
 
     [[ "$AIR_GAPPED" = true ]] && air_gap_iptables


### PR DESCRIPTION
This commit configures IPv6 addressing support for kind OVNK deployments
in ipv6,dual-stack mode.

Note: for local testing, it may be necessary to add
`--cap-add=NET_ADMIN --privileged=true` to the Dockerfile at [1].
This is not part of this PR, but may be useful for local testings.

[1]
https://github.com/submariner-io/shipyard/blob/devel/package/Dockerfile.shipyard-dapper-base#L7
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
