### PR TITLE
Update RPM lockfiles for v0.23.2

### DIFF
--- a/.rpm-lockfiles/nettest/rpms.lock.yaml
+++ b/.rpm-lockfiles/nettest/rpms.lock.yaml
@@ -4,27 +4,27 @@ lockfileVendor: redhat
 arches:
 - arch: aarch64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.8.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 1252147
-    checksum: sha256:911e2e51ccb0ba25a2adf07de7bfb0031edd0c127a5b44e39ae89743b9a3f187
+    size: 1261220
+    checksum: sha256:b88c59367eae12f82e367dc5f7aa3d3ac7b6b4a4b37de3ed357349cad2130d16
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.8.noarch.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19552
+    checksum: sha256:66b794c106205aafcf56db39a7207c35b951d942b0840b2fc02c4140883bed9d
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.aarch64.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.8.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 211613
-    checksum: sha256:c18967e7d1b18abfca1f2bbbc7e14bffd29194966896be0cd3285284471d4cda
+    size: 218919
+    checksum: sha256:7b9209acffc024f62bafc24b6240140c016556ce2f5d272dc6b16343f71eb837
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 29476
@@ -32,13 +32,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/i/iperf3-3.9-17.el9_8.1.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 112022
-    checksum: sha256:a3fd9b7ad40245418e2777778c43bd7d602f5952514569736b541223de77fedf
+    size: 112957
+    checksum: sha256:8ac3cff2e08f2e93d4e73dc0539843ef12bb0517c818cf1486d641898842230b
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8.1
+    sourcerpm: iperf3-3.9-17.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 40090
@@ -53,13 +53,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
-    size: 228860
-    checksum: sha256:bd929a6e3161dfee43b377f888d3712ee70cfb591f50cab845e8551973b010f1
+    size: 231099
+    checksum: sha256:7734a9d19d8a858db578e298f99148806f159668c010483fbd77e5ac4fe95e0d
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-appstream-rpms
     size: 548341
@@ -67,13 +67,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/c/curl-7.76.1-40.el9_8.5.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 295895
-    checksum: sha256:2ed44feaa9dd15834295493690fd383d21d226ab1801be9daf4234d064ccc428
+    size: 303758
+    checksum: sha256:0fb8426b8f874ced7fe96c194139c44d14721703d27b337b5bd822e668f165ce
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9_8.5
+    sourcerpm: curl-7.76.1-40.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/i/iputils-20210202-15.el9_7.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 178424
@@ -81,13 +81,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libibverbs-57.0-2.el9.aarch64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libibverbs-61.0-2.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
-    size: 458077
-    checksum: sha256:cff5c03177285b39d0e35584862488c441f15429f6396d9c6da264634c2cb400
+    size: 490223
+    checksum: sha256:fefa639490ba2fb332e93fee3db6ed1651fd8c5d138d4b0eb9c6088425198983
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.aarch64.rpm
     repoid: rhel-9-for-aarch64-baseos-rpms
     size: 363241
@@ -127,27 +127,27 @@ arches:
   module_metadata: []
 - arch: ppc64le
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.8.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 1420264
-    checksum: sha256:710bc12c265803d9f72b8c95d83d7ec545424a4f97f7d33dbeb42830712bd27c
+    size: 1429468
+    checksum: sha256:8c853fa364f97f7444f6f6ab84931f4cc3f70db94799c9f57d8e2429ccde0784
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.8.noarch.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19552
+    checksum: sha256:66b794c106205aafcf56db39a7207c35b951d942b0840b2fc02c4140883bed9d
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.ppc64le.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.8.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 217065
-    checksum: sha256:45047a99f745ed4552097f6b7695eece6c8f8639089efa19b2160c808c9a5515
+    size: 223990
+    checksum: sha256:cc0f58eb27f328b36fa6e23b26eac04e0b8d7e1002ca3017d552406b0dcc5253
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/f/fstrm-0.6.1-3.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 32044
@@ -155,13 +155,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/i/iperf3-3.9-17.el9_8.1.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 121933
-    checksum: sha256:0fad15addadf6ec2bb3fd67393d8e3621224f85237dbdc4ae87c87a31da3c0f3
+    size: 122367
+    checksum: sha256:c2c46acaef7f7241310a47a3c882e3066dfdd2fe7990401d30a8a4beab755495
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8.1
+    sourcerpm: iperf3-3.9-17.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 38048
@@ -176,13 +176,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
-    size: 255275
-    checksum: sha256:28c6e68a8955cc673506312af29bc88a4c5eb767d6db64cb4d07fed56e5badaa
+    size: 257579
+    checksum: sha256:e56086dbc08fd4acf9eb816cc00ad99b94175ad3d0df1d4de945806de6f439e3
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-appstream-rpms
     size: 577736
