### PR TITLE
Automated backport of #2032: Extract cached package information correctly

### DIFF
--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -73,7 +73,6 @@ runs:
       uses: submariner-io/shipyard/gh-actions/restore-images@devel
       with:
         cache: ${{ inputs.cache }}
-        working-directory: ${{ inputs.working-directory }}
 
     - name: Run E2E deployment and tests
       shell: bash


### PR DESCRIPTION
Backport of #2032 on release-0.17.

#2032: Extract cached package information correctly

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.