### PR TITLE
Framework: propagate contexts

### DIFF
--- a/test/e2e/dataplane/tcp_connectivity.go
+++ b/test/e2e/dataplane/tcp_connectivity.go
@@ -20,6 +20,8 @@ limitations under the License.
 package dataplane
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/submariner-io/shipyard/test/e2e/framework"
 	"github.com/submariner-io/shipyard/test/e2e/tcp"
@@ -29,8 +31,8 @@ var _ = Describe("[dataplane] Basic TCP connectivity test", func() {
 	f := framework.NewFramework("dataplane")
 
 	When("a pod connects to another pod via TCP in the same cluster", func() {
-		It("should send the expected data to the other pod", func() {
-			tcp.RunConnectivityTest(&tcp.ConnectivityTestParams{
+		It("should send the expected data to the other pod", func(ctx context.Context) {
+			tcp.RunConnectivityTest(ctx, &tcp.ConnectivityTestParams{
 				Framework:             f,
 				ToEndpointType:        tcp.PodIP,
 				Networking:            framework.HostNetworking,

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -19,6 +19,7 @@ limitations under the License.
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -37,9 +38,9 @@ import (
 // This function takes two parameters: one function which runs on only the first Ginkgo node,
 // returning an opaque byte array, and then a second function which runs on all Ginkgo nodes,
 // accepting the byte array.
-var _ = SynchronizedBeforeSuite(func() []byte {
+var _ = SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	// Run only on Ginkgo node 1
-	framework.BeforeSuite()
+	framework.BeforeSuite(ctx)
 	return nil
 }, func(_ []byte) {
 	// Run on all Ginkgo nodes
@@ -49,11 +50,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 // Here, the order of functions is reversed; first, the function which runs everywhere,
 // and then the function that only runs on the first Ginkgo node.
 
-var _ = SynchronizedAfterSuite(func() {
+var _ = SynchronizedAfterSuite(func(ctx context.Context) {
 	// Run on all Ginkgo nodes
 
 	// framework.Logf("Running AfterSuite actions on all node")
-	framework.RunCleanupActions()
+	framework.RunCleanupActions(ctx)
 }, func() {
 	// Run only Ginkgo on node 1
 })

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -18,20 +18,23 @@ limitations under the License.
 
 package framework
 
-import "sync"
+import (
+	"context"
+	"sync"
+)
 
 // CleanupActionHandle is an integer pointer type for handling cleanup action.
 type CleanupActionHandle *int
 
 var (
 	cleanupActionsLock sync.Mutex
-	cleanupActions     = map[CleanupActionHandle]func(){}
+	cleanupActions     = map[CleanupActionHandle]func(ctx context.Context){}
 )
 
 // AddCleanupAction installs a function that will be called in the event of the
 // whole test being terminated.  This allows arbitrary pieces of the overall
 // test to hook into SynchronizedAfterSuite().
-func AddCleanupAction(fn func()) CleanupActionHandle {
+func AddCleanupAction(fn func(ctx context.Context)) CleanupActionHandle {
 	p := CleanupActionHandle(new(int))
 
 	cleanupActionsLock.Lock()
@@ -54,8 +57,8 @@ func RemoveCleanupAction(p CleanupActionHandle) {
 // RunCleanupActions runs all functions installed by AddCleanupAction.  It does
 // not remove them (see RemoveCleanupAction) but it does run unlocked, so they
 // may remove themselves.
-func RunCleanupActions() {
-	list := []func(){}
+func RunCleanupActions(ctx context.Context) {
+	list := []func(ctx context.Context){}
 
 	func() {
 		cleanupActionsLock.Lock()
@@ -68,6 +71,6 @@ func RunCleanupActions() {
 
 	// Run unlocked.
 	for _, fn := range list {
-		fn()
+		fn(ctx)
 	}
 }

--- a/test/e2e/framework/clusterglobalegressip.go
+++ b/test/e2e/framework/clusterglobalegressip.go
@@ -36,16 +36,16 @@ var clusterGlobalEgressIPGVR = &schema.GroupVersionResource{
 	Resource: "clusterglobalegressips",
 }
 
-func (f *Framework) AwaitClusterGlobalEgressIPs(cluster ClusterIndex, name string) []string {
+func (f *Framework) AwaitClusterGlobalEgressIPs(ctx context.Context, cluster ClusterIndex, name string) []string {
 	gipClient := clusterGlobalEgressIPClient(cluster)
 
-	return AwaitAllocatedEgressIPs(gipClient, name)
+	return awaitAllocatedEgressIPs(ctx, gipClient, name)
 }
 
-func AwaitAllocatedEgressIPs(client dynamic.ResourceInterface, name string) []string {
-	obj := AwaitUntil("await allocated egress IPs for "+name,
-		func() (*unstructured.Unstructured, error) {
-			resGip, err := client.Get(context.TODO(), name, metav1.GetOptions{})
+func awaitAllocatedEgressIPs(ctx context.Context, client dynamic.ResourceInterface, name string) []string {
+	obj := AwaitUntil(ctx, "await allocated egress IPs for "+name,
+		func(ctx context.Context) (*unstructured.Unstructured, error) {
+			resGip, err := client.Get(ctx, name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return nil, nil //nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}

--- a/test/e2e/framework/endpoints.go
+++ b/test/e2e/framework/endpoints.go
@@ -28,7 +28,8 @@ import (
 	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-func (f *Framework) CreateTCPEndpoints(cluster ClusterIndex, epName, portName, address string, port int32) *corev1.Endpoints {
+func (f *Framework) CreateTCPEndpoints(ctx context.Context, cluster ClusterIndex, epName, portName, address string, port int32,
+) *corev1.Endpoints {
 	endpointsSpec := corev1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: epName,
@@ -51,28 +52,28 @@ func (f *Framework) CreateTCPEndpoints(cluster ClusterIndex, epName, portName, a
 
 	ec := KubeClients[cluster].CoreV1().Endpoints(f.Namespace)
 
-	return createEndpoints(ec, &endpointsSpec)
+	return createEndpoints(ctx, ec, &endpointsSpec)
 }
 
-func createEndpoints(ec typedv1.EndpointsInterface, endpointsSpec *corev1.Endpoints) *corev1.Endpoints {
-	return AwaitUntil("create endpoints", func() (*corev1.Endpoints, error) {
-		ep, err := ec.Create(context.TODO(), endpointsSpec, metav1.CreateOptions{})
+func createEndpoints(ctx context.Context, ec typedv1.EndpointsInterface, endpointsSpec *corev1.Endpoints) *corev1.Endpoints {
+	return AwaitUntil(ctx, "create endpoints", func(ctx context.Context) (*corev1.Endpoints, error) {
+		ep, err := ec.Create(ctx, endpointsSpec, metav1.CreateOptions{})
 		if errors.IsAlreadyExists(err) {
-			err = ec.Delete(context.TODO(), endpointsSpec.Name, metav1.DeleteOptions{})
+			err = ec.Delete(ctx, endpointsSpec.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return nil, err
 			}
 
-			ep, err = ec.Create(context.TODO(), endpointsSpec, metav1.CreateOptions{})
+			ep, err = ec.Create(ctx, endpointsSpec, metav1.CreateOptions{})
 		}
 
 		return ep, err
 	}, NoopCheckResult)
 }
 
-func (f *Framework) DeleteEndpoints(cluster ClusterIndex, endpointsName string) {
+func (f *Framework) DeleteEndpoints(ctx context.Context, cluster ClusterIndex, endpointsName string) {
 	By(fmt.Sprintf("Deleting endpoints %q on %q", endpointsName, TestContext.ClusterIDs[cluster]))
-	AwaitUntil("delete endpoints", func() (any, error) {
-		return nil, KubeClients[cluster].CoreV1().Endpoints(f.Namespace).Delete(context.TODO(), endpointsName, metav1.DeleteOptions{})
+	AwaitUntil(ctx, "delete endpoints", func(ctx context.Context) (any, error) {
+		return nil, KubeClients[cluster].CoreV1().Endpoints(f.Namespace).Delete(ctx, endpointsName, metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }

--- a/test/e2e/framework/fips.go
+++ b/test/e2e/framework/fips.go
@@ -33,8 +33,8 @@ const (
 	fipsConfigMapName = "cluster-config-v1"
 )
 
-func DetectFIPSConfig(cluster ClusterIndex) (bool, error) {
-	configMap, err := KubeClients[cluster].CoreV1().ConfigMaps(fipsNamespace).Get(context.TODO(), fipsConfigMapName, metav1.GetOptions{})
+func DetectFIPSConfig(ctx context.Context, cluster ClusterIndex) (bool, error) {
+	configMap, err := KubeClients[cluster].CoreV1().ConfigMaps(fipsNamespace).Get(ctx, fipsConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil
@@ -46,9 +46,9 @@ func DetectFIPSConfig(cluster ClusterIndex) (bool, error) {
 	return strings.Contains(configMap.Data["install-config"], "fips: true"), nil
 }
 
-func (f *Framework) FindFIPSEnabledCluster() ClusterIndex {
+func (f *Framework) FindFIPSEnabledCluster(ctx context.Context) ClusterIndex {
 	for idx := range TestContext.ClusterIDs {
-		fipsEnabled, err := DetectFIPSConfig(ClusterIndex(idx))
+		fipsEnabled, err := DetectFIPSConfig(ctx, ClusterIndex(idx))
 		Expect(err).NotTo(HaveOccurred())
 
 		if fipsEnabled {
@@ -64,10 +64,9 @@ func verifyFIPSOutput(data string) bool {
 		strings.Contains(strings.ToLower(data), "fips mode enabled for pluto daemon")
 }
 
-func (f *Framework) TestGatewayNodeFIPSMode(cluster ClusterIndex, gwPod string) {
+func (f *Framework) TestGatewayNodeFIPSMode(ctx context.Context, cluster ClusterIndex, gwPod string) {
 	By(fmt.Sprintf("Verify FIPS mode is enabled on gateway pod %q", gwPod))
 
-	ctx := context.TODO()
 	cmd := []string{"ipsec", "pluto", "--selftest"}
 
 	stdOut, stdErr, err := f.ExecWithOptions(ctx, &ExecOptions{

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -78,7 +78,7 @@ const (
 	DualStack       IPFamilyType = "DualStack"
 )
 
-type PatchFunc func(pt types.PatchType, payload []byte) error
+type PatchFunc func(ctx context.Context, pt types.PatchType, payload []byte) error
 
 type PatchStringValue struct {
 	Op    string `json:"op"`
@@ -93,7 +93,7 @@ type PatchUInt32Value struct {
 }
 
 type (
-	DoOperationFunc[T any] func() (T, error)
+	DoOperationFunc[T any] func(context.Context) (T, error)
 	CheckResultFunc[T any] func(result T) (bool, string, error)
 )
 
@@ -178,7 +178,7 @@ func init() {
 	}
 }
 
-func BeforeSuite() {
+func BeforeSuite(ctx context.Context) {
 	By("Creating kubernetes clients")
 
 	if len(RestConfigs) == 0 {
@@ -214,7 +214,7 @@ func BeforeSuite() {
 		DynClients = append(DynClients, createDynamicClient(restConfig))
 	}
 
-	fetchClusterIDs()
+	fetchClusterIDs(ctx)
 
 	err := mcsv1a1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
@@ -258,7 +258,7 @@ func initPodSecurityContext() {
 	}
 }
 
-func (f *Framework) BeforeEach() {
+func (f *Framework) BeforeEach(ctx context.Context) {
 	if !f.SkipNamespaceCreation {
 		By(fmt.Sprintf("Creating namespace objects with basename %q", f.BaseName))
 
@@ -271,7 +271,7 @@ func (f *Framework) BeforeEach() {
 		for idx, clientSet := range KubeClients {
 			if ClusterIndex(idx) == ClusterA {
 				// On the first cluster we let k8s generate a name for the namespace
-				namespace := generateNamespace(clientSet, f.BaseName, namespaceLabels)
+				namespace := generateNamespace(ctx, clientSet, f.BaseName, namespaceLabels)
 				f.Namespace = namespace.GetName()
 				f.UniqueName = namespace.GetName()
 				f.AddNamespacesToDelete(namespace)
@@ -279,7 +279,7 @@ func (f *Framework) BeforeEach() {
 			} else {
 				// On the other clusters we use the same name to make tracing easier
 				By(fmt.Sprintf("Creating namespace %q in cluster %q", f.Namespace, TestContext.ClusterIDs[idx]))
-				f.CreateNamespace(clientSet, f.Namespace, namespaceLabels)
+				f.CreateNamespace(ctx, clientSet, f.Namespace, namespaceLabels)
 			}
 		}
 	} else {
@@ -287,15 +287,15 @@ func (f *Framework) BeforeEach() {
 	}
 }
 
-func DetectGlobalnet() {
+func DetectGlobalnet(ctx context.Context) {
 	clusters := DynClients[ClusterA].Resource(schema.GroupVersionResource{
 		Group:    "submariner.io",
 		Version:  "v1",
 		Resource: "clusters",
 	}).Namespace(TestContext.SubmarinerNamespace)
 
-	AwaitUntil("find Clusters to detect if Globalnet is enabled", func() (*unstructured.UnstructuredList, error) {
-		return clusters.List(context.TODO(), metav1.ListOptions{})
+	AwaitUntil(ctx, "find Clusters to detect if Globalnet is enabled", func(ctx context.Context) (*unstructured.UnstructuredList, error) {
+		return clusters.List(ctx, metav1.ListOptions{})
 	}, func(result *unstructured.UnstructuredList) (bool, string, error) {
 		if result == nil || len(result.Items) == 0 {
 			return false, "No Cluster found", nil
@@ -316,11 +316,11 @@ func DetectGlobalnet() {
 	})
 }
 
-func InitNumClusterNodes() error {
+func InitNumClusterNodes(ctx context.Context) error {
 	TestContext.NumNodesInCluster = map[ClusterIndex]int{}
 
 	for i := range KubeClients {
-		nodes, err := KubeClients[i].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		nodes, err := KubeClients[i].CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return err
 		}
@@ -331,16 +331,17 @@ func InitNumClusterNodes() error {
 	return nil
 }
 
-func fetchClusterIDs() {
+func fetchClusterIDs(ctx context.Context) {
 	for i := range KubeClients {
-		gatewayNodes := FindGatewayNodes(ClusterIndex(i))
+		gatewayNodes := FindGatewayNodes(ctx, ClusterIndex(i))
 		if len(gatewayNodes) == 0 {
 			continue
 		}
 
 		name := "submariner-gateway"
-		daemonSet := AwaitUntil(fmt.Sprintf("find %s DaemonSet for %q", name, TestContext.ClusterIDs[i]), func() (*appsv1.DaemonSet, error) {
-			ds, err := KubeClients[i].AppsV1().DaemonSets(TestContext.SubmarinerNamespace).Get(context.TODO(), name, metav1.GetOptions{})
+		daemonSet := AwaitUntil(ctx, fmt.Sprintf("find %s DaemonSet for %q", name, TestContext.ClusterIDs[i]), func(ctx context.Context,
+		) (*appsv1.DaemonSet, error) {
+			ds, err := KubeClients[i].AppsV1().DaemonSets(TestContext.SubmarinerNamespace).Get(ctx, name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return nil, nil //nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 			}
@@ -421,12 +422,12 @@ func createRestConfig(kubeConfig, kubeContext string) *rest.Config {
 	return restConfig
 }
 
-func deleteNamespace(client kubeclientset.Interface, namespaceName string) error {
-	return client.CoreV1().Namespaces().Delete(context.TODO(), namespaceName, metav1.DeleteOptions{})
+func deleteNamespace(ctx context.Context, client kubeclientset.Interface, namespaceName string) error {
+	return client.CoreV1().Namespaces().Delete(ctx, namespaceName, metav1.DeleteOptions{})
 }
 
 // AfterEach deletes the namespace, after reading its events.
-func (f *Framework) AfterEach() {
+func (f *Framework) AfterEach(ctx context.Context) {
 	f.stopped = true
 	RemoveCleanupAction(f.cleanupHandle)
 
@@ -436,7 +437,7 @@ func (f *Framework) AfterEach() {
 	// if delete-namespace set to false, namespace will always be preserved.
 	// if delete-namespace is true and delete-namespace-on-failure is false, namespace will be preserved if test failed.
 	for ns := range f.namespacesToDelete {
-		if err := f.deleteNamespaceFromAllClusters(ns); err != nil {
+		if err := f.deleteNamespaceFromAllClusters(ctx, ns); err != nil {
 			nsDeletionErrors = append(nsDeletionErrors, err)
 		}
 
@@ -453,10 +454,10 @@ func (f *Framework) AfterEach() {
 }
 
 // CreateNamespace creates a namespace for e2e testing.
-func (f *Framework) CreateNamespace(clientSet *kubeclientset.Clientset,
+func (f *Framework) CreateNamespace(ctx context.Context, clientSet *kubeclientset.Clientset,
 	baseName string, labels map[string]string,
 ) *corev1.Namespace {
-	ns := createTestNamespace(clientSet, baseName, labels)
+	ns := createTestNamespace(ctx, clientSet, baseName, labels)
 	f.AddNamespacesToDelete(ns)
 
 	return ns
@@ -472,13 +473,13 @@ func (f *Framework) AddNamespacesToDelete(namespaces ...*corev1.Namespace) {
 	}
 }
 
-func (f *Framework) DetermineIPFamilyType(cluster ClusterIndex) IPFamilyType {
+func (f *Framework) DetermineIPFamilyType(ctx context.Context, cluster ClusterIndex) IPFamilyType {
 	ipFamilyType, ok := f.ipFamilyTypes[cluster]
 	if ok {
 		return ipFamilyType
 	}
 
-	svc, err := KubeClients[cluster].CoreV1().Services(f.Namespace).Create(context.TODO(), &corev1.Service{
+	svc, err := KubeClients[cluster].CoreV1().Services(f.Namespace).Create(ctx, &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-ip-families"},
 		Spec: corev1.ServiceSpec{
 			Type:           corev1.ServiceTypeClusterIP,
@@ -502,19 +503,19 @@ func (f *Framework) DetermineIPFamilyType(cluster ClusterIndex) IPFamilyType {
 
 	f.ipFamilyTypes[cluster] = ipFamilyType
 
-	err = KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(context.TODO(), svc.Name, metav1.DeleteOptions{})
+	err = KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(ctx, svc.Name, metav1.DeleteOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	return ipFamilyType
 }
 
-func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {
+func (f *Framework) deleteNamespaceFromAllClusters(ctx context.Context, ns string) error {
 	var errs []error
 
 	for i, clientSet := range KubeClients {
 		By(fmt.Sprintf("Deleting namespace %q on cluster %q", ns, TestContext.ClusterIDs[i]))
 
-		if err := deleteNamespace(clientSet, ns); err != nil {
+		if err := deleteNamespace(ctx, clientSet, ns); err != nil {
 			switch {
 			case apierrors.IsNotFound(err):
 				Logf("Namespace %q was already deleted", ns)
@@ -529,7 +530,7 @@ func (f *Framework) deleteNamespaceFromAllClusters(ns string) error {
 	return goerrors.Join(errs...)
 }
 
-func generateNamespace(client kubeclientset.Interface, baseName string, labels map[string]string) *corev1.Namespace {
+func generateNamespace(ctx context.Context, client kubeclientset.Interface, baseName string, labels map[string]string) *corev1.Namespace {
 	namespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("e2e-tests-%v-", baseName),
@@ -537,18 +538,18 @@ func generateNamespace(client kubeclientset.Interface, baseName string, labels m
 		},
 	}
 
-	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
+	namespace, err := client.CoreV1().Namespaces().Create(ctx, namespaceObj, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Error generating namespace %v", namespaceObj)
 
 	return namespace
 }
 
-func createTestNamespace(client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
-	namespace := createNamespace(client, name, labels)
+func createTestNamespace(ctx context.Context, client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
+	namespace := createNamespace(ctx, client, name, labels)
 	return namespace
 }
 
-func createNamespace(client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
+func createNamespace(ctx context.Context, client kubeclientset.Interface, name string, labels map[string]string) *corev1.Namespace {
 	namespaceObj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -556,40 +557,40 @@ func createNamespace(client kubeclientset.Interface, name string, labels map[str
 		},
 	}
 
-	namespace, err := client.CoreV1().Namespaces().Create(context.TODO(), namespaceObj, metav1.CreateOptions{})
+	namespace, err := client.CoreV1().Namespaces().Create(ctx, namespaceObj, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred(), "Error creating namespace %v", namespaceObj)
 
 	return namespace
 }
 
 // PatchString performs a REST patch operation for the given path and string value.
-func PatchString(path, value string, patchFunc PatchFunc) {
+func PatchString(ctx context.Context, path, value string, patchFunc PatchFunc) {
 	payload := []PatchStringValue{{
 		Op:    "add",
 		Path:  path,
 		Value: value,
 	}}
 
-	doPatchOperation(payload, patchFunc)
+	doPatchOperation(ctx, payload, patchFunc)
 }
 
 // PatchInt performs a REST patch operation for the given path and int value.
-func PatchInt(path string, value uint32, patchFunc PatchFunc) {
+func PatchInt(ctx context.Context, path string, value uint32, patchFunc PatchFunc) {
 	payload := []PatchUInt32Value{{
 		Op:    "add",
 		Path:  path,
 		Value: value,
 	}}
 
-	doPatchOperation(payload, patchFunc)
+	doPatchOperation(ctx, payload, patchFunc)
 }
 
-func doPatchOperation(payload any, patchFunc PatchFunc) {
+func doPatchOperation(ctx context.Context, payload any, patchFunc PatchFunc) {
 	payloadBytes, err := json.Marshal(payload)
 	Expect(err).NotTo(HaveOccurred())
 
-	AwaitUntil("perform patch operation", func() (*unstructured.Unstructured, error) {
-		return nil, patchFunc(types.JSONPatchType, payloadBytes)
+	AwaitUntil(ctx, "perform patch operation", func(ctx context.Context) (any, error) {
+		return nil, patchFunc(ctx, types.JSONPatchType, payloadBytes)
 	}, NoopCheckResult)
 }
 
@@ -599,19 +600,20 @@ func NoopCheckResult[T any](T) (bool, string, error) {
 
 // AwaitUntil periodically performs the given operation until the given CheckResultFunc returns true, an error, or a
 // timeout is reached.
-func AwaitUntil[T any](opMsg string, doOperation DoOperationFunc[T], checkResult CheckResultFunc[T]) T {
-	result, errMsg, err := AwaitResultOrError(opMsg, doOperation, checkResult)
+func AwaitUntil[T any](ctx context.Context, opMsg string, doOperation DoOperationFunc[T], checkResult CheckResultFunc[T]) T {
+	result, errMsg, err := AwaitResultOrError(ctx, opMsg, doOperation, checkResult)
 	Expect(err).NotTo(HaveOccurred(), errMsg)
 
 	return result
 }
 
-func AwaitResultOrError[T any](opMsg string, doOperation DoOperationFunc[T], checkResult CheckResultFunc[T]) (T, string, error) {
+func AwaitResultOrError[T any](ctx context.Context, opMsg string, doOperation DoOperationFunc[T], checkResult CheckResultFunc[T],
+) (T, string, error) {
 	var finalResult T
 	var lastMsg string
-	err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond, TestContext.OperationTimeoutToDuration(), true,
-		func(_ context.Context) (bool, error) {
-			result, err := doOperation()
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, TestContext.OperationTimeoutToDuration(), true,
+		func(ctx context.Context) (bool, error) {
+			result, err := doOperation(ctx)
 			if err != nil {
 				if IsTransientError(err, opMsg) {
 					return false, nil

--- a/test/e2e/framework/gateways.go
+++ b/test/e2e/framework/gateways.go
@@ -37,22 +37,22 @@ var gatewayGVR = &schema.GroupVersionResource{
 	Resource: "gateways",
 }
 
-func findGateway(cluster ClusterIndex, name string) (*unstructured.Unstructured, error) {
+func findGateway(ctx context.Context, cluster ClusterIndex, name string) (*unstructured.Unstructured, error) {
 	gwClient := gatewayClient(cluster)
-	resGw, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
+	resGw, err := gwClient.Get(ctx, name, metav1.GetOptions{})
 
 	if apierrors.IsNotFound(err) {
 		// Some environments sets a node in Gateway resource without a suffix
-		resGw, err = gwClient.Get(context.TODO(), strings.Split(name, ".")[0], metav1.GetOptions{})
+		resGw, err = gwClient.Get(ctx, strings.Split(name, ".")[0], metav1.GetOptions{})
 	}
 
 	return resGw, err
 }
 
-func (f *Framework) AwaitGatewayWithStatus(cluster ClusterIndex, name, status string) *unstructured.Unstructured {
-	return AwaitUntil(fmt.Sprintf("await Gateway on %q with status %q", name, status),
-		func() (*unstructured.Unstructured, error) {
-			gw, err := findGateway(cluster, name)
+func (f *Framework) AwaitGatewayWithStatus(ctx context.Context, cluster ClusterIndex, name, status string) *unstructured.Unstructured {
+	return AwaitUntil(ctx, fmt.Sprintf("await Gateway on %q with status %q", name, status),
+		func(ctx context.Context) (*unstructured.Unstructured, error) {
+			gw, err := findGateway(ctx, cluster, name)
 			if apierrors.IsNotFound(err) {
 				return nil, nil
 			}
@@ -78,10 +78,10 @@ func gatewayClient(cluster ClusterIndex) dynamic.ResourceInterface {
 	return DynClients[cluster].Resource(*gatewayGVR).Namespace(TestContext.SubmarinerNamespace)
 }
 
-func (f *Framework) AwaitGatewaysWithStatus(cluster ClusterIndex, status string) []unstructured.Unstructured {
-	return AwaitUntil(fmt.Sprintf("await Gateways with status %q", status),
-		func() ([]unstructured.Unstructured, error) {
-			return f.GetGatewaysWithHAStatus(cluster, status), nil
+func (f *Framework) AwaitGatewaysWithStatus(ctx context.Context, cluster ClusterIndex, status string) []unstructured.Unstructured {
+	return AwaitUntil(ctx, fmt.Sprintf("await Gateways with status %q", status),
+		func(ctx context.Context) ([]unstructured.Unstructured, error) {
+			return f.GetGatewaysWithHAStatus(ctx, cluster, status), nil
 		},
 		func(gateways []unstructured.Unstructured) (bool, string, error) {
 			if len(gateways) == 0 {
@@ -92,12 +92,12 @@ func (f *Framework) AwaitGatewaysWithStatus(cluster ClusterIndex, status string)
 		})
 }
 
-func (f *Framework) AwaitGatewayRemoved(cluster ClusterIndex, name string) {
+func (f *Framework) AwaitGatewayRemoved(ctx context.Context, cluster ClusterIndex, name string) {
 	gwClient := gatewayClient(cluster)
 
-	AwaitUntil(fmt.Sprintf("await Gateway on %q removed", name),
-		func() (bool, error) {
-			_, err := gwClient.Get(context.TODO(), name, metav1.GetOptions{})
+	AwaitUntil(ctx, fmt.Sprintf("await Gateway on %q removed", name),
+		func(ctx context.Context) (bool, error) {
+			_, err := gwClient.Get(ctx, name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}
@@ -109,10 +109,10 @@ func (f *Framework) AwaitGatewayRemoved(cluster ClusterIndex, name string) {
 		})
 }
 
-func (f *Framework) AwaitGatewayFullyConnected(cluster ClusterIndex, name string) *unstructured.Unstructured {
-	return AwaitUntil(fmt.Sprintf("await Gateway on %q with status active and connections UP", name),
-		func() (*unstructured.Unstructured, error) {
-			gw, err := findGateway(cluster, name)
+func (f *Framework) AwaitGatewayFullyConnected(ctx context.Context, cluster ClusterIndex, name string) *unstructured.Unstructured {
+	return AwaitUntil(ctx, fmt.Sprintf("await Gateway on %q with status active and connections UP", name),
+		func(ctx context.Context) (*unstructured.Unstructured, error) {
+			gw, err := findGateway(ctx, cluster, name)
 			if apierrors.IsNotFound(err) {
 				return nil, nil
 			}
@@ -151,10 +151,10 @@ func (f *Framework) AwaitGatewayFullyConnected(cluster ClusterIndex, name string
 }
 
 func (f *Framework) GetGatewaysWithHAStatus(
-	cluster ClusterIndex, status string,
+	ctx context.Context, cluster ClusterIndex, status string,
 ) []unstructured.Unstructured {
 	gwClient := gatewayClient(cluster)
-	gwList, err := gwClient.List(context.TODO(), metav1.ListOptions{})
+	gwList, err := gwClient.List(ctx, metav1.ListOptions{})
 
 	filteredGateways := []unstructured.Unstructured{}
 
@@ -175,9 +175,9 @@ func (f *Framework) GetGatewaysWithHAStatus(
 	return filteredGateways
 }
 
-func (f *Framework) DeleteGateway(cluster ClusterIndex, name string) {
-	AwaitUntil("delete gateway", func() (any, error) {
-		err := gatewayClient(cluster).Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (f *Framework) DeleteGateway(ctx context.Context, cluster ClusterIndex, name string) {
+	AwaitUntil(ctx, "delete gateway", func(ctx context.Context) (any, error) {
+		err := gatewayClient(cluster).Delete(ctx, name, metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			return nil, nil //nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 		}
@@ -193,9 +193,7 @@ func (f *Framework) SaveGatewayNode(cluster ClusterIndex, gwNode string) {
 // GatewayCleanup will be executed only on kind environment.
 // It will restore the gateway nodes to its initial state.
 // Other environments do not need any gw cleanup as MachineSet is responsible to keeping the gw nodes in active states.
-func (f *Framework) GatewayCleanup() {
-	ctx := context.TODO()
-
+func (f *Framework) GatewayCleanup(ctx context.Context) {
 	for cluster := range f.gatewayNodesToReset {
 		for _, gnode := range f.gatewayNodesToReset[cluster] {
 			By(fmt.Sprintf("Restoring gateway %q on cluster %q", gnode, TestContext.ClusterIDs[cluster]))

--- a/test/e2e/framework/globalegressip.go
+++ b/test/e2e/framework/globalegressip.go
@@ -38,11 +38,11 @@ func globalEgressIPClient(cluster ClusterIndex, namespace string) dynamic.Resour
 	return DynClients[cluster].Resource(*globalEgressIPGVR).Namespace(namespace)
 }
 
-func CreateGlobalEgressIP(cluster ClusterIndex, obj *unstructured.Unstructured) error {
+func CreateGlobalEgressIP(ctx context.Context, cluster ClusterIndex, obj *unstructured.Unstructured) error {
 	geipClient := globalEgressIPClient(cluster, obj.GetNamespace())
 
-	AwaitUntil("create GlobalEgressIP", func() (*unstructured.Unstructured, error) {
-		egressIP, err := geipClient.Create(context.TODO(), obj, metav1.CreateOptions{})
+	AwaitUntil(ctx, "create GlobalEgressIP", func(ctx context.Context) (*unstructured.Unstructured, error) {
+		egressIP, err := geipClient.Create(ctx, obj, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
 			err = nil
 		}
@@ -53,8 +53,8 @@ func CreateGlobalEgressIP(cluster ClusterIndex, obj *unstructured.Unstructured) 
 	return nil
 }
 
-func AwaitGlobalEgressIPs(cluster ClusterIndex, name, namespace string) []string {
+func AwaitGlobalEgressIPs(ctx context.Context, cluster ClusterIndex, name, namespace string) []string {
 	gipClient := globalEgressIPClient(cluster, namespace)
 
-	return AwaitAllocatedEgressIPs(gipClient, name)
+	return awaitAllocatedEgressIPs(ctx, gipClient, name)
 }

--- a/test/e2e/framework/globalingressips.go
+++ b/test/e2e/framework/globalingressips.go
@@ -35,12 +35,12 @@ var globalIngressIPGVR = &schema.GroupVersionResource{
 	Resource: "globalingressips",
 }
 
-func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace string) string {
+func (f *Framework) AwaitGlobalIngressIP(ctx context.Context, cluster ClusterIndex, name, namespace string) string {
 	if TestContext.GlobalnetEnabled {
 		gipClient := globalIngressIPClient(cluster, namespace)
-		obj := AwaitUntil(fmt.Sprintf("await GlobalIngressIP %s/%s", namespace, name),
-			func() (*unstructured.Unstructured, error) {
-				resGip, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
+		obj := AwaitUntil(ctx, fmt.Sprintf("await GlobalIngressIP %s/%s", namespace, name),
+			func(ctx context.Context) (*unstructured.Unstructured, error) {
+				resGip, err := gipClient.Get(ctx, name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					return nil, nil //nolint:nilnil // We want to repeat but let the checker known that nothing was found.
 				}
@@ -67,11 +67,11 @@ func (f *Framework) AwaitGlobalIngressIP(cluster ClusterIndex, name, namespace s
 	return ""
 }
 
-func (f *Framework) AwaitGlobalIngressIPRemoved(cluster ClusterIndex, name, namespace string) {
+func (f *Framework) AwaitGlobalIngressIPRemoved(ctx context.Context, cluster ClusterIndex, name, namespace string) {
 	gipClient := globalIngressIPClient(cluster, namespace)
-	AwaitUntil(fmt.Sprintf("await GlobalIngressIP %s/%s removed", namespace, name),
-		func() (bool, error) {
-			_, err := gipClient.Get(context.TODO(), name, metav1.GetOptions{})
+	AwaitUntil(ctx, fmt.Sprintf("await GlobalIngressIP %s/%s removed", namespace, name),
+		func(ctx context.Context) (bool, error) {
+			_, err := gipClient.Get(ctx, name, metav1.GetOptions{})
 			if apierrors.IsNotFound(err) {
 				return true, nil
 			}

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -97,7 +97,7 @@ const (
 	TestPort = 1234
 )
 
-func (f *Framework) NewNetworkPod(config *NetworkPodConfig) *NetworkPod {
+func (f *Framework) NewNetworkPod(ctx context.Context, config *NetworkPodConfig) *NetworkPod {
 	// check if all necessary details are provided
 	Expect(config.Scheduling).ShouldNot(Equal(InvalidScheduling))
 	Expect(config.Type).ShouldNot(Equal(InvalidPodType))
@@ -121,19 +121,19 @@ func (f *Framework) NewNetworkPod(config *NetworkPodConfig) *NetworkPod {
 
 	switch config.Type {
 	case ListenerPod:
-		networkPod.buildTCPCheckListenerPod()
+		networkPod.buildTCPCheckListenerPod(ctx)
 	case ConnectorPod:
-		networkPod.buildTCPCheckConnectorPod()
+		networkPod.buildTCPCheckConnectorPod(ctx)
 	case ThroughputClientPod:
-		networkPod.buildThroughputClientPod()
+		networkPod.buildThroughputClientPod(ctx)
 	case ThroughputServerPod:
-		networkPod.buildThroughputServerPod()
+		networkPod.buildThroughputServerPod(ctx)
 	case LatencyClientPod:
-		networkPod.buildLatencyClientPod()
+		networkPod.buildLatencyClientPod(ctx)
 	case LatencyServerPod:
-		networkPod.buildLatencyServerPod()
+		networkPod.buildLatencyServerPod(ctx)
 	case CustomPod:
-		networkPod.buildCustomPod()
+		networkPod.buildCustomPod(ctx)
 	case InvalidPodType:
 		panic("config.Type can't equal InvalidPodType here, we checked above")
 	}
@@ -155,11 +155,11 @@ func (np *NetworkPod) GetIP() string {
 	return ""
 }
 
-func (np *NetworkPod) AwaitReady() {
+func (np *NetworkPod) AwaitReady(ctx context.Context) {
 	pods := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
-	np.Pod = AwaitUntil("await pod ready", func() (*v1.Pod, error) {
-		return pods.Get(context.TODO(), np.Pod.Name, metav1.GetOptions{})
+	np.Pod = AwaitUntil(ctx, "await pod ready", func(ctx context.Context) (*v1.Pod, error) {
+		return pods.Get(ctx, np.Pod.Name, metav1.GetOptions{})
 	}, func(pod *v1.Pod) (bool, string, error) {
 		if pod.Status.Phase != v1.PodRunning {
 			if pod.Status.Phase != v1.PodPending {
@@ -175,16 +175,16 @@ func (np *NetworkPod) AwaitReady() {
 	})
 }
 
-func (np *NetworkPod) AwaitFinish() {
-	np.AwaitFinishVerbose(true)
+func (np *NetworkPod) AwaitFinish(ctx context.Context) {
+	np.AwaitFinishVerbose(ctx, true)
 }
 
-func (np *NetworkPod) AwaitFinishVerbose(verbose bool) {
+func (np *NetworkPod) AwaitFinishVerbose(ctx context.Context, verbose bool) {
 	pods := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
-	_, np.TerminationErrorMsg, np.TerminationError = AwaitResultOrError(fmt.Sprintf("await pod %q finished", np.Pod.Name),
-		func() (any, error) {
-			return pods.Get(context.TODO(), np.Pod.Name, metav1.GetOptions{})
+	_, np.TerminationErrorMsg, np.TerminationError = AwaitResultOrError(ctx, fmt.Sprintf("await pod %q finished", np.Pod.Name),
+		func(ctx context.Context) (any, error) {
+			return pods.Get(ctx, np.Pod.Name, metav1.GetOptions{})
 		}, func(result any) (bool, string, error) {
 			np.Pod = result.(*v1.Pod)
 
@@ -211,14 +211,14 @@ func (np *NetworkPod) CheckSuccessfulFinish() {
 	Expect(np.TerminationCode).To(Equal(int32(0)))
 }
 
-func (np *NetworkPod) CreateService() *v1.Service {
+func (np *NetworkPod) CreateService(ctx context.Context) *v1.Service {
 	ipFamily := v1.IPv4Protocol
 
 	if np.Config.IsIPv6 {
 		ipFamily = v1.IPv6Protocol
 	}
 
-	return np.framework.CreateTCPServiceWithIPFamily(np.Config.Cluster, np.Pod.Labels[TestAppLabel], np.Config.Port, &ipFamily)
+	return np.framework.CreateTCPServiceWithIPFamily(ctx, np.Config.Cluster, np.Pod.Labels[TestAppLabel], np.Config.Port, &ipFamily)
 }
 
 // RunCommand run the specified command in this NetworkPod.
@@ -257,10 +257,10 @@ func (np *NetworkPod) RunCommand(ctx context.Context, cmd []string) (string, str
 }
 
 // GetLog returns container log from this NetworkPod.
-func (np *NetworkPod) GetLog() string {
+func (np *NetworkPod) GetLog(ctx context.Context) string {
 	req := KubeClients[np.Config.Cluster].CoreV1().Pods(np.Pod.Namespace).GetLogs(np.Pod.Name, &v1.PodLogOptions{})
 
-	closer, err := req.Stream(context.TODO())
+	closer, err := req.Stream(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	defer closer.Close()
@@ -276,7 +276,7 @@ func (np *NetworkPod) GetLog() string {
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will listen on TestPort over TCP, send sendString over the connection,
 // and write the network response in the pod  termination log, then exit with 0 status.
-func (np *NetworkPod) buildTCPCheckListenerPod() {
+func (np *NetworkPod) buildTCPCheckListenerPod(ctx context.Context) {
 	listenAddress := "0.0.0.0"
 	if np.Config.IsIPv6 {
 		listenAddress = "::"
@@ -296,7 +296,7 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -324,16 +324,16 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &tcpCheckListenerPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &tcpCheckListenerPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will connect to remoteIP:TestPort over TCP, send sendString over the
 // connection, and write the network response in the pod termination log, then
 // exit with 0 status.
-func (np *NetworkPod) buildTCPCheckConnectorPod() {
+func (np *NetworkPod) buildTCPCheckConnectorPod(ctx context.Context) {
 	ncCmd := "nc -v"
 	if np.Config.IsIPv6 {
 		ncCmd = "nc -6 -v"
@@ -354,7 +354,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			HostNetwork:   bool(np.Config.Networking),
 			Containers: []v1.Container{
@@ -386,7 +386,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &tcpCheckConnectorPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &tcpCheckConnectorPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -394,7 +394,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 // The pod will initiate iperf3 throughput test to remoteIP and write the test
 // response in the pod termination log, then
 // exit with 0 status.
-func (np *NetworkPod) buildThroughputClientPod() {
+func (np *NetworkPod) buildThroughputClientPod(ctx context.Context) {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "nettest-client-pod",
@@ -403,7 +403,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -432,14 +432,14 @@ func (np *NetworkPod) buildThroughputClientPod() {
 	}
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &nettestPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &nettestPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will start iperf3 in server mode.
-func (np *NetworkPod) buildThroughputServerPod() {
+func (np *NetworkPod) buildThroughputServerPod(ctx context.Context) {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "nettest-server-pod",
@@ -448,7 +448,7 @@ func (np *NetworkPod) buildThroughputServerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -467,16 +467,16 @@ func (np *NetworkPod) buildThroughputServerPod() {
 	}
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &nettestPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &nettestPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will initiate netperf latency test to remoteIP and write the test
 // response in the pod termination log, then
 // exit with 0 status.
-func (np *NetworkPod) buildLatencyClientPod() {
+func (np *NetworkPod) buildLatencyClientPod(ctx context.Context) {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "latency-client-pod",
@@ -485,7 +485,7 @@ func (np *NetworkPod) buildLatencyClientPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -509,14 +509,14 @@ func (np *NetworkPod) buildLatencyClientPod() {
 	}
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &nettestPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &nettestPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will start netserver (server of netperf).
-func (np *NetworkPod) buildLatencyServerPod() {
+func (np *NetworkPod) buildLatencyServerPod(ctx context.Context) {
 	nettestPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "latency-server-pod",
@@ -525,7 +525,7 @@ func (np *NetworkPod) buildLatencyServerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
@@ -541,14 +541,14 @@ func (np *NetworkPod) buildLatencyServerPod() {
 	}
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &nettestPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &nettestPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
 // create a test pod inside the current test namespace on the specified cluster.
 // The pod will use the image specified and run command specified.
-func (np *NetworkPod) buildCustomPod() {
+func (np *NetworkPod) buildCustomPod(ctx context.Context) {
 	terminationGracePeriodSeconds := int64(5)
 	customPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -558,7 +558,7 @@ func (np *NetworkPod) buildCustomPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:                      np.nodeAffinity(np.Config.Scheduling),
+			Affinity:                      np.nodeAffinity(ctx, np.Config.Scheduling),
 			RestartPolicy:                 v1.RestartPolicyNever,
 			HostNetwork:                   bool(np.Config.Networking),
 			TerminationGracePeriodSeconds: &terminationGracePeriodSeconds,
@@ -578,31 +578,31 @@ func (np *NetworkPod) buildCustomPod() {
 	pc := KubeClients[np.Config.Cluster].CoreV1().Pods(np.framework.Namespace)
 
 	var err error
-	np.Pod, err = pc.Create(context.TODO(), &customPod, metav1.CreateOptions{})
+	np.Pod, err = pc.Create(ctx, &customPod, metav1.CreateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	np.AwaitReady()
+	np.AwaitReady(ctx)
 }
 
-func (np *NetworkPod) nodeAffinity(scheduling NetworkPodScheduling) *v1.Affinity {
+func (np *NetworkPod) nodeAffinity(ctx context.Context, scheduling NetworkPodScheduling) *v1.Affinity {
 	Expect(scheduling).ShouldNot(Equal(InvalidScheduling))
 
 	var nodeSelTerms []v1.NodeSelectorTerm
 
 	switch scheduling {
 	case GatewayNode:
-		hostname := np.activeGatewayHostname()
+		hostname := np.activeGatewayHostname(ctx)
 		nodeSelTerms = addNodeSelectorTerm(nodeSelTerms, "kubernetes.io/hostname", v1.NodeSelectorOpIn, []string{hostname})
 
 	case NonGatewayNode:
-		smE2eNonGWLabelledNodeList, err := KubeClients[np.Config.Cluster].CoreV1().Nodes().List(context.TODO(),
+		smE2eNonGWLabelledNodeList, err := KubeClients[np.Config.Cluster].CoreV1().Nodes().List(ctx,
 			metav1.ListOptions{LabelSelector: TestNonGWNodeLabel})
 		Expect(err).NotTo(HaveOccurred())
 
 		nonGWNodes := []string{}
 
 		if len(smE2eNonGWLabelledNodeList.Items) > 0 {
-			activeGWHostname := np.activeGatewayHostname()
+			activeGWHostname := np.activeGatewayHostname(ctx)
 
 			for i := range smE2eNonGWLabelledNodeList.Items {
 				hostname := smE2eNonGWLabelledNodeList.Items[i].GetObjectMeta().GetLabels()["kubernetes.io/hostname"]
@@ -637,10 +637,10 @@ func (np *NetworkPod) nodeAffinity(scheduling NetworkPodScheduling) *v1.Affinity
 	}
 }
 
-func (np *NetworkPod) activeGatewayHostname() string {
-	smGWPodList := AwaitUntil("await active gateway Pod",
-		func() (*v1.PodList, error) {
-			return KubeClients[np.Config.Cluster].CoreV1().Pods(TestContext.SubmarinerNamespace).List(context.TODO(),
+func (np *NetworkPod) activeGatewayHostname(ctx context.Context) string {
+	smGWPodList := AwaitUntil(ctx, "await active gateway Pod",
+		func(ctx context.Context) (*v1.PodList, error) {
+			return KubeClients[np.Config.Cluster].CoreV1().Pods(TestContext.SubmarinerNamespace).List(ctx,
 				metav1.ListOptions{LabelSelector: ActiveGatewayLabel})
 		},
 		func(result *v1.PodList) (bool, string, error) {

--- a/test/e2e/framework/nodes.go
+++ b/test/e2e/framework/nodes.go
@@ -37,8 +37,8 @@ const (
 )
 
 // FindGatewayNodes finds nodes in a given cluster by matching 'submariner.io/gateway' value.
-func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
-	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+func FindGatewayNodes(ctx context.Context, cluster ClusterIndex) []v1.Node {
+	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set{GatewayLabel: "true"}.String(),
 	})
 	Expect(err).NotTo(HaveOccurred())
@@ -47,8 +47,8 @@ func FindGatewayNodes(cluster ClusterIndex) []v1.Node {
 }
 
 // FindNonGatewayNodes finds nodes in a given cluster that doesn't match 'submariner.io/gateway' value.
-func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
-	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+func FindNonGatewayNodes(ctx context.Context, cluster ClusterIndex) []v1.Node {
+	nodes, err := KubeClients[cluster].CoreV1().Nodes().List(ctx, metav1.ListOptions{
 		LabelSelector: labels.NewSelector().Add(
 			NewRequirement(GatewayLabel, selection.NotEquals, []string{"true"})).String(),
 	})
@@ -59,9 +59,9 @@ func FindNonGatewayNodes(cluster ClusterIndex) []v1.Node {
 
 // FindClusterWithMultipleGateways finds the cluster with multiple GW nodes.
 // Returns cluster index.
-func (f *Framework) FindClusterWithMultipleGateways() int {
+func (f *Framework) FindClusterWithMultipleGateways(ctx context.Context) int {
 	for idx := range TestContext.ClusterIDs {
-		gatewayNodes := FindGatewayNodes(ClusterIndex(idx))
+		gatewayNodes := FindGatewayNodes(ctx, ClusterIndex(idx))
 		if len(gatewayNodes) >= 2 {
 			return idx
 		}
@@ -73,9 +73,8 @@ func (f *Framework) FindClusterWithMultipleGateways() int {
 // SetGatewayLabelOnNode sets the 'submariner.io/gateway' value for a node to the specified value.
 func (f *Framework) SetGatewayLabelOnNode(ctx context.Context, cluster ClusterIndex, nodeName string, isGateway bool) {
 	// Escape the '/' char in the label name with the special sequence "~1" so it isn't treated as part of the path
-	//nolint:contextcheck //  Function `PatchString->doPatchOperation->AwaitUntil->AwaitResultOrError` should pass the context parameter.
-	PatchString("/metadata/labels/"+strings.ReplaceAll(GatewayLabel, "/", "~1"), strconv.FormatBool(isGateway),
-		func(pt types.PatchType, payload []byte) error {
+	PatchString(ctx, "/metadata/labels/"+strings.ReplaceAll(GatewayLabel, "/", "~1"), strconv.FormatBool(isGateway),
+		func(ctx context.Context, pt types.PatchType, payload []byte) error {
 			_, err := KubeClients[cluster].CoreV1().Nodes().Patch(ctx, nodeName, pt, payload, metav1.PatchOptions{})
 			if err != nil && f.stopped {
 				Errorf("Error setting gateway label on node %q: %v", nodeName, err)

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -21,8 +21,8 @@ package framework
 import (
 	"context"
 	"fmt"
-	"time"
 
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,43 +66,39 @@ func (f *Framework) AwaitSubmarinerGatewayPod(ctx context.Context, cluster Clust
 }
 
 // AwaitActiveGatewayPod looks for active gateway pod.
-// Returns pod object or nil.
-func (f *Framework) AwaitActiveGatewayPod(ctx context.Context, cluster ClusterIndex, checkPod func(*v1.Pod) bool) *v1.Pod {
-	for retries := 1; retries <= 30; retries++ {
-		var activePod, retPod *v1.Pod
+// Returns pod object or fails.
+func (f *Framework) AwaitActiveGatewayPod(ctx context.Context, cluster ClusterIndex, checkPod func(*v1.Pod) bool,
+	optionalDescription ...any,
+) *v1.Pod {
+	var retPod *v1.Pod
+
+	if len(optionalDescription) == 0 {
+		optionalDescription = []any{"Did not find an active gateway pod for cluster %q", TestContext.ClusterIDs[cluster]}
+	}
+
+	Eventually(func(g Gomega, ctx context.Context) {
 		gwPods := f.AwaitPodsByAppLabel(ctx, cluster, SubmarinerGateway, TestContext.SubmarinerNamespace, -1)
 
+		var activePods []*v1.Pod
+
 		for i := range gwPods.Items {
-			pod := &gwPods.Items[i]
-			if pod.Labels[gatewayStatusLabel] == gatewayStatusActive {
-				if activePod != nil {
-					Errorf("Found 2 active gateway pods: %q and %q", activePod.Name, pod.Name)
-
-					retPod = nil
-
-					break
-				}
-
-				activePod = pod
-
-				if checkPod == nil || checkPod(pod) {
-					retPod = pod
-				}
+			if gwPods.Items[i].Labels[gatewayStatusLabel] == gatewayStatusActive {
+				activePods = append(activePods, &gwPods.Items[i])
 			}
 		}
 
-		if retPod != nil {
-			return retPod
+		g.Expect(activePods).To(HaveLen(1), "Expected 1 active gateway pod on cluster %q",
+			TestContext.ClusterIDs[cluster])
+
+		pod := activePods[0]
+		if checkPod == nil || checkPod(pod) {
+			retPod = pod
 		}
 
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-time.After(5 * time.Second):
-		}
-	}
+		g.Expect(retPod).ToNot(BeNil(), optionalDescription...)
+	}).WithTimeout(TestContext.OperationTimeoutToDuration()).WithContext(ctx).Should(Succeed())
 
-	return nil
+	return retPod
 }
 
 // DeletePod deletes the pod for the given name and namespace.

--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -31,9 +31,10 @@ import (
 
 // AwaitPodsByLabelSelector finds pods in a given cluster whose labels match a specified label selector. If the specified
 // expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
-func (f *Framework) AwaitPodsByLabelSelector(cluster ClusterIndex, labelSelector, namespace string, expectedCount int) *v1.PodList {
-	return AwaitUntil("find pods for label "+labelSelector, func() (*v1.PodList, error) {
-		return KubeClients[cluster].CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+func (f *Framework) AwaitPodsByLabelSelector(ctx context.Context, cluster ClusterIndex, labelSelector, namespace string, expectedCount int,
+) *v1.PodList {
+	return AwaitUntil(ctx, "find pods for label "+labelSelector, func(ctx context.Context) (*v1.PodList, error) {
+		return KubeClients[cluster].CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labelSelector,
 		})
 	}, func(pods *v1.PodList) (bool, string, error) {
@@ -53,22 +54,23 @@ func (f *Framework) AwaitPodsByLabelSelector(cluster ClusterIndex, labelSelector
 
 // AwaitPodsByAppLabel finds pods in a given cluster whose 'app' label value matches a specified value. If the specified
 // expectedCount >= 0, the function waits until the number of pods equals the expectedCount.
-func (f *Framework) AwaitPodsByAppLabel(cluster ClusterIndex, appName, namespace string, expectedCount int) *v1.PodList {
-	return f.AwaitPodsByLabelSelector(cluster, "app="+appName, namespace, expectedCount)
+func (f *Framework) AwaitPodsByAppLabel(ctx context.Context, cluster ClusterIndex, appName, namespace string, expectedCount int,
+) *v1.PodList {
+	return f.AwaitPodsByLabelSelector(ctx, cluster, "app="+appName, namespace, expectedCount)
 }
 
 // AwaitSubmarinerGatewayPod finds the submariner gateway pod in a given cluster, waiting if necessary for a period of time
 // for the pod to materialize.
-func (f *Framework) AwaitSubmarinerGatewayPod(cluster ClusterIndex) *v1.Pod {
-	return &f.AwaitPodsByAppLabel(cluster, SubmarinerGateway, TestContext.SubmarinerNamespace, 1).Items[0]
+func (f *Framework) AwaitSubmarinerGatewayPod(ctx context.Context, cluster ClusterIndex) *v1.Pod {
+	return &f.AwaitPodsByAppLabel(ctx, cluster, SubmarinerGateway, TestContext.SubmarinerNamespace, 1).Items[0]
 }
 
 // AwaitActiveGatewayPod looks for active gateway pod.
 // Returns pod object or nil.
-func (f *Framework) AwaitActiveGatewayPod(cluster ClusterIndex, checkPod func(*v1.Pod) bool) *v1.Pod {
+func (f *Framework) AwaitActiveGatewayPod(ctx context.Context, cluster ClusterIndex, checkPod func(*v1.Pod) bool) *v1.Pod {
 	for retries := 1; retries <= 30; retries++ {
 		var activePod, retPod *v1.Pod
-		gwPods := f.AwaitPodsByAppLabel(cluster, SubmarinerGateway, TestContext.SubmarinerNamespace, -1)
+		gwPods := f.AwaitPodsByAppLabel(ctx, cluster, SubmarinerGateway, TestContext.SubmarinerNamespace, -1)
 
 		for i := range gwPods.Items {
 			pod := &gwPods.Items[i]
@@ -93,23 +95,27 @@ func (f *Framework) AwaitActiveGatewayPod(cluster ClusterIndex, checkPod func(*v
 			return retPod
 		}
 
-		time.Sleep(5 * time.Second)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(5 * time.Second):
+		}
 	}
 
 	return nil
 }
 
 // DeletePod deletes the pod for the given name and namespace.
-func (f *Framework) DeletePod(cluster ClusterIndex, podName, namespace string) {
-	AwaitUntil("delete pod", func() (any, error) {
-		return nil, KubeClients[cluster].CoreV1().Pods(namespace).Delete(context.TODO(), podName, metav1.DeleteOptions{})
+func (f *Framework) DeletePod(ctx context.Context, cluster ClusterIndex, podName, namespace string) {
+	AwaitUntil(ctx, "delete pod", func(ctx context.Context) (any, error) {
+		return nil, KubeClients[cluster].CoreV1().Pods(namespace).Delete(ctx, podName, metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }
 
 // AwaitUntilAnnotationOnPod queries the Pod and looks for the presence of annotation.
-func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation, podName, namespace string) *v1.Pod {
-	return AwaitUntil("get "+annotation+" annotation for pod "+podName, func() (*v1.Pod, error) {
-		pod, err := KubeClients[cluster].CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func (f *Framework) AwaitUntilAnnotationOnPod(ctx context.Context, cluster ClusterIndex, annotation, podName, namespace string) *v1.Pod {
+	return AwaitUntil(ctx, "get "+annotation+" annotation for pod "+podName, func(ctx context.Context) (*v1.Pod, error) {
+		pod, err := KubeClients[cluster].CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
@@ -130,11 +136,11 @@ func (f *Framework) AwaitUntilAnnotationOnPod(cluster ClusterIndex, annotation, 
 
 // AwaitRouteAgentPodOnNode finds the route agent pod on a given node in a cluster, waiting if necessary for a period of time
 // for the pod to materialize. If prevPodUID is non-empty, the found pod's UID must not match it.
-func (f *Framework) AwaitRouteAgentPodOnNode(cluster ClusterIndex, nodeName string, prevPodUID types.UID) *v1.Pod {
+func (f *Framework) AwaitRouteAgentPodOnNode(ctx context.Context, cluster ClusterIndex, nodeName string, prevPodUID types.UID) *v1.Pod {
 	var found *v1.Pod
 
-	AwaitUntil(fmt.Sprintf("find route agent pod on node %q", nodeName), func() (*v1.PodList, error) {
-		return KubeClients[cluster].CoreV1().Pods(TestContext.SubmarinerNamespace).List(context.TODO(), metav1.ListOptions{
+	AwaitUntil(ctx, fmt.Sprintf("find route agent pod on node %q", nodeName), func(ctx context.Context) (*v1.PodList, error) {
+		return KubeClients[cluster].CoreV1().Pods(TestContext.SubmarinerNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: "app=" + RouteAgent,
 		})
 	}, func(pods *v1.PodList) (bool, string, error) {

--- a/test/e2e/framework/service_exports.go
+++ b/test/e2e/framework/service_exports.go
@@ -33,7 +33,7 @@ var gvr = schema.GroupVersionResource{
 	Resource: "serviceexports",
 }
 
-func (f *Framework) CreateServiceExport(cluster ClusterIndex, name string) {
+func (f *Framework) CreateServiceExport(ctx context.Context, cluster ClusterIndex, name string) {
 	resourceServiceExport := &unstructured.Unstructured{}
 	resourceServiceExport.SetName(name)
 	resourceServiceExport.SetNamespace(f.Namespace)
@@ -42,8 +42,8 @@ func (f *Framework) CreateServiceExport(cluster ClusterIndex, name string) {
 
 	svcExs := DynClients[cluster].Resource(gvr).Namespace(f.Namespace)
 
-	_ = AwaitUntil("create service export", func() (*unstructured.Unstructured, error) {
-		result, err := svcExs.Create(context.TODO(), resourceServiceExport, metav1.CreateOptions{})
+	_ = AwaitUntil(ctx, "create service export", func(ctx context.Context) (*unstructured.Unstructured, error) {
+		result, err := svcExs.Create(ctx, resourceServiceExport, metav1.CreateOptions{})
 		if errors.IsAlreadyExists(err) {
 			err = nil
 		}
@@ -52,8 +52,8 @@ func (f *Framework) CreateServiceExport(cluster ClusterIndex, name string) {
 	}, NoopCheckResult)
 }
 
-func (f *Framework) DeleteServiceExport(cluster ClusterIndex, name string) {
-	AwaitUntil("delete service export", func() (any, error) {
-		return nil, DynClients[cluster].Resource(gvr).Namespace(f.Namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+func (f *Framework) DeleteServiceExport(ctx context.Context, cluster ClusterIndex, name string) {
+	AwaitUntil(ctx, "delete service export", func(ctx context.Context) (any, error) {
+		return nil, DynClients[cluster].Resource(gvr).Namespace(f.Namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }

--- a/test/e2e/framework/services.go
+++ b/test/e2e/framework/services.go
@@ -67,6 +67,7 @@ func (f *Framework) NewService(name, portName string, port int32, protocol corev
 }
 
 func (f *Framework) CreateTCPServiceWithIPFamily(
+	ctx context.Context,
 	cluster ClusterIndex,
 	selectorName string,
 	port int32,
@@ -76,18 +77,19 @@ func (f *Framework) CreateTCPServiceWithIPFamily(
 		map[string]string{TestAppLabel: selectorName}, false, ipFamily)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return f.CreateService(sc, tcpService)
+	return f.CreateService(ctx, sc, tcpService)
 }
 
-func (f *Framework) CreateHeadlessTCPService(cluster ClusterIndex, selectorName string, port int32) *corev1.Service {
+func (f *Framework) CreateHeadlessTCPService(ctx context.Context, cluster ClusterIndex, selectorName string, port int32) *corev1.Service {
 	tcpService := f.NewService("test-svc"+selectorName, "tcp", port, corev1.ProtocolTCP,
 		map[string]string{TestAppLabel: selectorName}, true, nil)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return f.CreateService(sc, tcpService)
+	return f.CreateService(ctx, sc, tcpService)
 }
 
-func (f *Framework) NewNginxServiceWithIPFamilyPolicy(cluster ClusterIndex, ipFamilyPolicy *corev1.IPFamilyPolicy) *corev1.Service {
+func (f *Framework) NewNginxServiceWithIPFamilyPolicy(ctx context.Context, cluster ClusterIndex, ipFamilyPolicy *corev1.IPFamilyPolicy,
+) *corev1.Service {
 	nginxService := corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nginx-demo",
@@ -120,39 +122,40 @@ func (f *Framework) NewNginxServiceWithIPFamilyPolicy(cluster ClusterIndex, ipFa
 
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return f.CreateService(sc, &nginxService)
+	return f.CreateService(ctx, sc, &nginxService)
 }
 
-func (f *Framework) NewNginxService(cluster ClusterIndex) *corev1.Service {
-	return f.NewNginxServiceWithIPFamilyPolicy(cluster, nil)
+func (f *Framework) NewNginxService(ctx context.Context, cluster ClusterIndex) *corev1.Service {
+	return f.NewNginxServiceWithIPFamilyPolicy(ctx, cluster, nil)
 }
 
-func (f *Framework) CreateTCPServiceWithoutSelector(cluster ClusterIndex, svcName, portName string, port int32) *corev1.Service {
+func (f *Framework) CreateTCPServiceWithoutSelector(ctx context.Context, cluster ClusterIndex, svcName, portName string, port int32,
+) *corev1.Service {
 	serviceSpec := f.NewService(svcName, portName, port, corev1.ProtocolTCP, nil, false, nil)
 	sc := KubeClients[cluster].CoreV1().Services(f.Namespace)
 
-	return f.CreateService(sc, serviceSpec)
+	return f.CreateService(ctx, sc, serviceSpec)
 }
 
-func (f *Framework) CreateService(sc typedv1.ServiceInterface, serviceSpec *corev1.Service) *corev1.Service {
-	return AwaitUntil("create service", func() (*corev1.Service, error) {
-		service, err := sc.Create(context.TODO(), serviceSpec, metav1.CreateOptions{})
+func (f *Framework) CreateService(ctx context.Context, sc typedv1.ServiceInterface, serviceSpec *corev1.Service) *corev1.Service {
+	return AwaitUntil(ctx, "create service", func(ctx context.Context) (*corev1.Service, error) {
+		service, err := sc.Create(ctx, serviceSpec, metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			err = sc.Delete(context.TODO(), serviceSpec.Name, metav1.DeleteOptions{})
+			err = sc.Delete(ctx, serviceSpec.Name, metav1.DeleteOptions{})
 			if err != nil {
 				return nil, err
 			}
 
-			service, err = sc.Create(context.TODO(), serviceSpec, metav1.CreateOptions{})
+			service, err = sc.Create(ctx, serviceSpec, metav1.CreateOptions{})
 		}
 
 		return service, err
 	}, NoopCheckResult)
 }
 
-func (f *Framework) DeleteService(cluster ClusterIndex, serviceName string) {
+func (f *Framework) DeleteService(ctx context.Context, cluster ClusterIndex, serviceName string) {
 	By(fmt.Sprintf("Deleting service %q on %q", serviceName, TestContext.ClusterIDs[cluster]))
-	AwaitUntil("delete service", func() (any, error) {
-		return nil, KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(context.TODO(), serviceName, metav1.DeleteOptions{})
+	AwaitUntil(ctx, "delete service", func(ctx context.Context) (any, error) {
+		return nil, KubeClients[cluster].CoreV1().Services(f.Namespace).Delete(ctx, serviceName, metav1.DeleteOptions{})
 	}, NoopCheckResult)
 }

--- a/test/e2e/tcp/connectivity.go
+++ b/test/e2e/tcp/connectivity.go
@@ -20,6 +20,7 @@ limitations under the License.
 package tcp
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/gomega"
@@ -58,7 +59,7 @@ func (p *ConnectivityTestParams) GetIPFamily() k8snet.IPFamily {
 	return p.IPFamily
 }
 
-func RunConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
+func RunConnectivityTest(ctx context.Context, p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
 	if p.ConnectionTimeout == 0 {
 		p.ConnectionTimeout = framework.TestContext.ConnectionTimeout
 	}
@@ -67,7 +68,7 @@ func RunConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *fra
 		p.ConnectionAttempts = framework.TestContext.ConnectionAttempts
 	}
 
-	listenerPod, connectorPod := createPods(p)
+	listenerPod, connectorPod := createPods(ctx, p)
 	listenerPod.CheckSuccessfulFinish()
 	connectorPod.CheckSuccessfulFinish()
 
@@ -84,7 +85,7 @@ func RunConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *fra
 	return listenerPod, connectorPod
 }
 
-func RunNoConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
+func RunNoConnectivityTest(ctx context.Context, p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
 	if p.ConnectionTimeout == 0 {
 		p.ConnectionTimeout = 5
 	}
@@ -93,7 +94,7 @@ func RunNoConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *f
 		p.ConnectionAttempts = 1
 	}
 
-	listenerPod, connectorPod := createPods(p)
+	listenerPod, connectorPod := createPods(ctx, p)
 
 	framework.By("Verifying that listener pod exits with non-zero code and timed out message")
 	Expect(listenerPod.TerminationMessage).To(ContainSubstring("nc: timeout"))
@@ -107,13 +108,13 @@ func RunNoConnectivityTest(p *ConnectivityTestParams) (*framework.NetworkPod, *f
 	return listenerPod, connectorPod
 }
 
-func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
+func createPods(ctx context.Context, p *ConnectivityTestParams) (*framework.NetworkPod, *framework.NetworkPod) {
 	ipFamily := p.GetIPFamily()
 
 	framework.By(fmt.Sprintf("Creating a IPv%v listener pod in cluster %q, which will wait for a handshake over TCP",
 		ipFamily, framework.TestContext.ClusterIDs[p.ToCluster]))
 
-	listenerPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
+	listenerPod := p.Framework.NewNetworkPod(ctx, &framework.NetworkPodConfig{
 		Type:               framework.ListenerPod,
 		Cluster:            p.ToCluster,
 		Scheduling:         p.ToClusterScheduling,
@@ -134,7 +135,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 		framework.By(fmt.Sprintf("Pointing a service ClusterIP to the listener pod in cluster %q",
 			framework.TestContext.ClusterIDs[p.ToCluster]))
 
-		service = listenerPod.CreateService()
+		service = listenerPod.CreateService(ctx)
 		remoteIP = service.Spec.ClusterIP
 	}
 
@@ -143,7 +144,7 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	framework.By(fmt.Sprintf("Creating a IPv%v connector pod in cluster %q, which will attempt the specific UUID handshake over TCP",
 		ipFamily, framework.TestContext.ClusterIDs[p.FromCluster]))
 
-	connectorPod := p.Framework.NewNetworkPod(&framework.NetworkPodConfig{
+	connectorPod := p.Framework.NewNetworkPod(ctx, &framework.NetworkPodConfig{
 		Type:               framework.ConnectorPod,
 		Cluster:            p.FromCluster,
 		Scheduling:         p.FromClusterScheduling,
@@ -155,10 +156,10 @@ func createPods(p *ConnectivityTestParams) (*framework.NetworkPod, *framework.Ne
 	})
 
 	framework.By(fmt.Sprintf("Waiting for the connector pod %q to exit, returning what connector sent", connectorPod.Pod.Name))
-	connectorPod.AwaitFinish()
+	connectorPod.AwaitFinish(ctx)
 
 	framework.By(fmt.Sprintf("Waiting for the listener pod %q to exit, returning what listener sent", listenerPod.Pod.Name))
-	listenerPod.AwaitFinish()
+	listenerPod.AwaitFinish(ctx)
 
 	framework.Logf("Connector pod has IP: %s", connectorPod.GetIP())
 


### PR DESCRIPTION
This allows the Ginkgo context to be passed in as appropriate.

AwaitAllocatedEgressIPs isn't used anywhere outside its package (even in other projects), so this makes it private.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test framework made context-aware across lifecycle, polling, API, resource and cleanup helpers to propagate caller contexts for cancellation and timeouts.

* **Tests**
  * E2E tests (including TCP/connectivity flows and pod/service helpers) updated to use context-aware operations for more reliable waits, resource creation/deletion, and deterministic teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->