### PR TITLE
Skip UPX compression when building images for linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Run golangci-lint
-        run: make golangci-lint
+        run: make golangci-lint UPX_LEVEL=-0
 
   markdown-link-check:
     name: Markdown Links (modified files)
@@ -94,7 +94,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Run packagedoc-lint
-        run: make packagedoc-lint
+        run: make packagedoc-lint UPX_LEVEL=-0
 
   shellcheck:
     name: Shell

--- a/Makefile.images
+++ b/Makefile.images
@@ -12,6 +12,7 @@ export REPO ?= quay.io/submariner
 
 # Specific to `build_images.sh`
 export USE_CACHE ?= true
+export UPX_LEVEL
 
 # Specific to `images`
 export OCIFILE PLATFORM

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -72,7 +72,7 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
     dnf -y clean all && \
     rm -f /usr/bin/{dockerd,lto-dump} \
           /usr/libexec/gcc/x86_64-redhat-linux/10/lto1 && \
-    find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
+    [ "${UPX_LEVEL}" = -0 ] || find /usr/bin /usr/lib/golang /usr/libexec -type f -executable -newercc /proc -size +1M ! -name hyperkube \( -execdir upx ${UPX_LEVEL} {} \; -o -true \) && \
     ln -f /usr/bin/kubectl /usr/bin/hyperkube
 
 COPY tools/go.mod /tools.mod

--- a/scripts/shared/build_image.sh
+++ b/scripts/shared/build_image.sh
@@ -56,6 +56,7 @@ fi
 
 # Rebuild the image to update any changed layers and tag it back so it will be used.
 buildargs_flags=(--build-arg BUILDKIT_INLINE_CACHE=1 --build-arg "BASE_BRANCH=${BASE_BRANCH}" --build-arg "VERSION=${VERSION}")
+[[ -z "${UPX_LEVEL}" ]] || buildargs_flags+=(--build-arg "UPX_LEVEL=${UPX_LEVEL}")
 if [[ "${PLATFORM}" != "${default_platform}" ]] && docker buildx version > /dev/null 2>&1; then
     docker buildx use buildx_builder || docker buildx create --name buildx_builder --use
     docker buildx build "${output_flag}" -t "${local_image}" "${cache_flags[@]}" -f "${dockerfile}" --iidfile "${hashfile}" --platform "${PLATFORM}" "${buildargs_flags[@]}" .


### PR DESCRIPTION
UPX compression takes a significant amount of time, and is pointless for throwaway images such as those built for linting jobs.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
