### PR TITLE
Allow named K8s versions in e2e

### DIFF
--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -21,7 +21,7 @@ jobs:
         project: ['admiral', 'lighthouse', 'subctl', 'submariner', 'submariner-operator']
         cabledriver: ['libreswan']
         # Run most tests against the latest K8s version
-        k8s_version: ['1.33']
+        k8s_version: ['k8s-latest']
         include:
           # Test the same set of cable driver combinations as the consuming projects do in their CI
           - project: submariner
@@ -29,7 +29,7 @@ jobs:
           # Test multiple K8s versions only in submariner-operator, balancing coverage and jobs
           - project: submariner-operator
             # Bottom of supported K8s version range
-            k8s_version: '1.26'
+            k8s_version: 'k8s-oldest-supported'
     steps:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -9,7 +9,7 @@ inputs:
   k8s_version:
     description: 'Version of Kubernetes to use for clusters'
     required: false
-    default: '1.33'
+    default: 'k8s-latest'
   using:
     description: 'Various options to pass via using="..."'
     required: false
@@ -78,7 +78,10 @@ runs:
     - name: Run E2E deployment and tests
       shell: bash
       run: |
-        k8s_version=${{ inputs.k8s_version }} &&
+        k8s_version=${{ inputs.k8s_version }};
+        if [ "$k8s_version" = k8s-latest ]; then k8s_version=1.33; fi; \
+        if [ "$k8s_version" = k8s-oldest-working ]; then k8s_version=1.19; fi; \
+        if [ "$k8s_version" = k8s-oldest-supported ]; then k8s_version=1.31; fi; \
         make "${{ inputs.target }}" \
             using="${{ inputs.using }}" \
             ${k8s_version:+K8S_VERSION="$k8s_version"} \


### PR DESCRIPTION
To simplify branch rule management, this adds aliases for the latest, oldest supported, and oldest working versions of Kubernetes. This allows versions to be specified using aliases (k8s-latest, k8s-oldest-supported, k8s-oldest-working) in version matrices, so that the resulting job names remain consistent as underlying Kubernetes versions change.

Backwards compatibility is preserved: the version can still be specified as a version number (1.33 etc.).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
