### PR TITLE
Automated backport of #2130: Build golangci-lint with the installed Go compiler

### DIFF
--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -57,9 +57,12 @@ RUN dnf -y install --nodocs --setopt=install_weak_deps=False \
 
 COPY tools/go.mod /tools.mod
 
-# This layer's versioning is determined by us, and thus could be rebuilt more frequently to test different versions
+# This layer's versioning is determined by us,
+# and thus could be rebuilt more frequently to test different versions.
+# golangci-lint must be built with a version of Go equal to or newer
+# than the version used to analyse the code, so this rebuilds it.
 RUN LINT_VERSION=$(awk '/golangci-lint/ { print $2 }' /tools.mod) && \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin -d ${LINT_VERSION} && \
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@${LINT_VERSION} && \
     HELM_VERSION=$(awk '/helm.sh/ { print $2 }' /tools.mod) && \
     i=0; until curl "https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz" | tar -xzf -; do if ((++i > 5)); then break; fi; sleep 1; done && \
     mv linux-${ARCH}/helm /go/bin/ && chmod a+x /go/bin/helm && rm -rf linux-${ARCH} && \


### PR DESCRIPTION
Backport of #2130 on release-0.19.

#2130: Build golangci-lint with the installed Go compiler

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.