### PR TITLE
Remove ovn-ic deployment

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -126,7 +126,6 @@ jobs:
           - extra-toggles: ipv6-stack
           - extra-toggles: ovn
           - extra-toggles: 'ovn, intra-cluster-disabled'
-          - extra-toggles: ovn-ic
           - deploytool: operator
             extra-toggles: lighthouse
           - deploytool: helm

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ else
 SETTINGS ?= $(DAPPER_SOURCE)/.shipyard.e2e.yml
 endif
 
-ifneq (,$(filter ovn-ic,$(USING)))
-export OVN_IC = true
-endif
-
 export LAZY_DEPLOY = false
 
 scale: SETTINGS = $(DAPPER_SOURCE)/.shipyard.scale.yml

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -210,7 +210,6 @@ function deploy_kind_ovn(){
     export KIND_CLUSTER_NAME="${cluster}"
 
     local ovn_flags=()
-    [[ "$OVN_IC" != true ]] || ovn_flags=( -ic -npz 1 -wk 3 )
 
     if [[ "$IPV6_STACK" ]]; then
         ovn_flags+=( -n4 -i6 -sw)


### PR DESCRIPTION
This now fails with running out of disk space but it's not used anymore so remove it.