### PR TITLE
Bump prefetch-dependencies-oci-ta 0.3 → 0.10.1

### DIFF
--- a/.tekton/nettest-0-24-pull-request.yaml
+++ b/.tekton/nettest-0-24-pull-request.yaml
@@ -198,7 +198,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.10.1@sha256:c09c1c3ced67fb8740b2925a7de09c0810d4e8c8f148d41c21ffe37810d85c62
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/nettest-0-24-push.yaml
+++ b/.tekton/nettest-0-24-push.yaml
@@ -195,7 +195,7 @@ spec:
         - name: name
           value: prefetch-dependencies-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:92956e75cd4714286f9c0c043f5301d1c0df1d750884edeceee87e0a91cc1975
+          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.10.1@sha256:c09c1c3ced67fb8740b2925a7de09c0810d4e8c8f148d41c21ffe37810d85c62
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
EC deny rule bans task-prefetch-dependencies-oci-ta versions < 0.7.1 (effective 2026-08-13). Bump to 0.10.1 to satisfy the rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency prefetching pipeline task to use the newer version 0.10.1 bundle.
  * Updated the associated integrity checks for pull request and push workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->