### PR TITLE
Remove the unconfined seccomp setting

### DIFF
--- a/.dapper
+++ b/.dapper
@@ -130,11 +130,7 @@ while read -a replace; do
     mount_volume "${replace[1]}" "${mount_root}${replace[1]}"
 done < <(grep -o -E '=>[ ]*(\.\.?)?/[^ ]+' go.mod)
 
-# seccomp is unconfined to avoid problems with clone3 in Fedora 35
-# See https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
-# Remove "--security-opt seccomp=unconfined" once all supported container runtimes
-# handle clone3
-docker run -i --rm --security-opt seccomp=unconfined \
+docker run -i --rm \
        $(printf -- " -e %s" $DAPPER_ENV) -e "DAPPER_UID=$DAPPER_UID" -e "DAPPER_GID=$DAPPER_GID" \
        -v "${DAPPER_CP}:${DAPPER_SOURCE}${suffix}" \
        ${dockerargs} \


### PR DESCRIPTION
This was a temporary fix for an issue involving clone3 support in container runtimes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
