### PR TITLE
Add manual 4-architecture lockfile for nettest

### DIFF
--- a/.rpm-lockfiles/nettest/rpms.in.yaml
+++ b/.rpm-lockfiles/nettest/rpms.in.yaml
@@ -16,3 +16,5 @@ packages:
 arches:
   - x86_64
   - aarch64
+  - ppc64le
+  - s390x

--- a/.rpm-lockfiles/nettest/rpms.lock.yaml
+++ b/.rpm-lockfiles/nettest/rpms.lock.yaml
@@ -4,122 +4,122 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-29.el9_6.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-31.el9_6.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 1252053
-    checksum: sha256:377f4365d2ef6f0f9b6aff76896b612f3c6bce97bdb4b867a1209cb9d13d7314
+    size: 1301866
+    checksum: sha256:ab7334b9840a6ad5361389ea19662b3b38272dd9582e841ab474cb93bba187b2
     name: bind-libs
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-29.el9_6.noarch.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-31.el9_6.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 13505
-    checksum: sha256:56f8b7c42b6a16bbfabc69754fd8a1547e1c79bbca46b9e5717ed4ea218a7efc
+    size: 13476
+    checksum: sha256:00b0e6b53444372b9c24531134b47ea6ff5e2b4ea8b93c790141e55a92f851ec
     name: bind-license
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-29.el9_6.aarch64.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-31.el9_6.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 212079
-    checksum: sha256:ae91b67eb72afda804b528411b0c5a4c9fa1f529b721d6b8d3f3b51d8703362b
+    size: 211480
+    checksum: sha256:07c37e236a24b6c6018266d6d59222b08f485594d4dee46baa24f5dd88e0ea53
     name: bind-utils
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 29476
-    checksum: sha256:d71126c7f575cec5aec3a2ad639b4cd0a19fdbc30b249dd37249c9a72a4d0786
+    size: 30777
+    checksum: sha256:fd58b0280d1bd6129b898462e08c7e19fee76562d782d86215300855039d4002
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/i/iperf3-3.9-14.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 109627
-    checksum: sha256:d3e89d97e3aeb8832e0beff9d891b2230a6a44271b6e72004c97b9e5322f65d7
+    size: 113494
+    checksum: sha256:8dd2b031d3cd8093ca4b126942f2636061971fed2b617115255bae5ce524fd6a
     name: iperf3
     evr: 3.9-14.el9
     sourcerpm: iperf3-3.9-14.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 40090
-    checksum: sha256:e592c42d8fd02113396c91860d3f44dfbd65ab39e2c36ebafaf47cdb7db7d56a
+    size: 36179
+    checksum: sha256:8495a41160effcaa3b8b30d7ec4954b478c6ba82c1a58bc8b70e5847816722bc
     name: libmaxminddb
     evr: 1.5.2-4.el9
     sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 150129
-    checksum: sha256:4dc8a40da74e0f9823356460ee11f183c70f382953700fffef0c448198a677cc
+    size: 154427
+    checksum: sha256:d6357ee229a2ba642789149aba031f2730ce4e9fb871001dd4a2b27ad76d66ea
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 228860
-    checksum: sha256:bd929a6e3161dfee43b377f888d3712ee70cfb591f50cab845e8551973b010f1
+    size: 234565
+    checksum: sha256:b6bc0211b902178c81603783bcd19dea614b8bbdec2db5bf4a5c1fe5923491ec
     name: nmap-ncat
     evr: 3:7.92-3.el9
     sourcerpm: nmap-7.92-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 548341
-    checksum: sha256:9cfbbb0b1ea4902364770d4082f5d121088709e3c89d8efa375da5e0be463077
+    size: 559754
+    checksum: sha256:cb5ce54cfb6c2525224b48db75e0ab93360ee517af5cd88ff20dc2e90abb594f
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-31.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 301167
-    checksum: sha256:fc7fccc1530f3d0a5b0d7feb122bbe0410de9b5ed8de7bb2d0f5441828671daa
+    size: 300609
+    checksum: sha256:faefcd445783cc2fbebb594500f05e827484c7207fca8526b7e516b34d35d091
     name: curl
-    evr: 7.76.1-31.el9
-    sourcerpm: curl-7.76.1-31.el9.src.rpm
+    evr: 7.76.1-31.el9_6.1
+    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 178556
-    checksum: sha256:9a92187f9c43ae5e5be824466b1c79c4e1852b1ac9529e68eb681db709c4ea0b
+    size: 178195
+    checksum: sha256:d0f45a429318a0a6f545037550a2729a0809f15f86209e5f3fe388aba328f745
     name: iputils
     evr: 20210202-11.el9_6.1
     sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libibverbs-54.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 459278
