### PR TITLE
Fix CVEs in release-0.23

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,11 +1,6 @@
 ---
 ignore:
   # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
-  # https://github.com/anchore/grype/issues/558
-  - vulnerability: CVE-2015-5237
-    package:
-      name: google.golang.org/protobuf
-  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
   # https://github.com/anchore/grype/issues/633
   - vulnerability: CVE-2021-22570
     package:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,11 +1,5 @@
 ---
 ignore:
-  # False positive, CVE is actually about the C++ project protocolbuffers/protobuf
-  # https://github.com/anchore/grype/issues/633
-  - vulnerability: CVE-2021-22570
-    package:
-      name: google.golang.org/protobuf
-
   # Update requires Go 1.25.0 in tools/go.mod. Low severity doesn't justify breaking release-0.23 Go version constraint.
   - vulnerability: GO-2026-5024
     package:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/karamaru-alpha/copyloopvar v1.2.2 // indirect
 	github.com/kisielk/errcheck v1.9.0 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.6 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/kulti/thelper v0.7.1 // indirect
 	github.com/kunwardeep/paralleltest v1.0.15 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -246,8 +246,8 @@ github.com/kisielk/errcheck v1.9.0 h1:9xt1zI9EBfcYBvdU1nVrzMzzUPUtPKs9bVSIM3TAb3
 github.com/kisielk/errcheck v1.9.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi0D+/VL/i8=
 github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/ttjfJCE=
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
See commit messages for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Removed outdated vulnerability exceptions for the `google.golang.org/protobuf` package, allowing related findings to be reported again during security scanning.
  - Existing vulnerability coverage remains in place for the currently tracked exception.

- **Maintenance**
  - Updated the compression library used by tooling to a newer version, incorporating maintenance updates and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->