### PR TITLE
Add s390x EUS support for nettest

### DIFF
--- a/.rpm-lockfiles/nettest/rpms.in.yaml
+++ b/.rpm-lockfiles/nettest/rpms.in.yaml
@@ -16,3 +16,4 @@ packages:
 arches:
   - x86_64
   - aarch64
+  - s390x

--- a/.rpm-lockfiles/nettest/rpms.lock.yaml
+++ b/.rpm-lockfiles/nettest/rpms.lock.yaml
@@ -125,6 +125,129 @@ arches:
     sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
   source: []
   module_metadata: []
+- arch: s390x
+  packages:
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/b/bind-libs-9.16.23-18.el9_4.10.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 1233213
+    checksum: sha256:e9ab976b9960063e2450cb802d87255385c47b82030dc8b6deb84f5d199306a7
+    name: bind-libs
+    evr: 32:9.16.23-18.el9_4.10
+    sourcerpm: bind-9.16.23-18.el9_4.10.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/b/bind-license-9.16.23-18.el9_4.10.noarch.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 11778
+    checksum: sha256:7f5161e506b24e0ce1df74a198c5fa8b6a8ff0351c1be55c6755a4ad685242f7
+    name: bind-license
+    evr: 32:9.16.23-18.el9_4.10
+    sourcerpm: bind-9.16.23-18.el9_4.10.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/b/bind-utils-9.16.23-18.el9_4.10.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 209602
+    checksum: sha256:62429b7b5d30bca82ab56812f4f504d28312f73037b991c68218be47d5140f79
+    name: bind-utils
+    evr: 32:9.16.23-18.el9_4.10
+    sourcerpm: bind-9.16.23-18.el9_4.10.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/f/fstrm-0.6.1-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 29853
+    checksum: sha256:aab9775d0f1ef189c82069a4af4c540c669d61efdc285696fb3bde3c6a9fe9ea
+    name: fstrm
+    evr: 0.6.1-3.el9
+    sourcerpm: fstrm-0.6.1-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/i/iperf3-3.9-11.el9_4.1.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 108095
+    checksum: sha256:1752008fbf0a27ba061816d0593fde82906dff572715809f01e336bbbdb9381e
+    name: iperf3
+    evr: 3.9-11.el9_4.1
+    sourcerpm: iperf3-3.9-11.el9_4.1.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/l/libmaxminddb-1.5.2-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 36596
+    checksum: sha256:e1ccafd790c887c4503ed0958ac6070041b0f86630754b9acbe651accf49dc38
+    name: libmaxminddb
+    evr: 1.5.2-3.el9
+    sourcerpm: libmaxminddb-1.5.2-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/l/libuv-1.42.0-2.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 150561
+    checksum: sha256:7badf8ffee70ff4eabd9b96701d8926752c961e395dd79ecd70460056b88024f
+    name: libuv
+    evr: 1:1.42.0-2.el9_4
+    sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/n/nmap-ncat-7.92-1.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 228274
+    checksum: sha256:a6b33e568ea35a14bdd1ba1d37bfeb42686740a046312e6140d63af7753ab739
+    name: nmap-ncat
+    evr: 3:7.92-1.el9
+    sourcerpm: nmap-7.92-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-appstream-eus-rpms
+    size: 527514
+    checksum: sha256:40044b25178326f2d4a8b277a2b3123532626a0d39a7d6f6e8a01e502b6a2a74
+    name: tcpdump
+    evr: 14:4.99.0-9.el9
+    sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/c/curl-7.76.1-29.el9_4.3.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 297065
+    checksum: sha256:3785c2a14e7b3dd63d1348647e3dc5a2a83630de1eca2ea4a214726c7f1dbcce
+    name: curl
+    evr: 7.76.1-29.el9_4.3
+    sourcerpm: curl-7.76.1-29.el9_4.3.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/i/iputils-20210202-9.el9_4.5.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 177026
+    checksum: sha256:8e7249e4819c683f4f9f17b4d278441584a3daed545b6368fdb832a93643db76
+    name: iputils
+    evr: 20210202-9.el9_4.5
+    sourcerpm: iputils-20210202-9.el9_4.5.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/l/libibverbs-48.0-2.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 392239
+    checksum: sha256:52a99a10bd2de3438115ec40673cfe4fad0b0d0c71830ac2899df14fdc254baa
+    name: libibverbs
+    evr: 48.0-2.el9_4
+    sourcerpm: rdma-core-48.0-2.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/l/libnl3-3.9.0-1.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 353430
+    checksum: sha256:090a144acf174dbfe0c1b3379269fab71eab205041158713f0860930aee001e5
+    name: libnl3
+    evr: 3.9.0-1.el9
+    sourcerpm: libnl3-3.9.0-1.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/l/libpcap-1.10.0-4.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 172787
+    checksum: sha256:8eeed3015f2ea273202e6ae622a208a88758ee07dfa9a237fe7e2447646645a8
+    name: libpcap
+    evr: 14:1.10.0-4.el9
+    sourcerpm: libpcap-1.10.0-4.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/l/lksctp-tools-1.0.19-3.el9_4.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 103290
+    checksum: sha256:f9e9b208e6fd5e6bab5d6a30b56aeae7dce6d89bbdc218eec250e6df14d3dfe7
+    name: lksctp-tools
+    evr: 1.0.19-3.el9_4
+    sourcerpm: lksctp-tools-1.0.19-3.el9_4.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/l/lmdb-libs-0.9.29-3.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 65252
+    checksum: sha256:208717c21c3c8aee802a9437642dc4853368d268c4bd45ca8b0b781d409bb33c
+    name: lmdb-libs
+    evr: 0.9.29-3.el9
+    sourcerpm: lmdb-0.9.29-3.el9.src.rpm
+  - url: https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os/Packages/p/protobuf-c-1.3.3-13.el9.s390x.rpm
+    repoid: rhel-9-for-s390x-baseos-eus-rpms
+    size: 38450
+    checksum: sha256:0ba1d0bcbc80c2dc53fdac3eecf2606aab133ca22ba7cf857d720c78cb120782
+    name: protobuf-c
+    evr: 1.3.3-13.el9
+    sourcerpm: protobuf-c-1.3.3-13.el9.src.rpm
+  source: []
+  module_metadata: []
 - arch: x86_64
   packages:
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.x86_64.rpm