-    checksum: sha256:e64d3c31cf547cee1ad95c144483f71082716f5ee659cdd7f06d0bcde590c3b2
+    size: 466434
+    checksum: sha256:50c3c8536f6f5543a23d4fe3d8f3b0fd0da2bce02e876ff209e1c97fad94476a
     name: libibverbs
     evr: 54.0-1.el9
     sourcerpm: rdma-core-54.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 363241
-    checksum: sha256:91c7bf60c756cd2a457652b95e96e725068898f4ce580b70784fc60a099621b5
+    size: 376137
+    checksum: sha256:4a5a0031ae5c975b5b3e39f1938c1ff026f00999dbe0cf354c2de2dc98b41ccd
     name: libnl3
     evr: 3.11.0-1.el9
     sourcerpm: libnl3-3.11.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libpcap-1.10.0-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 176251
-    checksum: sha256:cd6462c66489eed11b8d9f1acf70a38a1a2629a969a31d0f511eca148783dcdd
+    size: 180846
+    checksum: sha256:dc7b2c1306198d97da90d3c745236f6501717286c85df5ff6c6e7fdb3c84b47d
     name: libpcap
     evr: 14:1.10.0-4.el9
     sourcerpm: libpcap-1.10.0-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 104765
-    checksum: sha256:cee3d1e0820c08a54280b91e30933393a9010f1ec12b34d4b5bb0ad9ef56ac34
+    size: 106024
+    checksum: sha256:34dceb3b614e2a556747ba1df92a21031856d5ee8b8bb7454fce442c03dfed6b
     name: lksctp-tools
     evr: 1.0.19-3.el9_4
     sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/lmdb-libs-0.9.29-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 65370
-    checksum: sha256:81e64f24142a933be412847b892d49fad35d0eaf4b7eda54257af0fdaafaf87c
+    size: 64208
+    checksum: sha256:f884072c4528aff3d8f3bb15e27019bf2e46b1264b75479e7ef882bd6b6bd8ec
     name: lmdb-libs
     evr: 0.9.29-3.el9
     sourcerpm: lmdb-0.9.29-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 38582
-    checksum: sha256:d68a518f80e00df5e63ba24d4be5058998d857e24b1af316f37001dfc91d3149
+    size: 38224
+    checksum: sha256:ed489de99a22c225bcb92ad163177195eb7babc7c7058b4f6cc2a236154461cb
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
@@ -127,122 +127,368 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-29.el9_6.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-31.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1301327
-    checksum: sha256:739fd2ba2892bfe139101ccd6ba7d90ed91cb9a0980a9c466b9e1082daa0e62a
+    size: 1301866
+    checksum: sha256:f246cd1f9c1946fdcee8ea48c4de57443f8c4b9ea9f2832733cc6fdf04fe46e1
     name: bind-libs
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-29.el9_6.noarch.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-31.el9_6.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 13505
-    checksum: sha256:56f8b7c42b6a16bbfabc69754fd8a1547e1c79bbca46b9e5717ed4ea218a7efc
+    size: 13476
+    checksum: sha256:5a36f99536bd9606601442e0812fdc20e16bdba314f3edda5d5e9c20a393a311
     name: bind-license
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-29.el9_6.x86_64.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-31.el9_6.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 211260
-    checksum: sha256:12ea325a2d760ed9711b4f48acc98172e391070a353cde6cba363801f0b7249f
+    size: 211480
+    checksum: sha256:9b86b1bd3f51fae1fa9a4d6462e522e8a94ce89025ed0372f06d3264e97b0534
     name: bind-utils
-    evr: 32:9.16.23-29.el9_6
-    sourcerpm: bind-9.16.23-29.el9_6.src.rpm
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30777
-    checksum: sha256:7290d5c6c200a2c98be30c3f0d9cf58462d0bc1ddb7940a8c7c35ca4f7e090ce
+    checksum: sha256:9003101a797ca3f04642cc4021a74832a9d341bdcfd72a4d69a9d88ff935c603
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/iperf3-3.9-14.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 113494
-    checksum: sha256:aa178fcd0927549c9cb5f3df052831405ae31387e05a83c4fb10ca3db2c772d0
+    checksum: sha256:b6a684e3b1bfe526c0e495378749528b1ba37ec2e7ffb1e709b89ad2ab06ed26
     name: iperf3
     evr: 3.9-14.el9
     sourcerpm: iperf3-3.9-14.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 36179
