### PR TITLE
Exclude embedded ovn-kubernetes from local grype scans

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -10,3 +10,7 @@ ignore:
   - vulnerability: CVE-2021-22570
     package:
       name: google.golang.org/protobuf
+
+exclude:
+  # Exclude git-ignored ovn-kubernetes directory
+  - "./ovn-kubernetes/**"


### PR DESCRIPTION
While ovn-kubernetes is git-ignored and not scanned by CI, local grype runs scan all files including ignored ones. This exclude pattern prevents false positive CVEs from embedded code that cannot be fixed via go.mod updates.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
