### PR TITLE
Extract cached package information correctly

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -73,7 +73,6 @@ runs:
       uses: submariner-io/shipyard/gh-actions/restore-images@devel
       with:
         cache: ${{ inputs.cache }}
-        working-directory: ${{ inputs.working-directory }}
 
     - name: Run E2E deployment and tests
       shell: bash


### PR DESCRIPTION
Commit 37a96ab4 ("Use local `Shipyard` when testing consuming E2E") removed the working-directory parameter. At the time we missed its use in the call to the restore-images action; as a result, the package directory containing image build stamps was extracted to the wrong location.

This fixes that by dropping the working-directory parameter, relying on the default value ('.').

To see the impact, compare the E2E run times on https://github.com/submariner-io/submariner/pull/3491 and https://github.com/submariner-io/submariner/pull/3492