### PR TITLE
Print debug trace commands without eval

### DIFF
--- a/scripts/shared/lib/debug_functions
+++ b/scripts/shared/lib/debug_functions
@@ -10,14 +10,13 @@ NO_COLOR=$(echo -e '\e[0m')
 # Function to print each bash command before it is executed.
 # Only outputs when $DEBUG_PRINT is set, to control printing precisely.
 # Skips common command (printing, control structures, etc).
-# Skips parsing `$()` as it causes the internal command to be executed twice.
-# Skips parsing `=(` as it causes an error for eval.
+# Prints $BASH_COMMAND verbatim (unexpanded) so secrets held in variables
+# (e.g. $QUAY_USERNAME) are never expanded into the debug trace.
 # Skips printing function name twice (caveat - if we ever do a recursion, we won't see it).
 function trap_commands() {
     trap '[[ "${DEBUG_PRINT}" == true ]] &&
           declare -g cmd="$BASH_COMMAND" cur_func="${FUNCNAME[0]}" &&
           ! [[ "$cmd" =~ ^(echo|read|\[|while|for|local|printf) ]] &&
-          { [[ "$cmd" =~ =\$?\( ]] && cmd="${cmd@Q}" || cmd=$(eval echo "$cmd"); } &&
           [[ -n "$cmd" && "${cmd%% *}" != "$cur_func" ]] &&
           ctxt="[$(date +%R:%S.%3N)] [dir=${PWD##*/}${cluster:+; cl=${cluster}}${cur_func:+; fn=${cur_func}}]" &&
           echo "${CYAN_COLOR}${ctxt}\$ ${cmd}${NO_COLOR}" >&2; true' DEBUG


### PR DESCRIPTION
debug_functions ran `eval echo "$BASH_COMMAND"` to expand each traced
command before printing it. With DEBUG_PRINT=true that expanded any
variable in the command, leaking $QUAY_USERNAME (and any other inherited
secret) into the release trace, and re-executing command substitutions.

Print $BASH_COMMAND verbatim instead: no expansion, no re-execution.
Ordinary commands are still traced; only literal $VAR tokens differ.

Follow-up to FIND-007 (the render_template eval, PR 7); different file
and mechanism, tracked separately.