### PR TITLE
Verify subctl download integrity in get-subctl.sh (FIND-006)

### DIFF
--- a/scripts/shared/get-subctl.sh
+++ b/scripts/shared/get-subctl.sh
@@ -11,8 +11,35 @@ if [[ "${0##*/}" = subctl ]] && [[ -L "$0" ]]; then
     rm -f "$0"
 fi
 
-# Default to devel if we don't know what base branch were on
-with_retries 3 curl -Lsf https://get.submariner.io | VERSION="${SUBCTL_VERSION:-${BASE_BRANCH:-devel}}" bash
+# Default to devel if we don't know what base branch we're on.
+VERSION="${SUBCTL_VERSION:-${BASE_BRANCH:-devel}}"
+
+# `devel` and `release-0.X` are subctl-repo release tags whose tarball URL is
+# derivable directly, so download the archive and verify it against the
+# published checksums before use. Everything else (`latest`, `rc`, a concrete
+# `vX.Y.Z`) is an alias resolved by get.submariner.io, so it stays on the
+# existing install path.
+case "${VERSION}" in
+devel|release-0.*)
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    arch="$(uname -m)"
+    case "${arch}" in
+        x86_64) arch=amd64;;
+        aarch64) arch=arm64;;
+        armv7l|armv6l) arch=arm;;
+    esac
+    archive="subctl-${VERSION}-${os}-${arch}.tar.xz"
+    baseurl="https://github.com/submariner-io/subctl/releases/download/subctl-${VERSION}"
+    mkdir -p ~/.local/bin
+    with_retries 3 curl -Lsf -o "/tmp/${archive}" "${baseurl}/${archive}"
+    with_retries 3 curl -Lsf -o /tmp/subctl-checksums.txt "${baseurl}/subctl-checksums.txt"
+    (cd /tmp && grep -F -- "  ${archive}" subctl-checksums.txt | sha256sum -c -)
+    tar -xJf "/tmp/${archive}" -C ~/.local/bin/ --strip-components=1
+    ;;
+*)
+    with_retries 3 curl -Lsf https://get.submariner.io | VERSION="${VERSION}" bash
+    ;;
+esac
 
 # If we're pretending to be subctl, run subctl with any given arguments
 [[ -z "${run_subctl}" ]] || subctl "$@"


### PR DESCRIPTION
Replaces the unauthenticated `curl -Lsf https://get.submariner.io | bash` in
`scripts/shared/get-subctl.sh` with download-and-verify for the `devel` and
`release-0.X` tags: fetch the subctl release tarball plus subctl-checksums.txt
and verify with `sha256sum -c` before extracting to ~/.local/bin. Alias tags
(`latest`/`rc`/`vX.Y.Z`) stay on the get.submariner.io path (its resolver is
not ported here). No `exit` is added, so the self-replacing `subctl` symlink
lifecycle is preserved.

**Draft — do not merge yet.** Requires:
1. submariner-io/subctl#1866 (publish subctl-checksums.txt) — must merge and a new `subctl-release-0.23` release cut
2. This branch's `shipyard-dapper-base` image rebuilt/republished

Merging before both clears makes the verified path fetch a 404 checksum file and hard-fail e2e under `set -e -o pipefail`.