### PR TITLE
Configure Claude plugin for HTTPS distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,16 +4,21 @@
     "name": "Submariner Project",
     "url": "https://submariner.io"
   },
+  "metadata": {
+    "description": "Shared development tools and workflows for Submariner repositories"
+  },
   "plugins": [
     {
       "name": "shipyard",
-      "source": {
-        "source": "github",
-        "repo": "submariner-io/shipyard",
-        "ref": "devel"
-      },
       "description": "Shared development tools for Submariner repositories",
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "author": {
+        "name": "Submariner Contributors",
+        "url": "https://github.com/submariner-io"
+      },
+      "source": "./",
+      "category": "productivity",
+      "homepage": "https://submariner.io"
     }
   ]
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,9 +2,8 @@
   "extraKnownMarketplaces": {
     "submariner": {
       "source": {
-        "source": "github",
-        "repo": "submariner-io/shipyard",
-        "ref": "devel"
+        "source": "git",
+        "url": "https://github.com/submariner-io/shipyard.git"
       }
     }
   },


### PR DESCRIPTION
Updates plugin infrastructure to use git source with explicit HTTPS URLs, avoiding SSH prompts while supporting relative paths.

Changes:
- marketplace.json: Use relative path source, add metadata description, include version (best practice for relative-path plugins)
- settings.json: Use git source with HTTPS URL (self-reference)
- Follows official Anthropic plugin distribution patterns

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated marketplace configuration with enhanced plugin metadata, including author information, category classification, and homepage links for improved plugin discoverability and user experience.
  * Transitioned plugin source references from repository-based to Git-based URL configuration for improved source management and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->