### PR TITLE
Use a single ncat for IPv4 and IPv6, or IPv6 only

### DIFF
--- a/scripts/nettest/simpleserver
+++ b/scripts/nettest/simpleserver
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
+# By default, ncat fails if it can't use an IPv4 connection; this tries an unspecified connection first
+# (listening on IPv4 and optionally IPv6), and if that fails, an IPv6-only connection
 while true
 do
-    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | /usr/bin/ncat -l -p 8080 --keep-open --allow 0.0.0.0 &
-    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | /usr/bin/ncat -6 -l -p 8080 --keep-open --allow ::
+    echo -e "HTTP/1.1 200 OK\r\n\r\nHello World" | (/usr/bin/ncat -l -p 8080 || /usr/bin/ncat -6 -l -p 8080)
 done


### PR DESCRIPTION
ncat without IP limitations (-4 or -6) uses both v4 and v6, so ncat
listening on port 8080 binds to the port on IPv4 and IPv6 addresses.
Starting a second ncat for IPv6 only then fails because the port is
already taken.

This tries an unspecified connection first, listening on IPv4 and, if
present, IPv6; if that fails, it uses an IPv6-only connection. It also
drops --keep-open, the tests rely on ncat restarting after every
connection.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
