### PR TITLE
Drop tcp.GlobalIP and enable iotamixing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -124,6 +124,7 @@ linters:
     - ineffassign
     # - interfacebloat # We track complexity elsewhere
     - intrange
+    - iotamixing
     # - ireturn # The argument to always "Return Concrete Types" doesn't seem compelling. It is perfectly valid to return
     #             an interface to avoid exposing the entire underlying struct
     - lll

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -33,10 +33,8 @@ type EndpointType int
 const (
 	PodIP EndpointType = iota
 	ServiceIP
-	// TODO: Remove GlobalIP once all consumer code switches to GlobalServiceIP.
-	GlobalIP
+	GlobalServiceIP
 	GlobalPodIP
-	GlobalServiceIP = GlobalIP
 )
 
 type ConnectivityTestParams struct {


### PR DESCRIPTION
golangci-lint 2.5 adds a linter, iotamixing, that checks iota usage in const blocks for consistency. This flags GlobalIP / GlobalServiceIP; the best option to fix that is to address the long-standing TODO item and remove GlobalIP in favour of GlobalServiceIP.

Depends on https://github.com/submariner-io/submariner/pull/3646