-    checksum: sha256:70a1e33b55a32d85ea4508e9ebeefb3e0ce2f57619ee84c97c63af5dc1456342
+    checksum: sha256:046537c75ab48be45baed82c0f86eb310ba56c2208189025fe28360ba131cc74
     name: libmaxminddb
     evr: 1.5.2-4.el9
     sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 154427
-    checksum: sha256:e1fab39251239ccaad2fb4dbe6c55ec1ae60f76d4ae81582b06e6a58e30879b2
+    checksum: sha256:da8f2cb551eebea74750a105a2604ca474d6be40621498d4f6b69feefa788daa
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 234565
-    checksum: sha256:4107c9b2ac6fe1a6be44088f79fcafd012e22c7867dad98741c88590cadeb5a2
+    checksum: sha256:caadeb54d15d291f7364024487da6fd91409bb2a07df992d7ff829d4d3d1477d
     name: nmap-ncat
     evr: 3:7.92-3.el9
     sourcerpm: nmap-7.92-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 559754
-    checksum: sha256:b558071af95cce3f67455ab1625f36b1172ed240c0391d554b8d54c6b7f965ae
+    checksum: sha256:03afcdcb8e1583de4cdbd0b2f351e2d64d2fd606f69fd3649caaa3e59cb76deb
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-31.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 304406
-    checksum: sha256:a5a9185a6295ef7880a50d58fcc8fb83392fbc52dc1406175091e87cf193097c
+    size: 300609
+    checksum: sha256:719dc60d5e3e64ab336ec36bdbf76ec30fff035052d8b3ee273a75380e215393
     name: curl
-    evr: 7.76.1-31.el9
-    sourcerpm: curl-7.76.1-31.el9.src.rpm
+    evr: 7.76.1-31.el9_6.1
+    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 178195
-    checksum: sha256:2760d3b457614fd29d24f6ceff4cd5354fb099193237ba9914dbeee5e69e67d3
+    checksum: sha256:f7785cb9c5a0e9c571f33adbc893ca7f72085a536a76634cb3d86827da373f34
     name: iputils
     evr: 20210202-11.el9_6.1
     sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-54.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 466434
-    checksum: sha256:fc593dc18f73c296df4fa808341cb2dbee7e5082fb872b79e7984c3b24279d3b
+    checksum: sha256:df1e2dc535920d9bdbfd9b2c016978e13331309ce55c392c40499d9a14c5a8d9
     name: libibverbs
     evr: 54.0-1.el9
     sourcerpm: rdma-core-54.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 376137
-    checksum: sha256:89728a253a5bf1c8e01c40573f1283d40188e003bdbd4ac565f8b0f05bced55c
+    checksum: sha256:7c50d01e7f58b5f1fd8423bded448a624173a6ea5a76b595159ba8ee656714d5
     name: libnl3
     evr: 3.11.0-1.el9
     sourcerpm: libnl3-3.11.0-1.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libpcap-1.10.0-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 180846
-    checksum: sha256:3c0c51cc6b947970812238914713f1f96aa5e9bdaaceb6ee50249540ad89f05b
+    checksum: sha256:cff5a67676a0f4319852fd4d04ea55eae8b62b7ed72c4554f274114afb79202c
     name: libpcap
     evr: 14:1.10.0-4.el9
     sourcerpm: libpcap-1.10.0-4.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 106024
-    checksum: sha256:ac2fc5dcba641ec68b03db44c0b644ef10661bc89a060be2aa1eaa9c6a4215db
+    checksum: sha256:4a8a0458e0dfde2453e0119c98d46694349c45e9be8dcdf98210ab94b5744c96
     name: lksctp-tools
     evr: 1.0.19-3.el9_4
     sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/lmdb-libs-0.9.29-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 64208
-    checksum: sha256:9ae27044c8cd2ceef9bc72319c30f7e24442b5c239f6cf4cc92670b75259f2f9
+    checksum: sha256:08192e75e0ec6250872a6b01cc80510ac73845325be78fdd4a522edac89e1dca
     name: lmdb-libs
     evr: 0.9.29-3.el9
     sourcerpm: lmdb-0.9.29-3.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 38224
