### PR TITLE
Reclaim storage after deploying OVN-K-enabled clusters

### DIFF
--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -281,6 +281,12 @@ data:
 EOF
 }
 
+function provider_succeeded() {
+    # At this stage we no longer need ovn-kubernetes,
+    # remove it to reclaim storage
+    rm -rf ovn-kubernetes
+}
+
 function provider_failed() {
     if [[ "$(cat /proc/sys/fs/inotify/max_user_instances)" -lt 512 ]]; then
         echo "Your inotify settings are lower than our recommendation."


### PR DESCRIPTION
The OVN-IC jobs are running out of storage, deleting the ovn-kubernetes clone should help.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added additional cleanup entries to the deployment workflow to remove a leftover ovn-kubernetes directory, reducing storage clutter and improving environment hygiene.
  * Cleanup was introduced in multiple locations without altering existing control flow or error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->