### PR TITLE
Add security policy and OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,47 @@
+---
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 6 * * 1"
+  push:
+    branches: [devel]
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results to OpenSSF REST API for the Scorecard badge.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ name: Scorecard supply-chain security
 on:
   branch_protection_rule:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "17 6 * * 1"
   push:
     branches: [devel]
 
@@ -34,14 +34,14 @@ jobs:
           # Publish results to OpenSSF REST API for the Scorecard badge.
           publish_results: true
 
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        with:
+          sarif_file: results.sarif
+
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
-        with:
-          sarif_file: results.sarif

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+Submariner welcomes and appreciates the responsible disclosure of security
+vulnerabilities. This document describes which versions receive security
+fixes and how to report a vulnerability.
+
+## Supported Versions
+
+Security fixes are made on the `devel` branch and, when they address serious
+issues or regressions, are backported to the actively maintained release
+branches following the project's [backports process][backports]. The set of
+maintained branches tracks the most recent Submariner releases; see the
+[releases documentation][releases] for the current list.
+
+## Reporting a Vulnerability
+
+If you know of a security issue with Submariner, please report it privately
+by email to [submariner-security@googlegroups.com][security-email] rather
+than opening a public issue or pull request.
+
+For full details, follow the project's
+[security reporting process][reporting].
+
+## Disclosure Policy
+
+Submariner Project Owners receive security disclosures by default. They may
+share disclosures with others as required to make and propagate fixes.
+
+[backports]: https://submariner.io/development/backports/
+[releases]: https://submariner.io/community/releases/
+[reporting]: https://submariner.io/development/security/
+[security-email]: mailto:submariner-security@googlegroups.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,5 +45,5 @@ share disclosures with others as required to make and propagate fixes.
 
 [backports]: https://submariner.io/development/backports/
 [releases]: https://submariner.io/community/releases/
-[reporting]: https://submariner.io/development/security/
+[reporting]: https://submariner.io/development/security/reporting/
 [security-email]: mailto:submariner-security@googlegroups.com

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,6 +12,23 @@ branches following the project's [backports process][backports]. The set of
 maintained branches tracks the most recent Submariner releases; see the
 [releases documentation][releases] for the current list.
 
+The following branches currently receive backported fixes, based on recent
+commit activity. This list is a best-effort snapshot rather than a formal
+policy; if it's out of date, please open an issue or pull request to correct
+it.
+
+| Branch        | Maintained |
+| ------------- | ---------- |
+| `devel`       | Yes        |
+| `release-0.24`| Yes        |
+| `release-0.23`| Yes        |
+| `release-0.22`| Yes        |
+| `release-0.21`| Yes        |
+| `release-0.20`| Yes        |
+| `release-0.19`| Yes        |
+| `release-0.18`| Yes        |
+| Earlier       | No         |
+
 ## Reporting a Vulnerability
 
 If you know of a security issue with Submariner, please report it privately


### PR DESCRIPTION
Two devel-only security posture additions:

- **FIND-018** — add `SECURITY.md` referencing the existing Submariner security process: supported versions, private reporting via submariner-security@googlegroups.com, and the disclosure policy at submariner.io/development/security/.
- **FIND-021** — add `.github/workflows/scorecard.yml` using `ossf/scorecard-action`: runs on push to devel and weekly schedule (never on PRs); `publish_results: true` for the OpenSSF badge; all action SHAs pinned to full commit hashes per the repo's pinning policy.

See commit messages for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added scheduled OpenSSF Scorecard analysis with GitHub code-scanning integration.
  - Added downloadable security analysis reports retained for five days.

- **Documentation**
  - Updated the security reporting link to direct users to the Submariner security reporting process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->