@@ -190,13 +190,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/c/curl-7.76.1-40.el9_8.5.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
-    size: 302683
-    checksum: sha256:089b35068610a9c120fcb60e0043efb776f16e1146a433cd9acc01cc8c910420
+    size: 310610
+    checksum: sha256:148fa0a9c7b7a828cd1a216e5c7049eb9cb31289cb7df50adc7e8bc0d16d64d6
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9_8.5
+    sourcerpm: curl-7.76.1-40.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/i/iputils-20210202-15.el9_7.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 182991
@@ -204,13 +204,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libibverbs-57.0-2.el9.ppc64le.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libibverbs-61.0-2.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
-    size: 510076
-    checksum: sha256:7216f066e90cec1dfc2a78e3eccc292af73cf1d1217a4376d66c83fbb9babb09
+    size: 545208
+    checksum: sha256:3972ff6b979e08abe28a91e6942fd8b432b5014b626c23d65a1083375bf5843f
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/ppc64le/baseos/os/Packages/l/libnl3-3.11.0-1.el9.ppc64le.rpm
     repoid: rhel-9-for-ppc64le-baseos-rpms
     size: 393979
@@ -250,27 +250,27 @@ arches:
   module_metadata: []
 - arch: s390x
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 1234976
-    checksum: sha256:2d0f09df9c4085bfb0a0d561ee04ef260f3e1256aab9799fcf5f4a250258357d
+    size: 1243611
+    checksum: sha256:8c04cca96a31b83013ba96029e551695e6e06a9395c1a684e742e164f274cefe
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.8.noarch.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19552
+    checksum: sha256:66b794c106205aafcf56db39a7207c35b951d942b0840b2fc02c4140883bed9d
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.s390x.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.8.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 208870
-    checksum: sha256:ebe107cc0dc4d64eeff676a1182851fcae1e195438b999fadcd5a75abca98f74
+    size: 216095
+    checksum: sha256:3f93e69f2c6d5bf4f99c1038e83a027d06d5f04ab2a27f3507754f30f08b4a68
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/f/fstrm-0.6.1-3.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 29853
@@ -278,13 +278,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/i/iperf3-3.9-17.el9_8.1.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 110814
-    checksum: sha256:15fb56a83c7001fa0f58b03eaa768f436637f5064f8e517a629a1663b210f10c
+    size: 111999
+    checksum: sha256:12fb03b48913737dab10f2ad317188c91dadcb3a12879cc7d9e88f841759ac14
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8.1
+    sourcerpm: iperf3-3.9-17.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 35548
@@ -299,13 +299,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
-    size: 228076
-    checksum: sha256:b42a004133dd719cc4b09052e3952b2a4d3877a5d576fc88c58122db2aa2d7fe
+    size: 230457
+    checksum: sha256:3ce35b67378a25a40abe20cd5195d0e116fad4dccd8909259210954e5a8b27e7
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.s390x.rpm
     repoid: rhel-9-for-s390x-appstream-rpms
     size: 527514
@@ -313,13 +313,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/c/curl-7.76.1-40.el9_8.5.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
-    size: 297640
-    checksum: sha256:28d114798ac0f43619f12602109f10d187e91935affa4c7a30ebd92c0c3e1920
+    size: 305540
+    checksum: sha256:a1a04ed84b032c2d73d3d768d4b07ee4f7704265977c265d7efa61f94cf03592
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9_8.5
+    sourcerpm: curl-7.76.1-40.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/i/iputils-20210202-15.el9_7.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 177321
@@ -327,13 +327,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libibverbs-57.0-2.el9.s390x.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libibverbs-61.0-2.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
-    size: 446293
-    checksum: sha256:c7164f42547454760cb437d7a84f55e7cca836a495cb4c7ee29f8a8b3bca72e8
+    size: 476102
+    checksum: sha256:08abe242ac96b170a3d74ed08ab75a16546d091efc4d35988c7ceefd5349ba56
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/s390x/baseos/os/Packages/l/libnl3-3.11.0-1.el9.s390x.rpm
     repoid: rhel-9-for-s390x-baseos-rpms
     size: 361754
@@ -373,27 +373,27 @@ arches:
   module_metadata: []
 - arch: x86_64
   packages:
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-34.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-libs-9.16.23-40.el9_8.8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 1301214
-    checksum: sha256:a8a735281125cae93c6c6067ba8ea473132f5ebdd81e6e898d1fe91d317c39b1
+    size: 1311413
+    checksum: sha256:7a418f4a2fc72b92147c138fd8cd5e681b57ed7acde2e65d65136f750e885838
     name: bind-libs
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-34.el9_7.1.noarch.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-license-9.16.23-40.el9_8.8.noarch.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 12809
-    checksum: sha256:546e909d1318b611512c07418ffc94b128cb46320b515ca5bc1010e38f376a27
+    size: 19552
+    checksum: sha256:66b794c106205aafcf56db39a7207c35b951d942b0840b2fc02c4140883bed9d
     name: bind-license
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-34.el9_7.1.x86_64.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/b/bind-utils-9.16.23-40.el9_8.8.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 211124
-    checksum: sha256:b61003436687afb2eae9e6301e10efc202c072fb45c4b88dfb95022db9fbc541
+    size: 218653
+    checksum: sha256:2a66d25cad4ea50bbae40d60f163221afdd90e483abf1289b88fb360f0e809a7
     name: bind-utils
