### PR TITLE
Ensure 'broker' var is set by load_settings

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -232,6 +232,9 @@ function load_settings() {
 
         # Determine broker, default to first declared cluster
         broker=$(_yq ".clusters[] | select(. | has(\"broker\")) | path | .[-1] // \"${clusters[0]}\"")
+        if [ -z "$broker" ]; then
+            broker="${clusters[0]}"
+        fi
     fi
 
     # Determine per cluster settings, default to global if not defined


### PR DESCRIPTION
This line:
    
`broker=$(_yq ".clusters[] | select(. | has(\"broker\")) | path | .[-1]  // \"${clusters[0]}\"")`
    
is supposed to find the cluster setting with the `broker` flag set or default to the first cluster. However this yields an empty value in the absence of the 'broker' flag. It seems it's not defaulting. This just started mysteriously happening. In lieu of that, if `broker` is empty,  explicitly set it to the first cluster.
