### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for nettest-0-21

### DIFF
--- a/package/Dockerfile.nettest.konflux
+++ b/package/Dockerfile.nettest.konflux
@@ -29,6 +29,7 @@ COPY LICENSE /licenses/LICENSE
 CMD ["/bin/bash","-l"]
 
 LABEL com.redhat.component="nettest-container" \
+      cpe="cpe:/a:redhat:acm:2.14::el9" \
       name="rhacm2/nettest-rhel9" \
       version="${BASE_BRANCH}" \
       summary="A container with networking test and troubleshooting tools" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
