### PR TITLE
Update version labels to v0.24.1

### DIFF
--- a/package/Dockerfile.nettest.konflux
+++ b/package/Dockerfile.nettest.konflux
@@ -31,7 +31,7 @@ CMD ["/bin/bash","-l"]
 
 LABEL com.redhat.component="nettest-container" \
       name="rhacm2/nettest-rhel9" \
-      version="v0.24.0" \
+      version="v0.24.1" \
       summary="A container with networking test and troubleshooting tools" \
       description="Provides common networking utilities (ping, iperf3, curl, etc.) for testing and troubleshooting Submariner." \
       io.k8s.display-name="Submariner Network Test Tools" \


### PR DESCRIPTION
Enables correct Konflux image tagging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nettest container image to version `v0.24.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->