### PR TITLE
Harden e2e test-pod security posture (FIND-009/010/011/017)

### DIFF
--- a/scripts/shared/resources/dummypod.yaml
+++ b/scripts/shared/resources/dummypod.yaml
@@ -13,6 +13,12 @@ spec:
       labels:
         app: dummypod
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
@@ -24,6 +30,19 @@ spec:
         - name: dummypod
           image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
           command:
             - sleep
             - infinity

--- a/scripts/shared/resources/netshoot.yaml
+++ b/scripts/shared/resources/netshoot.yaml
@@ -13,15 +13,29 @@ spec:
       labels:
         app: netshoot
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: netshoot
           image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
           command:
             - sleep
             - 1h

--- a/scripts/shared/resources/nginx-demo.yaml
+++ b/scripts/shared/resources/nginx-demo.yaml
@@ -13,10 +13,29 @@ spec:
       labels:
         app: nginx-demo
     spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: nginx-demo
           image: ${SUBM_IMAGE_REPO}/nettest:${SUBM_IMAGE_TAG}
           command: ["/app/simpleserver"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
           ports:
             - containerPort: 8080
 ---

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -218,6 +218,7 @@ func BeforeSuite() {
 func initPodSecurityContext() {
 	podSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				"ALL",

--- a/test/e2e/framework/network_pods.go
+++ b/test/e2e/framework/network_pods.go
@@ -29,11 +29,28 @@ import (
 
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
+
+// lightResources caps the light TCP listener/connector (and CustomPod default)
+// pods. Their work is trivial, so a small hard limit is safe.
+var lightResources = v1.ResourceRequirements{
+	Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("100m"), v1.ResourceMemory: resource.MustParse("128Mi")},
+	Limits:   v1.ResourceList{v1.ResourceCPU: resource.MustParse("500m"), v1.ResourceMemory: resource.MustParse("256Mi")},
+}
+
+// throughputResources sizes the iperf3/netperf throughput and latency pods. It
+// sets requests but deliberately omits a CPU limit: iperf3 -P 10 is
+// multithreaded and a hard CPU cap would throttle it and corrupt the very
+// measurements these pods exist to take.
+var throughputResources = v1.ResourceRequirements{
+	Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("500m"), v1.ResourceMemory: resource.MustParse("256Mi")},
+	Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("512Mi")},
+}
 
 type NetworkingType bool
 
@@ -75,9 +92,11 @@ type NetworkPodConfig struct {
 	ConnectionTimeout  uint
 	ConnectionAttempts uint
 	Networking         NetworkingType
+	WritableRootFS     bool
 	ContainerName      string
 	ImageName          string
 	Command            []string
+	Resources          v1.ResourceRequirements
 	// TODO: namespace, once https://github.com/submariner-io/submariner/pull/141 is merged
 }
 
@@ -264,8 +283,9 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:  "tcp-check-listener",
@@ -287,6 +307,7 @@ func (np *NetworkPod) buildTCPCheckListenerPod() {
 						{Name: "BUFS_NUM", Value: strconv.Itoa(int(np.Config.NumOfDataBufs))},
 					},
 					SecurityContext: podSecurityContext,
+					Resources:       lightResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -313,9 +334,10 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
-			HostNetwork:   bool(np.Config.Networking),
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
+			HostNetwork:                  bool(np.Config.Networking),
 			Containers: []v1.Container{
 				{
 					Name:  "tcp-check-connector",
@@ -343,6 +365,7 @@ func (np *NetworkPod) buildTCPCheckConnectorPod() {
 						{Name: "BUFS_NUM", Value: strconv.Itoa(int(np.Config.NumOfDataBufs))},
 					},
 					SecurityContext: podSecurityContext,
+					Resources:       lightResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -368,8 +391,9 @@ func (np *NetworkPod) buildThroughputClientPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:            "nettest-client-pod",
@@ -390,6 +414,7 @@ func (np *NetworkPod) buildThroughputClientPod() {
 						{Name: "CONN_TIMEOUT", Value: strconv.Itoa(int(np.Config.ConnectionTimeout * 1000))},
 					},
 					SecurityContext: podSecurityContext,
+					Resources:       throughputResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -413,8 +438,9 @@ func (np *NetworkPod) buildThroughputServerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:            "nettest-server-pod",
@@ -425,6 +451,7 @@ func (np *NetworkPod) buildThroughputServerPod() {
 						{Name: "TARGET_PORT", Value: strconv.Itoa(np.Config.Port)},
 					},
 					SecurityContext: podSecurityContext,
+					Resources:       throughputResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -450,8 +477,9 @@ func (np *NetworkPod) buildLatencyClientPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:            "latency-client-pod",
@@ -467,6 +495,7 @@ func (np *NetworkPod) buildLatencyClientPod() {
 						{Name: "TARGET_IP", Value: np.Config.RemoteIP},
 					},
 					SecurityContext: podSecurityContext,
+					Resources:       throughputResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -490,8 +519,9 @@ func (np *NetworkPod) buildLatencyServerPod() {
 			},
 		},
 		Spec: v1.PodSpec{
-			Affinity:      np.nodeAffinity(np.Config.Scheduling),
-			RestartPolicy: v1.RestartPolicyNever,
+			AutomountServiceAccountToken: new(bool),
+			Affinity:                     np.nodeAffinity(np.Config.Scheduling),
+			RestartPolicy:                v1.RestartPolicyNever,
 			Containers: []v1.Container{
 				{
 					Name:            "latency-server-pod",
@@ -499,6 +529,7 @@ func (np *NetworkPod) buildLatencyServerPod() {
 					ImagePullPolicy: v1.PullAlways,
 					Command:         []string{"netserver", "-D"},
 					SecurityContext: podSecurityContext,
+					Resources:       throughputResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},
@@ -515,6 +546,16 @@ func (np *NetworkPod) buildLatencyServerPod() {
 // The pod will use the image specified and run command specified.
 func (np *NetworkPod) buildCustomPod() {
 	terminationGracePeriodSeconds := int64(5)
+
+	customSecurityContext := *podSecurityContext
+	if np.Config.WritableRootFS {
+		customSecurityContext.ReadOnlyRootFilesystem = new(bool)
+	}
+
+	customResources := lightResources
+	if np.Config.Resources.Requests != nil || np.Config.Resources.Limits != nil {
+		customResources = np.Config.Resources
+	}
 	customPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "custom",
@@ -523,6 +564,7 @@ func (np *NetworkPod) buildCustomPod() {
 			},
 		},
 		Spec: v1.PodSpec{
+			AutomountServiceAccountToken:  new(bool),
 			Affinity:                      np.nodeAffinity(np.Config.Scheduling),
 			RestartPolicy:                 v1.RestartPolicyNever,
 			HostNetwork:                   bool(np.Config.Networking),
@@ -533,7 +575,8 @@ func (np *NetworkPod) buildCustomPod() {
 					Image:           np.Config.ImageName,
 					ImagePullPolicy: v1.PullAlways,
 					Command:         np.Config.Command,
-					SecurityContext: podSecurityContext,
+					SecurityContext: &customSecurityContext,
+					Resources:       customResources,
 				},
 			},
 			Tolerations: []v1.Toleration{{Operator: v1.TolerationOpExists}},


### PR DESCRIPTION
Test-pod security hardening covering four findings:

- **FIND-017** — add pod/container `securityContext`, `automountServiceAccountToken: false`, and CPU/memory requests+limits to the `dummypod`, `netshoot`, and `nginx-demo` CI helper manifests.
- **FIND-009** — disable service-account token automount on all 7 `NetworkPod` PodSpecs in `test/e2e/framework/network_pods.go`.
- **FIND-010** — add `readOnlyRootFilesystem: true` to the shared container `SecurityContext`; `CustomPod` callers that need a writable root can set `WritableRootFS: true`.
- **FIND-011** — differentiated resource profiles: hard-capped for TCP listener/connector/CustomPod; requests-only (no CPU limit) for throughput/latency pods where a hard CPU cap corrupts benchmark numbers.

**Note:** apply the `e2e-projects` label so the consuming-repo e2e gate exercises the framework changes.

See commit messages for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened demonstration and network test workloads with non-root execution, restricted privileges, dropped capabilities, read-only filesystems, and disabled service-account token mounting.
  * Added RuntimeDefault seccomp protection for supported workloads.

* **Resource Management**
  * Added CPU and memory requests and limits to improve workload scheduling and stability.
  * Introduced lightweight and throughput-oriented resource profiles for network test pods.

* **Testing**
  * Custom network test pods now support configurable resource requirements and optional writable filesystem access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->