### PR TITLE
Automated backport of #1730: Check unmerged commits in dependencies
#1739: Add a Makefile.inc rule to check non-release versions

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -210,6 +210,11 @@ post-mortem:
 unit:
 	$(SCRIPTS_DIR)/unit_test.sh
 
+# [check-non-release-versions] checks that Submariner dependencies referencing
+# hashes point to commits present on the relevant branch
+check-non-release-versions:
+	$(SCRIPTS_DIR)/check-non-release-versions.sh
+
 CODEOWNERS: CODEOWNERS.in
 	$(SCRIPTS_DIR)/gen-codeowners
 

--- a/scripts/shared/check-non-release-versions.sh
+++ b/scripts/shared/check-non-release-versions.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf $tmpdir' EXIT
+
+# List all submariner-io dependencies with a - in their version
+# We're looking for versions pointing to commits, of the form
+# vX.Y.Z-0.YYYYMMDDhhmmss-hash
+failed=0
+shopt -s lastpipe
+GOWORK=off go list -m -mod=mod -json all |
+    jq -r 'select(.Path | contains("/submariner-io/")) | select(.Main != true) | select(.Version | contains ("-")) | select(.Version | length > 14) | "\(.Path) \(.Version)"' |
+    while read -r project version; do
+        cd "$tmpdir" || exit 1
+        git clone "https://$project"
+        cd "${project##*/}" || exit 1
+        hash="${version##*-}"
+        branch="${GITHUB_BASE_REF:-devel}"
+        if ! git merge-base --is-ancestor "$hash" "origin/$branch"; then
+            printf "This project depends on %s %s\n" "$project" "$version"
+            printf "but %s branch %s does not contain commit %s\n" "$project" "$branch" "$hash"
+            failed=1
+        fi
+    done
+
+exit $failed


### PR DESCRIPTION
Backport of #1730 #1739 on release-0.18.

#1730: Check unmerged commits in dependencies
#1739: Add a Makefile.inc rule to check non-release versions

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.