### PR TITLE
Harden Dockerfiles (FIND-005/012)

### DIFF
--- a/package/Dockerfile.nettest
+++ b/package/Dockerfile.nettest
@@ -22,4 +22,6 @@ COPY scripts/nettest/* /app/
 
 RUN echo ${VERSION} >> /app/version
 
+USER 10000
+
 CMD ["/bin/bash","-l"]

--- a/package/Dockerfile.shipyard-dapper-base
+++ b/package/Dockerfile.shipyard-dapper-base
@@ -1,4 +1,4 @@
-FROM fedora:41
+FROM fedora:41@sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d
 
 # Unless specified otherwise, compress to a medium level which gives (from experemintation) a
 # good balance between compression time and resulting image size.

--- a/package/Dockerfile.shipyard-linting
+++ b/package/Dockerfile.shipyard-linting
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 ENV DAPPER_HOST_ARCH=amd64 SHELL=/bin/bash \
     SHIPYARD_DIR=/opt/shipyard


### PR DESCRIPTION
Dockerfile hardening covering two findings:

- **FIND-005** — digest-pin `package/Dockerfile.shipyard-dapper-base` (fedora:41) and `package/Dockerfile.shipyard-linting` (alpine:3.24). `Dockerfile.nettest` is intentionally not pinned — its `FEDORA_VERSION` ARG also drives `dnf_install` repo selection.
- **FIND-012** — add `USER 10000` to `package/Dockerfile.nettest` (after the version `RUN`, before `CMD`) so the community image defaults to non-root off-OpenShift.

Konflux files do not exist on release-0.18; FIND-019 Dependabot docker is devel-only.

See commit messages for details.