### PR TITLE
Automated backport of #2138: Ensure 'broker' var is set by load_settings

### DIFF
--- a/scripts/shared/lib/utils
+++ b/scripts/shared/lib/utils
@@ -232,6 +232,9 @@ function load_settings() {
 
         # Determine broker, default to first declared cluster
         broker=$(_yq ".clusters[] | select(. | has(\"broker\")) | path | .[-1] // \"${clusters[0]}\"")
+        if [ -z "$broker" ]; then
+            broker="${clusters[0]}"
+        fi
     fi
 
     # Determine per cluster settings, default to global if not defined


### PR DESCRIPTION
Backport of #2138 on release-0.17.

#2138: Ensure 'broker' var is set by load_settings

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.