-    evr: 32:9.16.23-34.el9_7.1
-    sourcerpm: bind-9.16.23-34.el9_7.1.src.rpm
+    evr: 32:9.16.23-40.el9_8.8
+    sourcerpm: bind-9.16.23-40.el9_8.8.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/f/fstrm-0.6.1-3.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 30777
@@ -401,13 +401,13 @@ arches:
     name: fstrm
     evr: 0.6.1-3.el9
     sourcerpm: fstrm-0.6.1-3.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/iperf3-3.9-14.el9_7.1.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/i/iperf3-3.9-17.el9_8.1.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 115589
-    checksum: sha256:5f91ef6d32f64b0be044c5f9c33fa687039d66e6797746493a7590a489226802
+    size: 116437
+    checksum: sha256:e19e7132eed0af6d8a16692c2ffbe3870fa020a6ad9eea7977d4893e4d520ee6
     name: iperf3
-    evr: 3.9-14.el9_7.1
-    sourcerpm: iperf3-3.9-14.el9_7.1.src.rpm
+    evr: 3.9-17.el9_8.1
+    sourcerpm: iperf3-3.9-17.el9_8.1.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/l/libmaxminddb-1.5.2-4.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 36179
@@ -422,13 +422,13 @@ arches:
     name: libuv
     evr: 1:1.42.0-2.el9_4
     sourcerpm: libuv-1.42.0-2.el9_4.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-3.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/n/nmap-ncat-7.92-5.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
-    size: 234565
-    checksum: sha256:4107c9b2ac6fe1a6be44088f79fcafd012e22c7867dad98741c88590cadeb5a2
+    size: 236896
+    checksum: sha256:2de304bc963e3d03b61716289e7e5504267646b3192da24f98f8e278068fec3e
     name: nmap-ncat
-    evr: 3:7.92-3.el9
-    sourcerpm: nmap-7.92-3.el9.src.rpm
+    evr: 3:7.92-5.el9
+    sourcerpm: nmap-7.92-5.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/Packages/t/tcpdump-4.99.0-9.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-appstream-rpms
     size: 559754
@@ -436,13 +436,13 @@ arches:
     name: tcpdump
     evr: 14:4.99.0-9.el9
     sourcerpm: tcpdump-4.99.0-9.el9.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-35.el9_7.3.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/c/curl-7.76.1-40.el9_8.5.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 299410
-    checksum: sha256:5b01bc58d38b77f3ff9a8c88a512b9a35c5a7fbecb6e3f734212008ea3bdc30b
+    size: 307326
+    checksum: sha256:273736810bf95bd5efd1ee4942d349c51aeba23941dc28026d2cb2cf6719a2e3
     name: curl
-    evr: 7.76.1-35.el9_7.3
-    sourcerpm: curl-7.76.1-35.el9_7.3.src.rpm
+    evr: 7.76.1-40.el9_8.5
+    sourcerpm: curl-7.76.1-40.el9_8.5.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/i/iputils-20210202-15.el9_7.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 177748
@@ -450,13 +450,13 @@ arches:
     name: iputils
     evr: 20210202-15.el9_7
     sourcerpm: iputils-20210202-15.el9_7.src.rpm
-  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-57.0-2.el9.x86_64.rpm
+  - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libibverbs-61.0-2.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
-    size: 463544
-    checksum: sha256:d96bbefb46683bd3ddfffd0668898c591f253dfca25e5ac2ddf90f812512e5b7
+    size: 498499
+    checksum: sha256:4789955ff27b0339c2b61ad52d492965e0ad7f02cd44b68370ca82d6aa596b41
     name: libibverbs
-    evr: 57.0-2.el9
-    sourcerpm: rdma-core-57.0-2.el9.src.rpm
+    evr: 61.0-2.el9
+    sourcerpm: rdma-core-61.0-2.el9.src.rpm
   - url: https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/Packages/l/libnl3-3.11.0-1.el9.x86_64.rpm
     repoid: rhel-9-for-x86_64-baseos-rpms
     size: 376137


### PR DESCRIPTION
Update RPM lockfiles to resolve package CVEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated networking and diagnostic utilities, including BIND, iperf3, Nmap Ncat, curl, and libibverbs across all supported architectures.
  - Refreshed associated package metadata and checksums to ensure consistent package versions across platforms.
  - Existing versions of fstrm, tcpdump, and iputils remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->