### PR TITLE
Automated backport of #2121: Ensure 'broker' var is set by load_settings

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -232,6 +232,9 @@ function load_settings() {
 
         # Determine broker, default to first declared cluster
         broker=$(_yq ".clusters[] | select(. | has(\"broker\")) | path | .[-1] // \"${clusters[0]}\"")
+        if [ -z "$broker" ]; then
+            broker="${clusters[0]}"
+        fi
     fi
 
     # Default kubeproxy mode


### PR DESCRIPTION
Backport of #2121 on devel.

#2121: Ensure 'broker' var is set by load_settings

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.