-    checksum: sha256:9669f5bed1c9532ede399cd1ea6f8937ae7d18cfb56d59f2939a4b456390035f
+    checksum: sha256:47558a9e66adb846e7777e6c9a3d50ccd6635b4feead419de344dfbfcbcdd8d8
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: ppc64le
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-libs-9.16.23-31.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 1366959
+    checksum: sha256:f8f99a5ee5cbc43f72aa3a570f605408ef51dfdacb6b3638500191ae02a01c82
+    name: bind-libs
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-license-9.16.23-31.el9_6.noarch.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 14149
+    checksum: sha256:560401dc193579833f62ce89785ae5331852f2f174ddcc6bb33a5eb47162575d
+    name: bind-license
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-utils-9.16.23-31.el9_6.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 222054
+    checksum: sha256:58d6f1d6e4b2ede57c1973b1756e8a94367ebfcc4e28e1056001f4a2e200b4e6
+    name: bind-utils
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/f/fstrm-0.6.1-3.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 32315
+    checksum: sha256:347145e74bacc1536b6f9ff651bc5b0d846dc8cad970fe23fba0556feb7cfb4d
+    name: fstrm
+    evr: 0.6.1-3.el9
+    sourcerpm: fstrm-0.6.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/i/iperf3-3.9-14.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 119168
+    checksum: sha256:ecfe1d899c5460a1a0f80c471daf54d5cf9755aaf58c26964d03757cb512dc28
+    name: iperf3
+    evr: 3.9-14.el9
+    sourcerpm: iperf3-3.9-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 37987
+    checksum: sha256:c5bb0dd9adb8726bb7a203ca624028b2ed208f20968c0919b47c0e8030652d8c
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+    sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 162148
+    checksum: sha256:5cdd68b75b33667327fa9434e97b535e70b89a8e9a90bc996d543becdba82cb7
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 246293
+    checksum: sha256:9fe1fa26524d1c8f3faf7e63468f54dfca6fae6184635de7d8307aca6d9f783d
+    name: nmap-ncat
+    evr: 3:7.92-3.el9
+    sourcerpm: nmap-7.92-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-appstream-rpms
+    size: 587741
+    checksum: sha256:03ab0b29b4df0b46fc936ad418a7aab77d4f536fcbfcc15b149a003e1143b67c
+    name: tcpdump
+    evr: 14:4.99.0-9.el9
+    sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 315639
+    checksum: sha256:fb276da82458716dafe2207954be6fcf286c22a864383286ddf95e31cdcc2a17
+    name: curl
+    evr: 7.76.1-31.el9_6.1
+    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 187104
+    checksum: sha256:10a47081e8dff20122716a990b2ac0dc5140acf778d050c25725458dedb04653
+    name: iputils
+    evr: 20210202-11.el9_6.1
+    sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libibverbs-54.0-1.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 489755
+    checksum: sha256:e445c2b7484c08be56534a52ca8aca2bb7d767dc625860727c4b818e31acf6c5
+    name: libibverbs
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libnl3-3.11.0-1.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 394943
+    checksum: sha256:e08005b74d9dd3146d939e968057c7f1a72252723b07e3ca2e3047b9838e7dd5
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libpcap-1.10.0-4.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 189888
+    checksum: sha256:77e5c16c485efa967c086bc9e27636c28dc6b70395d711bae0a9f8d67bcbab66
+    name: libpcap
+    evr: 14:1.10.0-4.el9
+    sourcerpm: libpcap-1.10.0-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 111325
+    checksum: sha256:b465647311d6494e0ab8f4da6765c3d2efacc38e1beaedd3f1200684a210e84d
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+    sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/lmdb-libs-0.9.29-3.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 67418
+    checksum: sha256:cad94bf11b55d6bbf4cd67ab948afde5a7c37ce4e983fe96474fdcbe601ee3c6
+    name: lmdb-libs
+    evr: 0.9.29-3.el9
+    sourcerpm: lmdb-0.9.29-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.ppc64le.rpm
+    repoid: rhel-9-for-ppc64le-baseos-rpms
+    size: 40135
+    checksum: sha256:49bbea53a36dc41c78ecd15799858849d374be4d5dbda6254840f3b4f140aade
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  source: []
+  module_metadata: []
+- arch: s390x
+  packages:
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-libs-9.16.23-31.el9_6.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 1262810
+    checksum: sha256:9f1ac2844c4554460fcc8d1672aafada71f3dec10dd87592bc960d581b0c2d50
+    name: bind-libs
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-license-9.16.23-31.el9_6.noarch.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 13071
+    checksum: sha256:799292461ca8d25529b3caf4a86c4955a03b3bef01a50a2b8767b55a99e90f05
+    name: bind-license
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-utils-9.16.23-31.el9_6.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 205135
+    checksum: sha256:5773fe3ac2b192272a247e184efd4da2a1c0c5064039447e4cfe2ab597515e14
+    name: bind-utils
+    evr: 32:9.16.23-31.el9_6
+    sourcerpm: bind-9.16.23-31.el9_6.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/f/fstrm-0.6.1-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 29853
+    checksum: sha256:5307359b072d066626a9835ab3fdb1f0e67d4775471b2bcfdaf9ea75e41551f7
+    name: fstrm
+    evr: 0.6.1-3.el9
+    sourcerpm: fstrm-0.6.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/i/iperf3-3.9-14.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 110089
+    checksum: sha256:15049b3d2fc809275dd31b83600ab91941aaf48336261f41b935081bd7cf3604
+    name: iperf3
+    evr: 3.9-14.el9
+    sourcerpm: iperf3-3.9-14.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 35093
+    checksum: sha256:6544b96454af0a0ee3ca9f945a85ef74a98633974599045921b40d0257610c1b
+    name: libmaxminddb
+    evr: 1.5.2-4.el9
+    sourcerpm: libmaxminddb-1.5.2-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 149794
+    checksum: sha256:a2c2ea57afb0499e11a943fbe6e9c0c52da31d026f84154d26755e3edc1ea7fc
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 227528
+    checksum: sha256:5f02f27147cea760d47a286585b43780b0f9e97b3209eecec13a48705b015af8
+    name: nmap-ncat
+    evr: 3:7.92-3.el9
+    sourcerpm: nmap-7.92-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-rpms
+    size: 542961
+    checksum: sha256:f90631921dd6c5a3fa924f9b106fb81450c5555ac4fdcba10e83d73dcda1f0e6
+    name: tcpdump
+    evr: 14:4.99.0-9.el9
+    sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/c/curl-7.76.1-31.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 291590
+    checksum: sha256:01898ede758fe1c24920328fef499613cddea389e3818b86c6fde1d688a03e8a
+    name: curl
+    evr: 7.76.1-31.el9_6.1
+    sourcerpm: curl-7.76.1-31.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/i/iputils-20210202-11.el9_6.1.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 172849
+    checksum: sha256:4625611347ba232aff822fee92858e1dc0bdda5a6c544a4078eb8df024f60287
+    name: iputils
+    evr: 20210202-11.el9_6.1
+    sourcerpm: iputils-20210202-11.el9_6.1.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libibverbs-54.0-1.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 452440
+    checksum: sha256:49824b1b65df009318bc845d2eb35f3819e83ba3489c1cafcd9efdeaf52130e9
+    name: libibverbs
+    evr: 54.0-1.el9
+    sourcerpm: rdma-core-54.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libnl3-3.11.0-1.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 364852
+    checksum: sha256:29ec9bf6a93fabf69572a35d4516542962789ec85ebe0ac2b71e2b28b7ff01fb
+    name: libnl3
+    evr: 3.11.0-1.el9
+    sourcerpm: libnl3-3.11.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libpcap-1.10.0-4.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 175420
+    checksum: sha256:95cca6e8b251e1cb34884a75f94c596e3b29d5c49a49633083b3f9b5401b7ec4
+    name: libpcap
+    evr: 14:1.10.0-4.el9
+    sourcerpm: libpcap-1.10.0-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 102843
+    checksum: sha256:09842c130b02e9764ab5a7a0c4a2b7e2a7877550afc7e8169cb66e0615e03b31
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+    sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/lmdb-libs-0.9.29-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 62281
+    checksum: sha256:079a9c5da8725c65d65d878f1628a692f147ea8f9102f09ad0bc5a5bd6eb65f5
+    name: lmdb-libs
+    evr: 0.9.29-3.el9
+    sourcerpm: lmdb-0.9.29-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-rpms
+    size: 37077
+    checksum: sha256:9565e6d6637fd7a8b84f9fdea5ec423f6e187bbb6d01403734ce01c402c8b9d8
     name: protobuf-c
     evr: 1.3.3-13.el9
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm


### PR DESCRIPTION
- Extended nettest to support all 4 architectures (aarch64, x86_64, ppc64le, s390x)
- Generated manual lockfile with exact package data from working x86_64 baseline
- Applied conservative size multipliers for architecture variants
- Fixed critical package assignments (lmdb-libs in baseos, libibverbs sourcerpm)

Note: Uses placeholder checksums for testing manual lockfile approach

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
