### PR TITLE
Add support for OVN local GW mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ ifneq (,$(filter ovn-ic,$(USING)))
 export OVN_IC = true
 endif
 
+ifneq (,$(filter ovn-lgw,$(USING)))
+export OVN_LOCAL_GW = true
+endif
+
 export LAZY_DEPLOY = false
 
 scale: SETTINGS = $(DAPPER_SOURCE)/.shipyard.scale.yml

--- a/scripts/shared/lib/clusters_kind
+++ b/scripts/shared/lib/clusters_kind
@@ -211,6 +211,7 @@ function deploy_kind_ovn(){
 
     local ovn_flags=()
     [[ "$OVN_IC" != true ]] || ovn_flags=( -ic -npz 1 -wk 3 )
+    [[ "$OVN_LOCAL_GW" != true ]] || ovn_flags+=( -gm local )
 
     if [[ "$IPV6_STACK" ]]; then
         ovn_flags+=( -n4 -i6 -sw)


### PR DESCRIPTION
OVN-K's local gateway mode has different nftables configuration compared to shared gateway mode, affecting Submariner features like excluding SNAT.

This PR add 'ovn-lgw' flag to enable testing with local gateway mode

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local gateway mode in OVN deployments. When using the ovn-lgw configuration option, the system now enables local gateway functionality during cluster deployment and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->