### PR TITLE
Allow skipping connector pod source IP validation

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -32,23 +32,24 @@ import (
 type contextArray []string
 
 type TestContextType struct {
-	ReporterConfig      *types.ReporterConfig
-	SuiteConfig         *types.SuiteConfig
-	KubeConfigs         []string // KubeConfigs provides an alternative to KubeConfig + KubeContexts
-	KubeConfig          string
-	KubeContexts        contextArray
-	ClusterIDs          []string
-	NumNodesInCluster   map[ClusterIndex]int
-	SubmarinerNamespace string
-	ConnectionTimeout   uint
-	ConnectionAttempts  uint
-	OperationTimeout    uint
-	PacketSize          uint
-	GlobalnetEnabled    bool
-	ClientQPS           float32
-	ClientBurst         int
-	GroupVersion        *schema.GroupVersion
-	NettestImageURL     string
+	ReporterConfig          *types.ReporterConfig
+	SuiteConfig             *types.SuiteConfig
+	KubeConfigs             []string // KubeConfigs provides an alternative to KubeConfig + KubeContexts
+	KubeConfig              string
+	KubeContexts            contextArray
+	ClusterIDs              []string
+	NumNodesInCluster       map[ClusterIndex]int
+	SubmarinerNamespace     string
+	ConnectionTimeout       uint
+	ConnectionAttempts      uint
+	OperationTimeout        uint
+	PacketSize              uint
+	SkipConnectorSrcIPCheck bool
+	GlobalnetEnabled        bool
+	ClientQPS               float32
+	ClientBurst             int
+	GroupVersion            *schema.GroupVersion
+	NettestImageURL         string
 }
 
 func (contexts *contextArray) String() string {

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -77,7 +77,7 @@ func RunConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *fra
 	Expect(listenerPod.TerminationMessage).To(ContainSubstring(connectorPod.Config.Data))
 	Expect(connectorPod.TerminationMessage).To(ContainSubstring(listenerPod.Config.Data))
 
-	if p.Networking == framework.PodNetworking {
+	if p.Networking == framework.PodNetworking && !framework.TestContext.SkipConnectorSrcIPCheck {
 		framework.By("Verifying the output of listener pod which must contain the source IP")
 		Expect(listenerPod.TerminationMessage).To(ContainSubstring(connectorPod.GetIP()))
 	}


### PR DESCRIPTION
Due to a known bug in submariner/ovnk, when a listener pod runs on a non-gateway node, E2E datapath test should fail because ovnk changes the source IP. 

Currently, Shipyard datapath E2E test verifies that the connector pod's source IP is preserved.

This PR introduces an option to skip connector pod source IP validation, and the default value will preserve the existing behavior.

It allows distinguishing E2E failures caused by the known ovnk SNAT issue from other potential issues.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