--- a/.rpm-lockfiles/nettest/submariner-rhel-9.repo
+++ b/.rpm-lockfiles/nettest/submariner-rhel-9.repo
@@ -5,8 +5,9 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 sslverify = 0
-sslclientcert = /etc/pki/entitlement/2713869142313201886.pem
-sslclientkey = /etc/pki/entitlement/2713869142313201886-key.pem
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem
+skip_if_unavailable = 1
 
 [rhel-9-for-$basearch-appstream-rpms]
 name = Red Hat Enterprise Linux 9 for $basearch - AppStream (RPMs)
@@ -15,5 +16,27 @@ enabled = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
 gpgcheck = 1
 sslverify = 0
-sslclientcert = /etc/pki/entitlement/2713869142313201886.pem
-sslclientkey = /etc/pki/entitlement/2713869142313201886-key.pem
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem
+skip_if_unavailable = 1
+
+# s390x requires EUS repos (standard RHEL 9 repos lack s390x in self-serve subscriptions)
+[rhel-9-for-s390x-baseos-eus-rpms]
+name = Red Hat Enterprise Linux 9 for s390x - BaseOS EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 0
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem
+
+[rhel-9-for-s390x-appstream-eus-rpms]
+name = Red Hat Enterprise Linux 9 for s390x - AppStream EUS (RPMs)
+baseurl = https://cdn.redhat.com/content/eus/rhel9/9.4/s390x/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 0
+sslclientcert = /etc/pki/entitlement/*.pem
+sslclientkey = /etc/pki/entitlement/*-key.pem

--- a/.tekton/nettest-0-19-pull-request.yaml
+++ b/.tekton/nettest-0-19-pull-request.yaml
@@ -31,6 +31,7 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/s390x
   - name: dockerfile
     value: package/Dockerfile.nettest.konflux
   - name: prefetch-input

--- a/.tekton/nettest-0-19-push.yaml
+++ b/.tekton/nettest-0-19-push.yaml
@@ -28,6 +28,7 @@ spec:
     value:
     - linux/x86_64
     - linux/arm64
+    - linux/s390x
   - name: dockerfile
     value: package/Dockerfile.nettest.konflux
   - name: prefetch-input


### PR DESCRIPTION
Standard RHEL 9 repos return 403 for s390x with self-serve subscriptions. EUS (Extended Update Support) repos are accessible and contain all required packages.

Changes:
- Add skip_if_unavailable=1 to standard repos (allows graceful fallback)
- Add s390x EUS BaseOS and AppStream repo entries
- Add s390x to rpms.in.yaml arches and regenerate lockfile
- Add linux/s390x to Tekton pipeline build-platforms

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IBM System z (s390x) architecture across build platforms and repository configurations, expanding system compatibility and deployment options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->