### PR TITLE
Harden GitHub Actions inputs (FIND-004/013/016)

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Delete current CODEOWNERS file
         run: rm CODEOWNERS
       - name: Run gen-codeowners to rebuild CODEOWNERS file

--- a/.github/workflows/consuming.yml
+++ b/.github/workflows/consuming.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           # This is replaced to stable branch by auto release process
           ref: release-0.20
           repository: submariner-io/${{ matrix.project }}
@@ -43,6 +44,7 @@ jobs:
       - name: Check out the Shipyard repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           path: shipyard
 
       - name: Build the latest Shipyard images
@@ -84,6 +86,8 @@ jobs:
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Build the latest Shipyard image
         run: make images
@@ -91,6 +95,7 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           # This is replaced to stable branch by auto release process
           ref: release-0.20
           repository: submariner-io/${{ matrix.project }}
@@ -139,6 +144,8 @@ jobs:
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Build the latest Shipyard image
         run: make images
@@ -146,6 +153,7 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           # This is replaced to stable branch by auto release process
           ref: release-0.20
           repository: submariner-io/${{ matrix.project }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Make sure each commit in the PR is within reviewable size
         uses: ./gh-actions/commit-size
         with:
@@ -51,6 +53,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Run gitlint
         run: make gitlint
@@ -61,6 +64,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run golangci-lint
         run: make golangci-lint
 
@@ -70,6 +75,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Run markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31
@@ -84,6 +91,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run markdownlint
         run: make markdownlint
 
@@ -93,6 +102,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run packagedoc-lint
         run: make packagedoc-lint
 
@@ -102,6 +113,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run shellcheck
         run: make shellcheck
 
@@ -111,6 +124,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         id: scan
@@ -133,5 +148,7 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run yamllint
         run: make yamllint

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Run markdown-link-check
         uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Check out the Shipyard repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Build go-mod-outdated
         run: cd tools && go build -o ../bin/go-mod-outdated github.com/psampaz/go-mod-outdated
@@ -52,6 +56,7 @@ jobs:
       - name: Check out the ${{ matrix.project }} repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           repository: submariner-io/${{ matrix.project }}
           path: ${{ matrix.project }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Build and release new images

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
       - name: Run Anchore vulnerability scanner
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         id: scan

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU (to support building on non-native architectures)
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -60,6 +64,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Build images
         run: make images
@@ -78,6 +84,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -96,6 +104,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -139,6 +149,7 @@ jobs:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Fetch all git tags
@@ -162,6 +173,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -179,6 +192,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Build the images if necessary
         uses: ./gh-actions/cache-images
@@ -190,6 +205,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -204,6 +221,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images
@@ -221,6 +240,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Restore images from the cache
         uses: ./gh-actions/restore-images

--- a/.github/workflows/upgrade-e2e.yml
+++ b/.github/workflows/upgrade-e2e.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Install an old cluster, upgrade it and check it
         uses: ./gh-actions/upgrade-e2e

--- a/gh-actions/cache-images/action.yaml
+++ b/gh-actions/cache-images/action.yaml
@@ -19,13 +19,17 @@ runs:
     - name: Build the images if necessary
       if: steps.image-cache.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        INPUT_CACHE: ${{ inputs.cache }}
       run: |
         echo "::group::Building images and storing them"
         make images
-        mkdir -p ${{ inputs.cache }}
+        # A leading ~ in an env value is not tilde-expanded by the shell; do it here.
+        INPUT_CACHE="${INPUT_CACHE/#\~/$HOME}"
+        mkdir -p "$INPUT_CACHE"
         for image in package/.image.*; do \
           docker save quay.io/submariner/${image#package/.image.} | \
-          gzip > ${{ inputs.cache }}/${image#package/.image.}.tar.gz; \
-          cp $image ${{ inputs.cache }}; \
+          gzip > "$INPUT_CACHE/${image#package/.image.}.tar.gz"; \
+          cp $image "$INPUT_CACHE"; \
         done
         echo "::endgroup::"

--- a/gh-actions/commit-size/action.yaml
+++ b/gh-actions/commit-size/action.yaml
@@ -12,13 +12,17 @@ runs:
     - name: Make sure the size of each commit doesn't pass the desired size
       shell: bash
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-size-check') }}
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        MAX_SIZE: ${{ inputs.size }}
       run: |
         set -e
         # Fetch 'origin' to get all commits for size checking
         git fetch -q -n origin
 
         result=0
-        commits_range=${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
+        commits_range="${BASE_SHA}..${HEAD_SHA}"
         sum_commit() { git diff --numstat ${1} ${1}^ | awk '{ sum += $1 + $2 } END { print sum }'; }
         for commit in $(git log --pretty="format:%H" ${commits_range}); do
             if [[ $(git cat-file -p "${commit}" | grep -c "^parent ") -gt 1 ]]; then
@@ -28,12 +32,12 @@ runs:
 
             size=$(sum_commit ${commit})
             printf "Size of commit %s (%d) " "${commit}" "${size}"
-            if [[ ${size} -gt ${{ inputs.size }} ]]; then
-                echo "is larger than the allowed size ${{ inputs.size }}"
+            if [[ ${size} -gt ${MAX_SIZE} ]]; then
+                echo "is larger than the allowed size ${MAX_SIZE}"
                 result=1
                 continue
             fi
 
-            echo "is within allowed size ${{ inputs.size }}"
+            echo "is within allowed size ${MAX_SIZE}"
         done
         exit $result

--- a/gh-actions/e2e/action.yaml
+++ b/gh-actions/e2e/action.yaml
@@ -62,8 +62,10 @@ runs:
 
     - name: Install WireGuard specific modules
       shell: bash
+      env:
+        INPUT_USING: ${{ inputs.using }}
       run: |
-        [[ "${{ inputs.using }}" =~ "wireguard" ]] || exit 0
+        [[ "$INPUT_USING" =~ "wireguard" ]] || exit 0
         echo "::group::Installing WireGuard modules"
         sudo apt install -y linux-headers-$(uname -r) wireguard
         sudo modprobe wireguard
@@ -76,14 +78,21 @@ runs:
 
     - name: Run E2E deployment and tests
       shell: bash
+      env:
+        INPUT_K8S_VERSION: ${{ inputs.k8s_version }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_USING: ${{ inputs.using }}
+        INPUT_PLUGIN: ${{ inputs.plugin }}
+        INPUT_TEST_ARGS: ${{ inputs.test_args }}
+        INPUT_TESTDIR: ${{ inputs.testdir }}
       run: |
-        k8s_version=${{ inputs.k8s_version }};
+        k8s_version="$INPUT_K8S_VERSION";
         if [ "$k8s_version" = k8s-latest ]; then k8s_version=1.32; fi; \
         if [ "$k8s_version" = k8s-oldest-working ]; then k8s_version=1.19; fi; \
         if [ "$k8s_version" = k8s-oldest-supported ]; then k8s_version=1.26; fi; \
-        make "${{ inputs.target }}" \
-            using="${{ inputs.using }}" \
+        make "$INPUT_TARGET" \
+            using="$INPUT_USING" \
             ${k8s_version:+K8S_VERSION="$k8s_version"} \
-            PLUGIN="${{ inputs.plugin }}" \
-            TEST_ARGS="${{ inputs.test_args }}" \
-            E2E_TESTDIR="${{ inputs.testdir }}"
+            PLUGIN="$INPUT_PLUGIN" \
+            TEST_ARGS="$INPUT_TEST_ARGS" \
+            E2E_TESTDIR="$INPUT_TESTDIR"

--- a/gh-actions/restore-images/action.yaml
+++ b/gh-actions/restore-images/action.yaml
@@ -23,8 +23,13 @@ runs:
     - name: Restore images from cache
       if: steps.image-cache.outputs.cache-hit == 'true'
       shell: bash
+      env:
+        INPUT_CACHE: ${{ inputs.cache }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: |
-        for archive in ${{ inputs.cache }}/*.tar*; do docker load -i $archive; done
-        if [ -d ${{ inputs.working-directory }}/package ]; then \
-          cp ${{ inputs.cache }}/.image.* ${{ inputs.working-directory }}/package/; \
+        # A leading ~ in an env value is not tilde-expanded by the shell; do it here.
+        INPUT_CACHE="${INPUT_CACHE/#\~/$HOME}"
+        for archive in "$INPUT_CACHE"/*.tar*; do docker load -i "$archive"; done
+        if [ -d "$INPUT_WORKING_DIRECTORY"/package ]; then \
+          cp "$INPUT_CACHE"/.image.* "$INPUT_WORKING_DIRECTORY"/package/; \
         fi


### PR DESCRIPTION
GitHub Actions hardening covering two findings:

- **FIND-004** — move `${{ inputs.* }}` interpolations in the cache-images, restore-images, commit-size, and e2e composite actions out of `run:` scripts and into step `env:` maps, referenced as quoted shell vars. Removes the shell-injection surface from composite action inputs.
- **FIND-016** — add `persist-credentials: false` to all `actions/checkout` steps so the GITHUB_TOKEN is not written into `.git/config` after checkout.

FIND-013 (`@devel` self-reference) is not applicable on release-0.20 — already self-references.

**Note:** apply the `e2e-projects` label so the consuming-repo e2e gate runs against the updated `e2e/action.yaml`.

See commit messages for details.