### PR TITLE
Harden Dockerfiles (FIND-005/008/012)

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -24,4 +24,6 @@ COPY scripts/nettest/* /app/
 
 RUN echo ${VERSION} >> /app/version
 
+USER 10000
+
 CMD ["/bin/bash","-l"]

--- a/package/Dockerfile.nettest.konflux
+++ b/package/Dockerfile.nettest.konflux
@@ -1,6 +1,6 @@
 ARG BASE_BRANCH=release-0.21
 
-FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9:latest
+FROM --platform=${TARGETPLATFORM} registry.redhat.io/ubi9@sha256:5426a8f45e80a07168a30ea24d84f266094b3756624a5508cc53927e6ee39e09
 ARG BASE_BRANCH
 ARG SOURCE_DATE_EPOCH
 
@@ -26,6 +26,8 @@ COPY scripts/nettest/metricsproxy.konflux /app/metricsproxy
 COPY scripts/nettest/nc /app/
 
 COPY LICENSE /licenses/LICENSE
+
+USER 10000
 
 CMD ["/bin/bash","-l"]
 

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:43@sha256:762d73ba1c455232b0272c5d445a34f36c4b9f421cbc05ce8102552325b6a222
 
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.

--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 ENV DAPPER_HOST_ARCH=amd64 SHELL=/bin/bash \
     SHIPYARD_DIR=/opt/shipyard

--- a/scripts/nettest/metricsproxy.konflux
+++ b/scripts/nettest/metricsproxy.konflux
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 # Arguments: source-port target-IP target-port
-exec /usr/bin/ncat -v -lk -p "$1" -c "/usr/bin/ncat $2 $3"
+exec /usr/bin/ncat -v -lk -p "$1" -e "/usr/bin/ncat $2 $3"


### PR DESCRIPTION
Dockerfile hardening covering three findings:

- **FIND-005** — digest-pin `package/Dockerfile.shipyard-dapper-base` (fedora:43), `package/Dockerfile.shipyard-linting` (alpine:3.24), and `package/Dockerfile.nettest.konflux` (ubi9 multi-arch index digest; `--platform` kept, `:latest` dropped). `Dockerfile.nettest` is intentionally not pinned — its `FEDORA_VERSION` ARG also drives `dnf_install` repo selection.
- **FIND-012** — add `USER 10000` to `package/Dockerfile.nettest` and `package/Dockerfile.nettest.konflux` (no `adduser` needed).
- **FIND-008** — switch `scripts/nettest/metricsproxy.konflux` ncat from `-c` (`--sh-exec`) to `-e` (`--exec`), removing the second-shell re-parse.

See commit messages for details.