### PR TITLE
Add metricsproxy script that uses nc vs busybox nc

### DIFF
--- a/package/Dockerfile.nettest.konflux
+++ b/package/Dockerfile.nettest.konflux
@@ -19,7 +19,10 @@ RUN dnf -y update && \
 WORKDIR /app
 
 COPY scripts/nettest/nc /usr/bin/
-COPY scripts/nettest/* /app/
+COPY scripts/nettest/simpleserver /app/
+COPY scripts/nettest/metricsproxy.konflux /app/metricsproxy
+# TODO: I think nc script not needed in app dir but matching current version
+COPY scripts/nettest/nc /app/
 
 COPY LICENSE /licenses/LICENSE
 

--- a/scripts/nettest/metricsproxy.konflux
+++ b/scripts/nettest/metricsproxy.konflux
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Arguments: source-port target-IP target-port
+exec /usr/bin/ncat -v -lk -p "$1" -c "/usr/bin/ncat $2 $3"


### PR DESCRIPTION
This would benefit from cleanup later.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
