### PR TITLE
Remove unused com.github.commit label from Konflux Dockerfiles

### DIFF
--- a/package/Dockerfile.nettest.konflux
+++ b/package/Dockerfile.nettest.konflux
@@ -39,6 +39,5 @@ LABEL com.redhat.component="nettest-container" \
       io.openshift.tags="submariner, nettest, rhacm" \
       maintainer="multi-cluster-networking@redhat.com" \
       com.github.url="https://github.com/submariner-io/shipyard" \
-      com.github.commit="${BASE_BRANCH}" \
       cpe="cpe:/a:redhat:acm:2.17::el9" \
       org.opencontainers.image.created="${SOURCE_DATE_EPOCH}"


### PR DESCRIPTION
The label was never used by any tooling and contained stale values.