### PR TITLE
Move OVN to an older commit to avoid kind dependency issue

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -274,8 +274,8 @@ function prepare_ovn() {
     pushd ovn-kubernetes || exit
 
     # When updating commit, Update the OVN_SRC_IMAGE to the corressponding commit
-    git checkout 24b0ae73a996e409bfefad7b90cb42224e34be54
-    local OVN_SRC_IMAGE="ghcr.io/ovn-org/ovn-kubernetes/ovn-kube-u:master@sha256:ba102783d520f0474e5c7dd5f2a0a1dce0ec2bda6cd42ac547621892e57c25e2"
+    git checkout ca2fbb5b25c5bd5351bf1d44c8d447cf521fa782
+    local OVN_SRC_IMAGE="quay.io/aswinsuryan/ovn-daemonset-f@sha256:0bb074cf3fb38a75a8be684ec433268e8f7238fd0be62424c5b00260b122087a"
 
     docker pull "${OVN_SRC_IMAGE}"
     docker tag "${OVN_SRC_IMAGE}" "${OVN_IMAGE}"


### PR DESCRIPTION
The kind deployment script check for minimum kind version from[1]
and Submariner 0.20 kind version is not updated yet to that version.

Since image for this commit is not available using a locally build
one.
[1]https://github.com/ovn-kubernetes/ovn-kubernetes/commit/e6a2e98b5572bba6692e7fa0c1d02e67700a1a66

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
