### PR TITLE
Adjust command for excluding directories containing e2e tests

### DIFF
--- a/scripts/shared/unit_test.sh
+++ b/scripts/shared/unit_test.sh
@@ -33,7 +33,9 @@ for module in "${modules[@]}"; do
         cd "$module"
 
         # Exclude any directories containing e2e tests
-        for dir in $(git grep -w -l e2e | grep _test.go | sed 's#\(.*/.*\)/.*$#\1#' | sort -u); do
+        readarray -d '' e2e_test_files < <(git grep -z -w -l RunE2ETests -- '*_test.go' || true)
+        for file in "${e2e_test_files[@]}"; do
+            dir="$(dirname -- "$file")"
             exclude_args+=(-path "./${dir}" -prune -o)
         done
 


### PR DESCRIPTION
...when running unit tests. The command `git grep -w -l e2e | grep _test.go` is too broad as it also finds unit tests files that import shipyard's `test/e2e/framework`. This causes them to be excluded. Instead of grepping for `e2e`, we can grep for the more specific `RunE2ETests` function that every project's E2E tests call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test discovery and pruning to make test runs more reliable and reduce false positives during test selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->