### PR TITLE
Automated backport of #2188: Check non-release dependencies across modules

### DIFF
--- a/scripts/shared/check-non-release-versions.sh
+++ b/scripts/shared/check-non-release-versions.sh
@@ -8,19 +8,21 @@ trap 'rm -rf $tmpdir' EXIT
 # vX.Y.Z-0.YYYYMMDDhhmmss-hash
 failed=0
 shopt -s lastpipe
-GOWORK=off go list -m -mod=mod -json all |
-    jq -r 'select(.Path | contains("/submariner-io/")) | select(.Main != true) | select(.Version | contains ("-")) | select(.Version | length > 14) | "\(.Path) \(.Version)"' |
-    while read -r project version; do
-        cd "$tmpdir" || exit 1
-        git clone "https://$project"
-        cd "${project##*/}" || exit 1
-        hash="${version##*-}"
-        branch="${GITHUB_BASE_REF:-devel}"
-        if ! git merge-base --is-ancestor "$hash" "origin/$branch"; then
-            printf "This project depends on %s %s\n" "$project" "$version"
-            printf "but %s branch %s does not contain commit %s\n" "$project" "$branch" "$hash"
-            failed=1
-        fi
-    done
+while read -d $'\0' -r module <&3; do
+    GOWORK=off go -C "$module" list -m -mod=mod -json all |
+        jq -r 'select(.Path | contains("/submariner-io/")) | select(.Main != true) | select(.Version | contains ("-")) | select(.Version | length > 14) | "\(.Path) \(.Version)"' |
+        while read -r project version; do
+            cd "$tmpdir" || exit 1
+            [ -d "${project##*/}" ] || git clone "https://$project"
+            cd "${project##*/}" || exit 1
+            hash="${version##*-}"
+            branch="${GITHUB_BASE_REF:-devel}"
+            if ! git merge-base --is-ancestor "$hash" "origin/$branch"; then
+                printf "This project depends on %s %s\n" "$project" "$version"
+                printf "but %s branch %s does not contain commit %s\n" "$project" "$branch" "$hash"
+                failed=1
+            fi
+        done
+done 3< <(find . -name go.mod -printf '%h\0')
 
 exit $failed


### PR DESCRIPTION
Backport of #2188 on release-0.17.

#2188: Check non-release dependencies across modules

For details on the backport process, see the [backport requests](https://submariner.io/development/backports/) page.