### PR TITLE
Regenerate RPM lockfiles for release-0.20

### DIFF
--- a/.rpm-lockfiles/nettest/rpms.lock.yaml
+++ b/.rpm-lockfiles/nettest/rpms.lock.yaml
@@ -4,27 +4,27 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.2.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 1252147
-    checksum: sha256:911e2e51ccb0ba25a2adf07de7bfb0031edd0c127a5b44e39ae89743b9a3f187
+    size: 1259537
+    checksum: sha256:d68243437b090605f10f493b51546a14246b8a40966b25aa56ba403609e6d059
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.2.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19124
+    checksum: sha256:dd3765429061138663ff13b155df45f05b3a196fc65c3a9ef7f25c0856a84de7
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.aarch64.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.2.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 211613
-    checksum: sha256:c18967e7d1b18abfca1f2bbbc7e14bffd29194966896be0cd3285284471d4cda
+    size: 218063
+    checksum: sha256:9f7acfcbc6f3dc13f68f6125d8b17521d45f26ff4659abe51fffb97de5313952
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 29476
@@ -32,13 +32,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/i/iperf3-3.9-17.el9_8.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 112022
-    checksum: sha256:a3fd9b7ad40245418e2777778c43bd7d602f5952514569736b541223de77fedf
+    size: 112342
+    checksum: sha256:a39ade81e09323143528dd36be026054e786b29880885eeef1a0fbbf5e9c8cd0
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8
+    sourcerpm: iperf3-3.9-17.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 40090
@@ -53,13 +53,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 228860
-    checksum: sha256:bd929a6e3161dfee43b377f888d3712ee70cfb591f50cab845e8551973b010f1
+    size: 231099
+    checksum: sha256:7734a9d19d8a858db578e298f99148806f159668c010483fbd77e5ac4fe95e0d
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 548341
@@ -67,13 +67,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 295895
-    checksum: sha256:2ed44feaa9dd15834295493690fd383d21d226ab1801be9daf4234d064ccc428
+    size: 303260
+    checksum: sha256:5abd0d4ade384b6432882e095ee3f354700d66aeb3f655bd78c25427444a3875
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9
+    sourcerpm: curl-7.76.1-40.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/i/iputils-20210202-15.el9_7.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 178424
@@ -81,20 +81,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libcurl-minimal-7.76.1-35.el9_7.3.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libibverbs-61.0-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 225290
-    checksum: sha256:1c1842809017627ff3bf6b7095167e47db01f0675c6a1c7f34c39ea40d32c253
-    name: libcurl-minimal
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libibverbs-57.0-2.el9.aarch64.rpm
-    repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 458077
-    checksum: sha256:cff5c03177285b39d0e35584862488c441f15429f6396d9c6da264634c2cb400
+    size: 490223
+    checksum: sha256:fefa639490ba2fb332e93fee3db6ed1651fd8c5d138d4b0eb9c6088425198983
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 363241
@@ -134,27 +127,27 @@ arches:
   module_metadata: []
 - arch: ppc64le
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.2.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 1420264
-    checksum: sha256:710bc12c265803d9f72b8c95d83d7ec545424a4f97f7d33dbeb42830712bd27c
+    size: 1428198
+    checksum: sha256:bcbf388bcc3a01a9e364fc068397e5e48c675c92afc94a4496b6005e391164f1
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.2.noarch.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19124
+    checksum: sha256:dd3765429061138663ff13b155df45f05b3a196fc65c3a9ef7f25c0856a84de7
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.ppc64le.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.2.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 217065
-    checksum: sha256:45047a99f745ed4552097f6b7695eece6c8f8639089efa19b2160c808c9a5515
+    size: 224223
+    checksum: sha256:0a07d0491aaaf16f31463bc728d7b40853bc502b9bdc4583af3c66a6969e5109
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/f/fstrm-0.6.1-3.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 32044
@@ -162,13 +155,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/i/iperf3-3.9-17.el9_8.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 121933
-    checksum: sha256:0fad15addadf6ec2bb3fd67393d8e3621224f85237dbdc4ae87c87a31da3c0f3
+    size: 122083
+    checksum: sha256:d3ef88390bc0278b5b4d18dedf15506b7674f42e88e9fb2493df68b371e939b3
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8
+    sourcerpm: iperf3-3.9-17.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 38048
@@ -183,13 +176,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 255275
-    checksum: sha256:28c6e68a8955cc673506312af29bc88a4c5eb767d6db64cb4d07fed56e5badaa
+    size: 257579
+    checksum: sha256:e56086dbc08fd4acf9eb816cc00ad99b94175ad3d0df1d4de945806de6f439e3
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 577736
@@ -197,13 +190,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-40.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
-    size: 302683
-    checksum: sha256:089b35068610a9c120fcb60e0043efb776f16e1146a433cd9acc01cc8c910420
+    size: 310002
+    checksum: sha256:2c86a5ed7f7e7ce14a8aaacafafff421576f8093b539d3cf0d7acbed0bb25c1b
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9
+    sourcerpm: curl-7.76.1-40.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/i/iputils-20210202-15.el9_7.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 182991
@@ -211,20 +204,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libcurl-minimal-7.76.1-35.el9_7.3.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libibverbs-61.0-2.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
-    size: 255297
-    checksum: sha256:2cf7dbc31082911a629ea1379ebffb56d2bb58f60efda89d299257f17b3b916c
-    name: libcurl-minimal
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libibverbs-57.0-2.el9.ppc64le.rpm
-    repoid: rhel-9-for-ppc64le-baseos-rpms
-    size: 510076
-    checksum: sha256:7216f066e90cec1dfc2a78e3eccc292af73cf1d1217a4376d66c83fbb9babb09
+    size: 545208
+    checksum: sha256:3972ff6b979e08abe28a91e6942fd8b432b5014b626c23d65a1083375bf5843f
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libnl3-3.11.0-1.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 393979
@@ -264,27 +250,27 @@ arches:
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.2.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 1234976
-    checksum: sha256:2d0f09df9c4085bfb0a0d561ee04ef260f3e1256aab9799fcf5f4a250258357d
+    size: 1241040
+    checksum: sha256:b16e969ddc24af4b70c3929d86ff00f626f716f50522edb6c52b3ea699a96ea0
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.2.noarch.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19124
+    checksum: sha256:dd3765429061138663ff13b155df45f05b3a196fc65c3a9ef7f25c0856a84de7
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.s390x.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.2.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 208870
-    checksum: sha256:ebe107cc0dc4d64eeff676a1182851fcae1e195438b999fadcd5a75abca98f74
+    size: 215656
+    checksum: sha256:72e74ef9f6cdc2136dd94850701079a7ed85a8a0b760a5aa2c8372d423eaedcc
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/f/fstrm-0.6.1-3.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 29853
@@ -292,13 +278,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/i/iperf3-3.9-17.el9_8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 110814
-    checksum: sha256:15fb56a83c7001fa0f58b03eaa768f436637f5064f8e517a629a1663b210f10c
+    size: 111511
+    checksum: sha256:e3731afd7a60a2df7bf1a20e7558fbb8d60f8ad0a6a8ea2c7afcdeff32eb1dbc
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8
+    sourcerpm: iperf3-3.9-17.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 35548
@@ -313,13 +299,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 228076
-    checksum: sha256:b42a004133dd719cc4b09052e3952b2a4d3877a5d576fc88c58122db2aa2d7fe
+    size: 230457
+    checksum: sha256:3ce35b67378a25a40abe20cd5195d0e116fad4dccd8909259210954e5a8b27e7
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 527514
@@ -327,13 +313,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/c/curl-7.76.1-40.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
-    size: 297640
-    checksum: sha256:28d114798ac0f43619f12602109f10d187e91935affa4c7a30ebd92c0c3e1920
+    size: 304744
+    checksum: sha256:c23fc2f7f609a64899eca1b9b930f92441bd437c6d8827e9a092f887e4aa3362
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9
+    sourcerpm: curl-7.76.1-40.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/i/iputils-20210202-15.el9_7.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 177321
@@ -341,20 +327,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libcurl-minimal-7.76.1-35.el9_7.3.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libibverbs-61.0-2.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
-    size: 224781
-    checksum: sha256:d1ebd6099409746d96e6b817d4d0a1839ec4dd15dd66380d069427d652d1f831
-    name: libcurl-minimal
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libibverbs-57.0-2.el9.s390x.rpm
-    repoid: rhel-9-for-s390x-baseos-rpms
-    size: 446293
-    checksum: sha256:c7164f42547454760cb437d7a84f55e7cca836a495cb4c7ee29f8a8b3bca72e8
+    size: 476102
+    checksum: sha256:08abe242ac96b170a3d74ed08ab75a16546d091efc4d35988c7ceefd5349ba56
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libnl3-3.11.0-1.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 361754
@@ -394,27 +373,27 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1301214
-    checksum: sha256:a8a735281125cae93c6c6067ba8ea473132f5ebdd81e6e898d1fe91d317c39b1
+    size: 1309418
+    checksum: sha256:705c230e5500c8135171d9b401061eaee897b8eacf26dd627a75978bdfe3c005
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.2.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19124
+    checksum: sha256:dd3765429061138663ff13b155df45f05b3a196fc65c3a9ef7f25c0856a84de7
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.x86_64.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.2.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 211124
-    checksum: sha256:b61003436687afb2eae9e6301e10efc202c072fb45c4b88dfb95022db9fbc541
+    size: 218219
+    checksum: sha256:71f78d4a009d8bb6ccf031d44992df9ab6d7392901b11f5a39f86bc018bd5435
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.2
+    sourcerpm: bind-9.16.23-40.el9_8.2.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30777
@@ -422,13 +401,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/iperf3-3.9-17.el9_8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 115589
-    checksum: sha256:5f91ef6d32f64b0be044c5f9c33fa687039d66e6797746493a7590a489226802
+    size: 116104
+    checksum: sha256:6cb38c12dce9b3214db2330c176f9788c8168f43a3f84b79f50b5d991c4a3368
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8
+    sourcerpm: iperf3-3.9-17.el9_8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 36179
@@ -443,13 +422,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 234565
-    checksum: sha256:4107c9b2ac6fe1a6be44088f79fcafd012e22c7867dad98741c88590cadeb5a2
+    size: 236896
+    checksum: sha256:2de304bc963e3d03b61716289e7e5504267646b3192da24f98f8e278068fec3e
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 559754
@@ -457,13 +436,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 299410
-    checksum: sha256:5b01bc58d38b77f3ff9a8c88a512b9a35c5a7fbecb6e3f734212008ea3bdc30b
+    size: 306411
+    checksum: sha256:dffe60e96ea6473d6fd99f2ca688914d8342bc20819018ebe23d5d43ddb958ad
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9
+    sourcerpm: curl-7.76.1-40.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iputils-20210202-15.el9_7.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 177748
@@ -471,20 +450,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libcurl-minimal-7.76.1-35.el9_7.3.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-61.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 229001
-    checksum: sha256:b192815df8073689a55cdcc06deff482d5eefea260270363c8824fd3c4a06bf4
-    name: libcurl-minimal
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-57.0-2.el9.x86_64.rpm
-    repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 463544
-    checksum: sha256:d96bbefb46683bd3ddfffd0668898c591f253dfca25e5ac2ddf90f812512e5b7
+    size: 498499
+    checksum: sha256:4789955ff27b0339c2b61ad52d492965e0ad7f02cd44b68370ca82d6aa596b41
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 376137


### PR DESCRIPTION
Updated lockfiles to resolve latest package versions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bundled package versions across supported CPU architectures.
  * Refreshed network and diagnostics tools, including `curl`, `bind` utilities, `iperf3`, `nmap-ncat`, `tcpdump`, and `libibverbs`.
  * Removed outdated minimal curl package entries from the updated package set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->